### PR TITLE
Added Augmented Lagrangian options

### DIFF
--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -282,13 +282,24 @@ functions with different signatures that allow the behavior to be controlled:
  *     class.
  * @param function The function to optimize.
  * @param coordinates Output matrix to store the optimized coordinates in.
+ * @param penaltyThresholdFactor When the penalty threshold is updated set
+ *    the penalty threshold to the penalty multplied by this factor. The
+ *    default value of 0.25 is is taken from Burer and Monteiro (2002).
+ * @param sigmaUpdateFactor When sigma is updated  multiply sigma by this
+ *    value. The default value of 10 is taken from Burer and Monteiro (2002).
  * @param maxIterations Maximum number of iterations of the Augmented
  *     Lagrangian algorithm.  0 indicates no maximum.
+ * @param internalMaxIterations Maximum number of iterations of L-BFGS
+ *    iterations internal to the Augmented Lagrangian algorithm.
+ *    0 indicates no maximum.
  */
 template<typename LagrangianFunctionType>
 bool Optimize(LagrangianFunctionType& function,
               arma::mat& coordinates,
-              const size_t maxIterations = 1000);
+              const double penaltyThresholdFactor = 0.25,
+              const double sigmaUpdateFactor = 10.0,
+              const size_t maxIterations = 1000,
+              const size_t internalMaxIterations = 1000);
 
 /**
  * Optimize the function, giving initial estimates for the Lagrange
@@ -302,15 +313,26 @@ bool Optimize(LagrangianFunctionType& function,
  * @param initLambda Vector of initial Lagrange multipliers.  Should have
  *     length equal to the number of constraints.
  * @param initSigma Initial penalty parameter.
+ * @param penaltyThresholdFactor When the penalty threshold is updated set
+ *    the penalty threshold to the penalty multplied by this factor. The
+ *    default value of 0.25 is is taken from Burer and Monteiro (2002).
+ * @param sigmaUpdateFactor When sigma is updated  multiply sigma by this
+ *    value. The default value of 10 is taken from Burer and Monteiro (2002).
  * @param maxIterations Maximum number of iterations of the Augmented
  *     Lagrangian algorithm.  0 indicates no maximum.
+ * @param internalMaxIterations Maximum number of iterations of L-BFGS
+ *    iterations internal to the Augmented Lagrangian algorithm.
+ *    0 indicates no maximum.
  */
 template<typename LagrangianFunctionType>
 bool Optimize(LagrangianFunctionType& function,
               arma::mat& coordinates,
               const arma::vec& initLambda,
               const double initSigma,
-              const size_t maxIterations = 1000);
+              const double penaltyThresholdFactor = 0.25,
+              const double sigmaUpdateFactor = 10.0,
+              const size_t maxIterations = 1000,
+              const size_t internalMaxIterations = 1000);
 ```
 
 #### Examples

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -265,12 +265,19 @@ optimizer uses [L-BFGS](#l-bfgs).
 
 #### Constructors
 
- * `AugLagrangian()`
+ * `AugLagrangian(`_`maxIterations, penaltyThresholdFactor sigmaUpdateFactor, internalMaxIterations`_`)`
 
 #### Attributes
 
-This optimizer has no attributes, but instead has two separate `Optimize()`
-functions with different signatures that allow the behavior to be controlled:
+| **type** | **name** | **description** | **default** |
+|----------|----------|-----------------|-------------|
+| `size_t` | **`maxIterations`** | Maximum number of iterations allowed (0 means no limit). | `1000` |
+| `size_t` | **`internalMaxIterations`** | Maximum number of iterations allowed by L-BFGS (0 means no limit). | `1000` |
+| `double` | **`penaltyThresholdFactor`** | When penalty threshold is updated, set it to this multiplied by the penalty. | `10.0` |
+| `double` | **`sigmaUpdateFactor`** | When sigma is updated, multiply it by this. | `0.25` |
+
+The attributes of the optimizer may also be modified via the member methods
+`MaxIterations()`, `InternalMaxIterations()`, `PenaltyThresholdFactor()`, and `SigmaUpdateFactor()`
 
 ```c++
 /**
@@ -282,24 +289,10 @@ functions with different signatures that allow the behavior to be controlled:
  *     class.
  * @param function The function to optimize.
  * @param coordinates Output matrix to store the optimized coordinates in.
- * @param penaltyThresholdFactor When the penalty threshold is updated set
- *    the penalty threshold to the penalty multplied by this factor. The
- *    default value of 0.25 is is taken from Burer and Monteiro (2002).
- * @param sigmaUpdateFactor When sigma is updated  multiply sigma by this
- *    value. The default value of 10 is taken from Burer and Monteiro (2002).
- * @param maxIterations Maximum number of iterations of the Augmented
- *     Lagrangian algorithm.  0 indicates no maximum.
- * @param internalMaxIterations Maximum number of iterations of L-BFGS
- *    iterations internal to the Augmented Lagrangian algorithm.
- *    0 indicates no maximum.
  */
 template<typename LagrangianFunctionType>
 bool Optimize(LagrangianFunctionType& function,
-              arma::mat& coordinates,
-              const double penaltyThresholdFactor = 0.25,
-              const double sigmaUpdateFactor = 10.0,
-              const size_t maxIterations = 1000,
-              const size_t internalMaxIterations = 1000);
+              arma::mat& coordinates);
 
 /**
  * Optimize the function, giving initial estimates for the Lagrange
@@ -313,26 +306,12 @@ bool Optimize(LagrangianFunctionType& function,
  * @param initLambda Vector of initial Lagrange multipliers.  Should have
  *     length equal to the number of constraints.
  * @param initSigma Initial penalty parameter.
- * @param penaltyThresholdFactor When the penalty threshold is updated set
- *    the penalty threshold to the penalty multplied by this factor. The
- *    default value of 0.25 is is taken from Burer and Monteiro (2002).
- * @param sigmaUpdateFactor When sigma is updated  multiply sigma by this
- *    value. The default value of 10 is taken from Burer and Monteiro (2002).
- * @param maxIterations Maximum number of iterations of the Augmented
- *     Lagrangian algorithm.  0 indicates no maximum.
- * @param internalMaxIterations Maximum number of iterations of L-BFGS
- *    iterations internal to the Augmented Lagrangian algorithm.
- *    0 indicates no maximum.
  */
 template<typename LagrangianFunctionType>
 bool Optimize(LagrangianFunctionType& function,
               arma::mat& coordinates,
               const arma::vec& initLambda,
-              const double initSigma,
-              const double penaltyThresholdFactor = 0.25,
-              const double sigmaUpdateFactor = 10.0,
-              const size_t maxIterations = 1000,
-              const size_t internalMaxIterations = 1000);
+              const double initSigma);
 ```
 
 #### Examples
@@ -342,7 +321,7 @@ GockenbachFunction f;
 arma::mat coordinates = f.GetInitialPoint();
 
 AugLagrangian optimizer;
-optimizer.Optimize(f, coords, 0);
+optimizer.Optimize(f, coords);
 ```
 
 #### See also:

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -274,9 +274,10 @@ optimizer uses [L-BFGS](#l-bfgs).
 | `size_t` | **`maxIterations`** | Maximum number of iterations allowed (0 means no limit). | `1000` |
 | `double` | **`penaltyThresholdFactor`** | When penalty threshold is updated, set it to this multiplied by the penalty. | `10.0` |
 | `double` | **`sigmaUpdateFactor`** | When sigma is updated, multiply it by this. | `0.25` |
+| `L_BFGS&` | **`lbfgs`** | Internal l-bfgs optimizer. | `L_BFGS()` |
 
 The attributes of the optimizer may also be modified via the member methods
-`MaxIterations()`, `PenaltyThresholdFactor()`, and `SigmaUpdateFactor()`
+`MaxIterations()`, `PenaltyThresholdFactor()`, `SigmaUpdateFactor()` and `L_BFGS()`.
 
 ```c++
 /**

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -265,19 +265,18 @@ optimizer uses [L-BFGS](#l-bfgs).
 
 #### Constructors
 
- * `AugLagrangian(`_`maxIterations, penaltyThresholdFactor sigmaUpdateFactor, internalMaxIterations`_`)`
+ * `AugLagrangian(`_`maxIterations, penaltyThresholdFactor sigmaUpdateFactor`_`)`
 
 #### Attributes
 
 | **type** | **name** | **description** | **default** |
 |----------|----------|-----------------|-------------|
 | `size_t` | **`maxIterations`** | Maximum number of iterations allowed (0 means no limit). | `1000` |
-| `size_t` | **`internalMaxIterations`** | Maximum number of iterations allowed by L-BFGS (0 means no limit). | `1000` |
 | `double` | **`penaltyThresholdFactor`** | When penalty threshold is updated, set it to this multiplied by the penalty. | `10.0` |
 | `double` | **`sigmaUpdateFactor`** | When sigma is updated, multiply it by this. | `0.25` |
 
 The attributes of the optimizer may also be modified via the member methods
-`MaxIterations()`, `InternalMaxIterations()`, `PenaltyThresholdFactor()`, and `SigmaUpdateFactor()`
+`MaxIterations()`, `PenaltyThresholdFactor()`, and `SigmaUpdateFactor()`
 
 ```c++
 /**

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
@@ -31,23 +31,14 @@ namespace ens {
  * ensmallen website.
  */
 
+// TODO expose LBFGS params
+// TODO finalise docs update
+
 class AugLagrangian
 {
  public:
   /**
    * Initialize the Augmented Lagrangian with the default L-BFGS optimizer.
-   */
-  AugLagrangian();
-
-  /**
-   * Optimize the function.  The value '1' is used for the initial value of each
-   * Lagrange multiplier.  To set the Lagrange multipliers yourself, use the
-   * other overload of Optimize().
-   *
-   * @tparam LagrangianFunctionType Function which can be optimized by this
-   *     class.
-   * @param function The function to optimize.
-   * @param coordinates Output matrix to store the optimized coordinates in.
    * @param penaltyThresholdFactor When the penalty threshold is updated set
    *    the penalty threshold to the penalty multplied by this factor. The
    *    default value of 0.25 is is taken from Burer and Monteiro (2002).
@@ -59,13 +50,24 @@ class AugLagrangian
    *    iterations internal to the Augmented Lagrangian algorithm.
    *    0 indicates no maximum.
    */
-  template<typename LagrangianFunctionType>
-  bool Optimize(LagrangianFunctionType& function,
-                arma::mat& coordinates,
+  AugLagrangian(const size_t maxIterations = 1000,
                 const double penaltyThresholdFactor = 0.25,
                 const double sigmaUpdateFactor = 10.0,
-                const size_t maxIterations = 1000,
                 const size_t internalMaxIterations = 1000);
+
+  /**
+   * Optimize the function.  The value '1' is used for the initial value of each
+   * Lagrange multiplier.  To set the Lagrange multipliers yourself, use the
+   * other overload of Optimize().
+   *
+   * @tparam LagrangianFunctionType Function which can be optimized by this
+   *     class.
+   * @param function The function to optimize.
+   * @param coordinates Output matrix to store the optimized coordinates in.
+   */
+  template<typename LagrangianFunctionType>
+  bool Optimize(LagrangianFunctionType& function,
+                arma::mat& coordinates);
 
   /**
    * Optimize the function, giving initial estimates for the Lagrange
@@ -79,26 +81,12 @@ class AugLagrangian
    * @param initLambda Vector of initial Lagrange multipliers.  Should have
    *     length equal to the number of constraints.
    * @param initSigma Initial penalty parameter.
-   * @param penaltyThresholdFactor When the penalty threshold is updated set
-   *    the penalty threshold to the penalty multplied by this factor. The
-   *    default value of 0.25 is is taken from Burer and Monteiro (2002).
-   * @param sigmaUpdateFactor When sigma is updated  multiply sigma by this
-   *    value. The default value of 10 is taken from Burer and Monteiro (2002).
-   * @param maxIterations Maximum number of iterations of the Augmented
-   *     Lagrangian algorithm.  0 indicates no maximum.
-   * @param internalMaxIterations Maximum number of iterations of L-BFGS
-   *    iterations internal to the Augmented Lagrangian algorithm.
-   *    0 indicates no maximum.
    */
   template<typename LagrangianFunctionType>
   bool Optimize(LagrangianFunctionType& function,
                 arma::mat& coordinates,
                 const arma::vec& initLambda,
-                const double initSigma,
-                const double penaltyThresholdFactor = 0.25,
-                const double sigmaUpdateFactor = 10.0,
-                const size_t maxIterations = 1000,
-                const size_t internalMaxIterations = 1000);
+                const double initSigma);
 
   //! Get the L-BFGS object used for the actual optimization.
   const L_BFGS& LBFGS() const { return lbfgs; }
@@ -115,7 +103,41 @@ class AugLagrangian
   //! Modify the penalty parameter.
   double& Sigma() { return sigma; }
 
+  //! Get the maximum iterations
+  size_t MaxIterations() const { return maxIterations; }
+  //! Modify the maximum iterations
+  size_t& MaxIterations() { return maxIterations; }
+
+  // TODO remove
+  //! Get the maximum iterations
+  size_t InternalMaxIterations() const { return internalMaxIterations; }
+  //! Modify the maximum iterations
+  size_t& InternalMaxIterations() { return internalMaxIterations; }
+
+  //! Get the penalty threshold updating parameter
+  double PenaltyThresholdFactor() const { return penaltyThresholdFactor; }
+  //! Modify the penalty threshold updating parameter
+  double& PenaltyThresholdFactor() { return penaltyThresholdFactor; }
+
+  //! Get the sigma update factor
+  double SigmaUpdateFactor() const { return sigmaUpdateFactor; }
+  //! Modify the sigma update factor
+  double& SigmaUpdateFactor() { return sigmaUpdateFactor; }
+
  private:
+  //! Maximum number of iterations.
+  size_t maxIterations;
+
+  //! Parameter for updating the penalty threshold
+  double penaltyThresholdFactor;
+
+  //! Parameter for updating sigma
+  double sigmaUpdateFactor;
+
+  // TODO remove
+  //! Internal max iterations
+  size_t internalMaxIterations;
+
   //! If the user did not pass an L_BFGS object, we'll use our own internal one.
   L_BFGS lbfgsInternal;
 
@@ -133,11 +155,7 @@ class AugLagrangian
    */
   template<typename LagrangianFunctionType>
   bool Optimize(AugLagrangianFunction<LagrangianFunctionType>& augfunc,
-                arma::mat& coordinates,
-                const double penaltyThresholdFactor,
-                const double sigmaUpdateFactor,
-                const size_t maxIterations,
-                const size_t internalMaxIterations);
+                arma::mat& coordinates);
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
@@ -30,10 +30,6 @@ namespace ens {
  * documentation on function types included with this distribution or on the
  * ensmallen website.
  */
-
-// TODO expose LBFGS params
-// TODO finalise docs update
-
 class AugLagrangian
 {
  public:
@@ -46,14 +42,10 @@ class AugLagrangian
    *    value. The default value of 10 is taken from Burer and Monteiro (2002).
    * @param maxIterations Maximum number of iterations of the Augmented
    *     Lagrangian algorithm.  0 indicates no maximum.
-   * @param internalMaxIterations Maximum number of iterations of L-BFGS
-   *    iterations internal to the Augmented Lagrangian algorithm.
-   *    0 indicates no maximum.
    */
   AugLagrangian(const size_t maxIterations = 1000,
                 const double penaltyThresholdFactor = 0.25,
-                const double sigmaUpdateFactor = 10.0,
-                const size_t internalMaxIterations = 1000);
+                const double sigmaUpdateFactor = 10.0);
 
   /**
    * Optimize the function.  The value '1' is used for the initial value of each
@@ -108,12 +100,6 @@ class AugLagrangian
   //! Modify the maximum iterations
   size_t& MaxIterations() { return maxIterations; }
 
-  // TODO remove
-  //! Get the maximum iterations
-  size_t InternalMaxIterations() const { return internalMaxIterations; }
-  //! Modify the maximum iterations
-  size_t& InternalMaxIterations() { return internalMaxIterations; }
-
   //! Get the penalty threshold updating parameter
   double PenaltyThresholdFactor() const { return penaltyThresholdFactor; }
   //! Modify the penalty threshold updating parameter
@@ -133,10 +119,6 @@ class AugLagrangian
 
   //! Parameter for updating sigma
   double sigmaUpdateFactor;
-
-  // TODO remove
-  //! Internal max iterations
-  size_t internalMaxIterations;
 
   //! If the user did not pass an L_BFGS object, we'll use our own internal one.
   L_BFGS lbfgsInternal;

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
@@ -30,13 +30,12 @@ namespace ens {
  * documentation on function types included with this distribution or on the
  * ensmallen website.
  */
+
 class AugLagrangian
 {
  public:
   /**
    * Initialize the Augmented Lagrangian with the default L-BFGS optimizer.  We
-   * limit the number of L-BFGS iterations to 1000, rather than the unlimited
-   * default L-BFGS.
    */
   AugLagrangian();
 
@@ -49,13 +48,24 @@ class AugLagrangian
    *     class.
    * @param function The function to optimize.
    * @param coordinates Output matrix to store the optimized coordinates in.
+   * @param penaltyThresholdFactor When the penalty threshold is updated set
+   *    the penalty threshold to the penalty multplied by this factor. The
+   *    default value of 0.25 is is taken from Burer and Monteiro (2002).
+   * @param sigmaUpdateFactor When sigma is updated  multiply sigma by this
+   *    value. The default value of 10 is taken from Burer and Monteiro (2002).
    * @param maxIterations Maximum number of iterations of the Augmented
    *     Lagrangian algorithm.  0 indicates no maximum.
+   * @param internalMaxIterations Maximum number of iterations of L-BFGS
+   *    iterations internal to the Augmented Lagrangian algorithm.
+   *    0 indicates no maximum.
    */
   template<typename LagrangianFunctionType>
   bool Optimize(LagrangianFunctionType& function,
                 arma::mat& coordinates,
-                const size_t maxIterations = 1000);
+                const double penaltyThresholdFactor = 0.25,
+                const double sigmaUpdateFactor = 10.0,
+                const size_t maxIterations = 1000,
+                const size_t internalMaxIterations = 1000);
 
   /**
    * Optimize the function, giving initial estimates for the Lagrange
@@ -69,15 +79,26 @@ class AugLagrangian
    * @param initLambda Vector of initial Lagrange multipliers.  Should have
    *     length equal to the number of constraints.
    * @param initSigma Initial penalty parameter.
+   * @param penaltyThresholdFactor When the penalty threshold is updated set
+   *    the penalty threshold to the penalty multplied by this factor. The
+   *    default value of 0.25 is is taken from Burer and Monteiro (2002).
+   * @param sigmaUpdateFactor When sigma is updated  multiply sigma by this
+   *    value. The default value of 10 is taken from Burer and Monteiro (2002).
    * @param maxIterations Maximum number of iterations of the Augmented
    *     Lagrangian algorithm.  0 indicates no maximum.
+   * @param internalMaxIterations Maximum number of iterations of L-BFGS
+   *    iterations internal to the Augmented Lagrangian algorithm.
+   *    0 indicates no maximum.
    */
   template<typename LagrangianFunctionType>
   bool Optimize(LagrangianFunctionType& function,
                 arma::mat& coordinates,
                 const arma::vec& initLambda,
                 const double initSigma,
-                const size_t maxIterations = 1000);
+                const double penaltyThresholdFactor = 0.25,
+                const double sigmaUpdateFactor = 10.0,
+                const size_t maxIterations = 1000,
+                const size_t internalMaxIterations = 1000);
 
   //! Get the L-BFGS object used for the actual optimization.
   const L_BFGS& LBFGS() const { return lbfgs; }
@@ -113,7 +134,10 @@ class AugLagrangian
   template<typename LagrangianFunctionType>
   bool Optimize(AugLagrangianFunction<LagrangianFunctionType>& augfunc,
                 arma::mat& coordinates,
-                const size_t maxIterations);
+                const double penaltyThresholdFactor,
+                const double sigmaUpdateFactor,
+                const size_t maxIterations,
+                const size_t internalMaxIterations);
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
@@ -45,7 +45,8 @@ class AugLagrangian
    */
   AugLagrangian(const size_t maxIterations = 1000,
                 const double penaltyThresholdFactor = 0.25,
-                const double sigmaUpdateFactor = 10.0);
+                const double sigmaUpdateFactor = 10.0,
+                const L_BFGS& lbfgs = L_BFGS());
 
   /**
    * Optimize the function.  The value '1' is used for the initial value of each
@@ -120,11 +121,8 @@ class AugLagrangian
   //! Parameter for updating sigma
   double sigmaUpdateFactor;
 
-  //! If the user did not pass an L_BFGS object, we'll use our own internal one.
-  L_BFGS lbfgsInternal;
-
   //! The L-BFGS optimizer that we will use.
-  L_BFGS& lbfgs;
+  L_BFGS lbfgs;
 
   //! Lagrange multipliers.
   arma::vec lambda;

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
@@ -35,7 +35,7 @@ class AugLagrangian
 {
  public:
   /**
-   * Initialize the Augmented Lagrangian with the default L-BFGS optimizer.  We
+   * Initialize the Augmented Lagrangian with the default L-BFGS optimizer.
    */
   AugLagrangian();
 

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
@@ -21,17 +21,13 @@ namespace ens {
 
 inline AugLagrangian::AugLagrangian(const size_t maxIterations,
                                     const double penaltyThresholdFactor,
-                                    const double sigmaUpdateFactor,
-                                    const size_t internalMaxIterations) :
+                                    const double sigmaUpdateFactor) :
     maxIterations(maxIterations),
     penaltyThresholdFactor(penaltyThresholdFactor),
     sigmaUpdateFactor(sigmaUpdateFactor),
