### PR TITLE
Incorrect class name RMSProp in documentation

### DIFF
--- a/doc/function_types.md
+++ b/doc/function_types.md
@@ -614,7 +614,7 @@ int main()
   // Use RMSprop to find the best parameters for the linear regression model.
   // The type 'ens::RMSprop' can be changed for any ensmallen optimizer able to
   // handle differentiable separable functions.
-  ens::RMSprop rmsprop;
+  ens::RMSProp rmsprop;
   LinearRegressionFunction lrf(data, responses);
   rmsprop.Optimize(lrf, params);
 


### PR DESCRIPTION
Fix for a small error in the documentation where ens::RMSProp was being used.

If this same file is being used on the website for the documentation, then this should fix the issue there too. Else, the same error is there on the documentation webpage.