### PR TITLE
fix the default super-ugly coloured link boxes (citations, urls, figure numbers, footnote numbers, etc)

### DIFF
--- a/doc/mlsys_paper/paper.tex
+++ b/doc/mlsys_paper/paper.tex
@@ -13,6 +13,9 @@
 \usepackage{parcolumns}
 \usepackage{booktabs}
 
+% fix the default super-ugly coloured link boxes (citations, urls, figure numbers, footnote numbers, etc)
+\usepackage[pagebackref=false,breaklinks=true,colorlinks,bookmarks=false,urlcolor=blue,linkcolor=blue,citecolor=blue]{hyperref}
+
 \usepackage[utf8]{inputenc} % allow utf-8 input
 \usepackage[T1]{fontenc}    % use 8-bit T1 fonts
 \usepackage{hyperref}       % hyperlinks


### PR DESCRIPTION
Remove those super-ugly link boxes and replace them with sane looking links.  This noticeably improves the presentation of the paper (ie. less annoying for reviewers).