-    internalMaxIterations(internalMaxIterations),
     lbfgsInternal(),
     lbfgs(lbfgsInternal)
 {
-  // Set the internal max iterations for the optimisation
-  lbfgs.MaxIterations() = internalMaxIterations;
 }
 
 template<typename LagrangianFunctionType>

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
@@ -21,12 +21,12 @@ namespace ens {
 
 inline AugLagrangian::AugLagrangian(const size_t maxIterations,
                                     const double penaltyThresholdFactor,
-                                    const double sigmaUpdateFactor) :
+                                    const double sigmaUpdateFactor,
+                                    const L_BFGS& lbfgs) :
     maxIterations(maxIterations),
     penaltyThresholdFactor(penaltyThresholdFactor),
     sigmaUpdateFactor(sigmaUpdateFactor),
-    lbfgsInternal(),
-    lbfgs(lbfgsInternal)
+    lbfgs(lbfgs)
 {
 }
 

--- a/include/ensmallen_bits/sdp/lrsdp_impl.hpp
+++ b/include/ensmallen_bits/sdp/lrsdp_impl.hpp
@@ -30,7 +30,8 @@ template <typename SDPType>
 double LRSDP<SDPType>::Optimize(arma::mat& coordinates)
 {
   augLag.Sigma() = 10;
-  augLag.Optimize(function, coordinates, maxIterations);
+  augLag.MaxIterations() = maxIterations;
+  augLag.Optimize(function, coordinates);
 
   return function.Evaluate(coordinates);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,40 +2,40 @@ project(ensmallen_tests CXX)
 
 set(ENSMALLEN_TESTS_SOURCES
     main.cpp
-    #ada_delta_test.cpp
-    #ada_grad_test.cpp
-    #adam_test.cpp
+    ada_delta_test.cpp
+    ada_grad_test.cpp
+    adam_test.cpp
     aug_lagrangian_test.cpp
-    #bigbatch_sgd_test.cpp
-    #cmaes_test.cpp
-    #cne_test.cpp
-    #eve_test.cpp
-    #frankwolfe_test.cpp
-    #function_test.cpp
-    #gradient_descent_test.cpp
-    #grid_search_test.cpp
-    #iqn_test.cpp
-    #katyusha_test.cpp
-    #lbfgs_test.cpp
-    #line_search_test.cpp
-    #lrsdp_test.cpp
-    #momentum_sgd_test.cpp
-    #nesterov_momentum_sgd_test.cpp
-    #parallel_sgd_test.cpp
-    #proximal_test.cpp
-    #rmsprop_test.cpp
-    #sa_test.cpp
-    #sarah_test.cpp
-    #scd_test.cpp
-    #sdp_primal_dual_test.cpp
-    #sgdr_test.cpp
-    #sgd_test.cpp
-    #smorms3_test.cpp
-    #snapshot_ensembles.cpp
-    #spalera_sgd_test.cpp
-    #svrg_test.cpp
-    #swats_test.cpp
-    #wn_grad_test.cpp
+    bigbatch_sgd_test.cpp
+    cmaes_test.cpp
+    cne_test.cpp
+    eve_test.cpp
+    frankwolfe_test.cpp
+    function_test.cpp
+    gradient_descent_test.cpp
+    grid_search_test.cpp
+    iqn_test.cpp
+    katyusha_test.cpp
+    lbfgs_test.cpp
+    line_search_test.cpp
+    lrsdp_test.cpp
+    momentum_sgd_test.cpp
+    nesterov_momentum_sgd_test.cpp
+    parallel_sgd_test.cpp
+    proximal_test.cpp
+    rmsprop_test.cpp
+    sa_test.cpp
+    sarah_test.cpp
+    scd_test.cpp
+    sdp_primal_dual_test.cpp
+    sgdr_test.cpp
+    sgd_test.cpp
+    smorms3_test.cpp
+    snapshot_ensembles.cpp
+    spalera_sgd_test.cpp
+    svrg_test.cpp
+    swats_test.cpp
+    wn_grad_test.cpp
 )
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,40 +2,40 @@ project(ensmallen_tests CXX)
 
 set(ENSMALLEN_TESTS_SOURCES
     main.cpp
-    ada_delta_test.cpp
-    ada_grad_test.cpp
-    adam_test.cpp
+    #ada_delta_test.cpp
+    #ada_grad_test.cpp
+    #adam_test.cpp
     aug_lagrangian_test.cpp
-    bigbatch_sgd_test.cpp
-    cmaes_test.cpp
-    cne_test.cpp
-    eve_test.cpp
-    frankwolfe_test.cpp
-    function_test.cpp
-    gradient_descent_test.cpp
-    grid_search_test.cpp
-    iqn_test.cpp
-    katyusha_test.cpp
-    lbfgs_test.cpp
-    line_search_test.cpp
-    lrsdp_test.cpp
-    momentum_sgd_test.cpp
-    nesterov_momentum_sgd_test.cpp
-    parallel_sgd_test.cpp
-    proximal_test.cpp
-    rmsprop_test.cpp
-    sa_test.cpp
-    sarah_test.cpp
-    scd_test.cpp
-    sdp_primal_dual_test.cpp
-    sgdr_test.cpp
-    sgd_test.cpp
-    smorms3_test.cpp
-    snapshot_ensembles.cpp
-    spalera_sgd_test.cpp
-    svrg_test.cpp
-    swats_test.cpp
-    wn_grad_test.cpp
+    #bigbatch_sgd_test.cpp
+    #cmaes_test.cpp
+    #cne_test.cpp
+    #eve_test.cpp
+    #frankwolfe_test.cpp
+    #function_test.cpp
+    #gradient_descent_test.cpp
+    #grid_search_test.cpp
+    #iqn_test.cpp
+    #katyusha_test.cpp
+    #lbfgs_test.cpp
+    #line_search_test.cpp
+    #lrsdp_test.cpp
+    #momentum_sgd_test.cpp
+    #nesterov_momentum_sgd_test.cpp
+    #parallel_sgd_test.cpp
+    #proximal_test.cpp
+    #rmsprop_test.cpp
+    #sa_test.cpp
+    #sarah_test.cpp
+    #scd_test.cpp
+    #sdp_primal_dual_test.cpp
+    #sgdr_test.cpp
+    #sgd_test.cpp
+    #smorms3_test.cpp
+    #snapshot_ensembles.cpp
+    #spalera_sgd_test.cpp
+    #svrg_test.cpp
+    #swats_test.cpp
+    #wn_grad_test.cpp
 )
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/aug_lagrangian_test.cpp
+++ b/tests/aug_lagrangian_test.cpp
@@ -31,7 +31,7 @@ TEST_CASE("AugLagrangianTestFunctionTest", "[AugLagrangianTest]")
 
   arma::vec coords = f.GetInitialPoint();
 
-  if (!aug.Optimize(f, coords, 0.25, 10.0, 0))
+  if (!aug.Optimize(f, coords))
     FAIL("Optimization reported failure.");
 
   double finalValue = f.Evaluate(coords);
@@ -51,7 +51,7 @@ TEST_CASE("GockenbachFunctionTest", "[AugLagrangianTest]")
 
   arma::vec coords = f.GetInitialPoint();
 
-  if (!aug.Optimize(f, coords, 0.25, 10.0, 0))
+  if (!aug.Optimize(f, coords))
     FAIL("Optimization reported failure.");
 
   double finalValue = f.Evaluate(coords);

--- a/tests/aug_lagrangian_test.cpp
+++ b/tests/aug_lagrangian_test.cpp
@@ -31,7 +31,7 @@ TEST_CASE("AugLagrangianTestFunctionTest", "[AugLagrangianTest]")
 
   arma::vec coords = f.GetInitialPoint();
 
-  if (!aug.Optimize(f, coords, 0))
+  if (!aug.Optimize(f, coords, 0.25, 10.0, 0))
     FAIL("Optimization reported failure.");
 
   double finalValue = f.Evaluate(coords);
@@ -51,7 +51,7 @@ TEST_CASE("GockenbachFunctionTest", "[AugLagrangianTest]")
 
   arma::vec coords = f.GetInitialPoint();
 
-  if (!aug.Optimize(f, coords, 0))
+  if (!aug.Optimize(f, coords, 0.25, 10.0, 0))
     FAIL("Optimization reported failure.");
 
   double finalValue = f.Evaluate(coords);


### PR DESCRIPTION
Added optionality to set the L-BFGS iterations, the penalty update factor and the sigma update factor in the augmented Lagrangian class. Kept defaults the same as the originally hardcoded values.