### PR TITLE
Fix typo in differentiable function docs

### DIFF
--- a/doc/function_types.md
+++ b/doc/function_types.md
@@ -78,7 +78,7 @@ class DifferentiableFunctionType
 {
  public:
   // Given parameters x, return the value of f(x).
-  void Evaluate(const arma::mat& x);
+  double Evaluate(const arma::mat& x);
 
   // Given parameters x and a matrix g, store f'(x) in the provided matrix g.
   // g should have the same size (rows, columns) as x.


### PR DESCRIPTION
Was reading through the docs and noticed that `Evaluate` should probably return a `double`.