### PR TITLE
CMAES inconsistency fix

### DIFF
--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -415,8 +415,8 @@ by implementing a class with the same method signatures.
 
 For convenience the following types can be used:
 
- * **`CMAES<>`** (equivalent to `CMAES<FullSelection>`): uses all separable functions to compute objective
- * **`ApproxCMAES`** (equivalent to `CMAES<RandomSelection>`): uses a small amount of separable functions to compute approximate objective
+ * **`CMAES<>`** (equivalent to `CMAES<FullSelection>`): uses all separable functions to compute objective.
+ * **`ApproxCMAES`** (equivalent to `CMAES<RandomSelection>`): uses a small amount of separable functions to compute approximate objective.
 
 #### Attributes
 

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -403,9 +403,10 @@ matrix within an iterative procedure using the covariance matrix.
 #### Constructors
 
  * `CMAES<`_`SelectionPolicyType`_`>()`
- * `CMAES<`_`SelectionPolicyType`_`>(`_`lambda, lowerBound, upperBound`_`)`
- * `CMAES<`_`SelectionPolicyType`_`>(`_`lambda, lowerBound, upperBound, batchSize`_`)`
- * `CMAES<`_`SelectionPolicyType`_`>(`_`lambda, lowerBound, upperBound, batchSize, maxIterations, tolerance, selectionPolicy`_`)`
+ * `CMAES<`_`SelectionPolicyType`_`>(`_`lambda, initialSigma, lowerBound, upperBound`_`)`
+ * `CMAES<`_`SelectionPolicyType`_`>(`_`lambda, initialSigma, lowerBound, upperBound, batchSize`_`)`
+ * `CMAES<`_`SelectionPolicyType`_`>(`_`lambda, initialSigma, lowerBound, upperBound, batchSize, maxIterations, 
+ 	tolerance, selectionPolicy`_`)`
 
 The _`SelectionPolicyType`_ template parameter refers to the strategy used to
 compute the (approximate) objective function.  The `FullSelection` and
@@ -422,6 +423,7 @@ For convenience the following types can be used:
 | **type** | **name** | **description** | **default** |
 |----------|----------|-----------------|-------------|
 | `size_t` | **`lambda`** | The population size (0 uses a default size). | `0` |
+| `double` | **`initialSigma`** | The initial step size | `0.6` |
 | `double` | **`lowerBound`** | Lower bound of decision variables. | `-10.0` |
 | `double` | **`upperBound`** | Upper bound of decision variables. | `10.0` |
 | `size_t` | **`batchSize`** | Batch size to use for the objective calculation. | `32` |
@@ -430,7 +432,7 @@ For convenience the following types can be used:
 | `SelectionPolicyType` | **`selectionPolicy`** | Instantiated selection policy used to calculate the objective. | `SelectionPolicyType()` |
 
 Attributes of the optimizer may also be changed via the member methods
-`Lambda()`, `LowerBound()`, `UpperBound()`, `BatchSize()`, `MaxIterations()`,
+`Lambda()`, `InitialSigma()`, `LowerBound()`, `UpperBound()`, `BatchSize()`, `MaxIterations()`,
 `Tolerance()`, and `SelectionPolicy()`.
 
 The `selectionPolicy` attribute allows an instantiated `SelectionPolicyType` to
@@ -447,7 +449,7 @@ RosenbrockFunction f;
 arma::mat coordinates = f.GetInitialPoint();
 
 // CMAES with the FullSelection policy.
-CMAES<> optimizer(0, -1, 1, 32, 200, 0.1e-4);
+CMAES<> optimizer(0, 0.6, -1, 1, 32, 200, 0.1e-4);
 optimizer.Optimize(f, coordinates);
 
 // CMAES with the RandomSelection policy.

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -440,7 +440,7 @@ be given.  The `FullSelection` policy has no need to be instantiated and thus
 the option is not relevant when the `CMAES<>` optimizer type is being used; the
 `RandomSelection` policy has the constructor `RandomSelection(`_`fraction`_`)`
 where _`fraction`_ specifies the percentage of separable functions to use to
-estimate the objective function.
+estimate the objective function. By default, _`fraction`_ is 0.3.
 
 #### Examples:
 
@@ -452,9 +452,15 @@ arma::mat coordinates = f.GetInitialPoint();
 CMAES<> optimizer(0, 0.6, -1, 1, 32, 200, 0.1e-4);
 optimizer.Optimize(f, coordinates);
 
-// CMAES with the RandomSelection policy.
-ApproxCMAES<> approxOptimizer(batchSize, 0.01, 0.1, 8000, 1e-4);
+// CMAES with the default RandomSelection policy.
+ApproxCMAES<> approxOptimizer(0, 0.6, -1, 1, 32, 200, 0.1e-4);
 approxOptimizer.Optimize(f, coordinates);
+
+// CMAES with user defined RandomSelection policy.
+RandomSelection myPolicy(0.5);
+CMAES<RandomSelection> optimizer(0, 0.6, -1, 1, 32, 200, 0.1e-4, myPolicy);
+optimizer.Optimize(f,coordinates);
+
 ```
 
 #### See also:

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -423,7 +423,7 @@ For convenience the following types can be used:
 | **type** | **name** | **description** | **default** |
 |----------|----------|-----------------|-------------|
 | `size_t` | **`lambda`** | The population size (0 uses a default size). | `0` |
-| `double` | **`initialSigma`** | The initial step size | `0.6` |
+| `double` | **`initialSigma`** | The initial step size. | `0.6` |
 | `double` | **`lowerBound`** | Lower bound of decision variables. | `-10.0` |
 | `double` | **`upperBound`** | Upper bound of decision variables. | `10.0` |
 | `size_t` | **`batchSize`** | Batch size to use for the objective calculation. | `32` |

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -460,7 +460,6 @@ approxOptimizer.Optimize(f, coordinates);
 RandomSelection myPolicy(0.5);
 CMAES<RandomSelection> optimizer(0, 0.6, -1, 1, 32, 200, 0.1e-4, myPolicy);
 optimizer.Optimize(f,coordinates);
-
 ```
 
 #### See also:

--- a/include/ensmallen_bits/cmaes/cmaes.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes.hpp
@@ -107,9 +107,9 @@ class CMAES
   //! Modify the lower bound of decision variables.
   double& LowerBound() { return lowerBound; }
 
-  //! Get the upper bound of decision variables
+  //! Get the upper bound of decision variables.
   double UpperBound() const { return upperBound; }
-  //! Modify the upper bound of decision variables
+  //! Modify the upper bound of decision variables.
   double& UpperBound() { return upperBound; }
 
   //! Get the batch size.
@@ -132,14 +132,14 @@ class CMAES
   //! Modify the selection policy.
   SelectionPolicyType& SelectionPolicy() { return selectionPolicy; }
 
-  //! Get the step size damping
+  //! Get the step size damping.
   double StepSizeDamping() const { return ds; }
-  //! Modify the step size damping
+  //! Modify the step size damping.
   double& StepSizeDamping() { return ds; }
 
-  //! Get the cumulation constant
+  //! Get the cumulation constant.
   double CumulationConstant() const { return cc; }
-  //! Modify the cumulation constant
+  //! Modify the cumulation constant.
   double& CumulationConstant() { return cc; }
 
  private:
@@ -152,7 +152,7 @@ class CMAES
   //! Lower bound of decision variables.
   double lowerBound;
 
-  //! Upper bound of decision variables
+  //! Upper bound of decision variables.
   double upperBound;
 
   //! The batch size for processing.
@@ -167,13 +167,13 @@ class CMAES
   //! The selection policy used to calculate the objective.
   SelectionPolicyType selectionPolicy;
 
-  //! Step size damping
+  //! Step size damping.
   double ds;
 
-  //! Cumulation constant
+  //! Cumulation constant.
   double cc;
 
-  //! Methods used to transform the candidates into the constraints
+  //! Methods used to transform the candidates into the constraints.
   void BoundaryTransform(arma::mat& iterate);
   void BoundaryTransformInverse(arma::mat& iterate);
 };

--- a/include/ensmallen_bits/cmaes/cmaes.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes.hpp
@@ -163,6 +163,9 @@ class CMAES
   //! Cumulation constant
   double cc;
 
+  //! Methods used to transform the candidates into the constraints
+  void BoundaryTransform(arma::mat& iterate);
+  void BoundaryTransformInverse(arma::mat& iterate);
 };
 
 /**

--- a/include/ensmallen_bits/cmaes/cmaes.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes.hpp
@@ -60,6 +60,7 @@ class CMAES
    * equal one pass over the dataset).
    *
    * @param lambda The population size (0 use the default size).
+   * @param initialSigma The initial step size
    * @param lowerBound Lower bound of decision variables.
    * @param upperBound Upper bound of decision variables.
    * @param batchSize Batch size to use for the objective calculation.
@@ -70,6 +71,7 @@ class CMAES
    *     objective.
    */
   CMAES(const size_t lambda = 0,
+        const double initialSigma = 0.6,
         const double lowerBound = -10,
         const double upperBound = 10,
         const size_t batchSize = 32,
@@ -94,6 +96,11 @@ class CMAES
   size_t PopulationSize() const { return lambda; }
   //! Modify the population size.
   size_t& PopulationSize() { return lambda; }
+
+  //! Get the initial step size.
+  double InitialSigma() const { return initialSigma; }
+  //! Modify the initial step size.
+  double& InitialSigma() { return initialSigma; }
 
   //! Get the lower bound of decision variables.
   double LowerBound() const { return lowerBound; }
@@ -138,6 +145,9 @@ class CMAES
  private:
   //! Population size.
   size_t lambda;
+
+  //! Initial step size.
+  double initialSigma;
 
   //! Lower bound of decision variables.
   double lowerBound;

--- a/include/ensmallen_bits/cmaes/cmaes.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes.hpp
@@ -125,6 +125,16 @@ class CMAES
   //! Modify the selection policy.
   SelectionPolicyType& SelectionPolicy() { return selectionPolicy; }
 
+  //! Get the step size damping
+  double StepSizeDamping() const { return ds; }
+  //! Modify the step size damping
+  double& StepSizeDamping() { return ds; }
+
+  //! Get the cumulation constant
+  double CumulationConstant() const { return cc; }
+  //! Modify the cumulation constant
+  double& CumulationConstant() { return cc; }
+
  private:
   //! Population size.
   size_t lambda;
@@ -146,6 +156,13 @@ class CMAES
 
   //! The selection policy used to calculate the objective.
   SelectionPolicyType selectionPolicy;
+
+  //! Step size damping
+  double ds;
+
+  //! Cumulation constant
+  double cc;
+
 };
 
 /**

--- a/include/ensmallen_bits/cmaes/cmaes.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes.hpp
@@ -60,7 +60,7 @@ class CMAES
    * equal one pass over the dataset).
    *
    * @param lambda The population size (0 use the default size).
-   * @param initialSigma The initial step size
+   * @param initialSigma The initial step size.
    * @param lowerBound Lower bound of decision variables.
    * @param upperBound Upper bound of decision variables.
    * @param batchSize Batch size to use for the objective calculation.

--- a/include/ensmallen_bits/cmaes/cmaes.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes.hpp
@@ -90,9 +90,9 @@ class CMAES
   template<typename DecomposableFunctionType>
   double Optimize(DecomposableFunctionType& function, arma::mat& iterate);
 
-  //! Get the step size.
+  //! Get the population size.
   size_t PopulationSize() const { return lambda; }
-  //! Modify the step size.
+  //! Modify the population size.
   size_t& PopulationSize() { return lambda; }
 
   //! Get the lower bound of decision variables.

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -129,7 +129,7 @@ double CMAES<SelectionPolicyType>::Optimize(
     const size_t idx1 = i % 2;
 
     // Perform Cholesky decomposition. If the matrix is not positive definite,
-    // add a small value and try again
+    // add a small value and try again.
     arma::mat covLower;
     while (!arma::chol(covLower, C.slice(idx0), "lower"))
       C.slice(idx0).diag() += 1e-16;
@@ -287,19 +287,19 @@ double CMAES<SelectionPolicyType>::Optimize(
   return overallObjective;
 }
 
-// Transforms the candidate into the given bounds
+// Transforms the candidate into the given bounds.
 template<typename SelectionPolicyType>
 void CMAES<SelectionPolicyType>::BoundaryTransform(arma::mat& iterate)
 {
   double al = std::min((upperBound - lowerBound) / 2, (1 + std::abs(lowerBound)) / 20 );
   double au = std::min((upperBound - lowerBound) / 2, (1 + std::abs(upperBound)) / 20 );
-  for(size_t ii = 0; ii < iterate.n_cols; ii++)
+  for (size_t ii = 0; ii < iterate.n_cols; ii++)
   {
     for (size_t it = 0; it < iterate.n_rows; it++)
     {
       double x = iterate(it,ii);
 
-      // Shift x into [lowerBound-al, upperBound+au]
+      // Shift x into [lowerBound-al, upperBound+au].
       if (x < lowerBound - 2 * al - (upperBound - lowerBound) / 2 || x > upperBound + 2 * au + (upperBound - lowerBound) / 2)
       {
         double r = 2 * (upperBound - lowerBound + al + au);
@@ -311,7 +311,7 @@ void CMAES<SelectionPolicyType>::BoundaryTransform(arma::mat& iterate)
       if (x < lowerBound - al)
         x += 2 * (lowerBound - al - x);
 
-      // Shifts x into [upperBound - lowerBound] 
+      // Shifts x into [upperBound - lowerBound].
       if (x < lowerBound + al)
         x = lowerBound + std::pow((x - (lowerBound - al)), 2) / 4 / al;
       else if (x < upperBound - au)
@@ -326,13 +326,13 @@ void CMAES<SelectionPolicyType>::BoundaryTransform(arma::mat& iterate)
   }
 }
 
-// Computes the inverse of the transformation
+// Computes the inverse of the transformation.
 template<typename SelectionPolicyType>
 void CMAES<SelectionPolicyType>::BoundaryTransformInverse(arma::mat& iterate)
 {
   double al = std::min((upperBound - lowerBound) / 2, (1 + std::abs(lowerBound)) / 20 );
   double au = std::min((upperBound - lowerBound) / 2, (1 + std::abs(upperBound)) / 20 );
-  for(size_t ii = 0; ii < iterate.n_cols; ii++)
+  for (size_t ii = 0; ii < iterate.n_cols; ii++)
   {
     for (size_t it = 0; it < iterate.n_rows; it++)
     {
@@ -359,8 +359,6 @@ void CMAES<SelectionPolicyType>::BoundaryTransformInverse(arma::mat& iterate)
     }
   }
 }
-
-
 
 } // namespace ens
 

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -18,7 +18,7 @@
 // In case it hasn't been included yet.
 #include "cmaes.hpp"
 
-#include <ensmallen_bits/function.hpp>
+#include "../function.hpp"
 
 namespace ens {
 
@@ -69,14 +69,14 @@ double CMAES<SelectionPolicyType>::Optimize(
   arma::vec sigma(3);
   sigma(0) = 0.3 * (upperBound - lowerBound);
   const double cs = (muEffective + 2) / (iterate.n_elem + muEffective + 5);
-  const double ds = 1 + cs + 2 * std::max(std::sqrt((muEffective - 1) /
+  ds = 1 + cs + 2 * std::max(std::sqrt((muEffective - 1) /
       (iterate.n_elem + 1)) - 1, 0.0);
   const double enn = std::sqrt(iterate.n_elem) * (1.0 - 1.0 /
       (4.0 * iterate.n_elem) + 1.0 / (21 * std::pow(iterate.n_elem, 2)));
 
   // Covariance update parameters.
   // Cumulation for distribution.
-  const double cc = (4 + muEffective / iterate.n_elem) /
+  cc = (4 + muEffective / iterate.n_elem) /
       (4 + iterate.n_elem + 2 * muEffective / iterate.n_elem);
   const double h = (1.4 + 2.0 / (iterate.n_elem + 1.0)) * enn;
 
@@ -87,9 +87,7 @@ double CMAES<SelectionPolicyType>::Optimize(
       alphaMu * muEffective / 2));
 
   arma::cube mPosition(iterate.n_rows, iterate.n_cols, 3);
-  mPosition.slice(0) = lowerBound + arma::randu(
-      iterate.n_rows, iterate.n_cols) * (upperBound - lowerBound);
-
+  mPosition.slice(0) = iterate + arma::randu(iterate.n_rows, iterate.n_cols);
   arma::mat step = arma::zeros(iterate.n_rows, iterate.n_cols);
 
   // Calculate the first objective function.

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -24,6 +24,7 @@ namespace ens {
 
 template<typename SelectionPolicyType>
 CMAES<SelectionPolicyType>::CMAES(const size_t lambda,
+                                  const double initialSigma,
                                   const double lowerBound,
                                   const double upperBound,
                                   const size_t batchSize,
@@ -31,6 +32,7 @@ CMAES<SelectionPolicyType>::CMAES(const size_t lambda,
                                   const double tolerance,
                                   const SelectionPolicyType& selectionPolicy) :
     lambda(lambda),
+    initialSigma(initialSigma),
     lowerBound(lowerBound),
     upperBound(upperBound),
     batchSize(batchSize),
@@ -67,7 +69,7 @@ double CMAES<SelectionPolicyType>::Optimize(
 
   // Step size control parameters.
   arma::vec sigma(3);
-  sigma(0) = 0.3 * (upperBound - lowerBound);
+  sigma(0) = initialSigma;
   const double cs = (muEffective + 2) / (iterate.n_elem + muEffective + 5);
   ds = 1 + cs + 2 * std::max(std::sqrt((muEffective - 1) /
       (iterate.n_elem + 1)) - 1, 0.0);

--- a/tests/cmaes_test.cpp
+++ b/tests/cmaes_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("CMAESLogisticRegressionTest", "[CMAESTest]")
         responses, testResponses, shuffledResponses);
     LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
 
-    CMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
+    CMAES<> cmaes(0, -20, 20, 32, 200, 1e-3);
     arma::mat coordinates = lr.GetInitialPoint();
     cmaes.Optimize(lr, coordinates);
 
@@ -85,7 +85,7 @@ TEST_CASE("ApproxCMAESLogisticRegressionTest", "[CMAESTest]")
         responses, testResponses, shuffledResponses);
     LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
 
-    ApproxCMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
+    ApproxCMAES<> cmaes(0, -20, 20, 32, 200, 1e-3);
     arma::mat coordinates = lr.GetInitialPoint();
     cmaes.Optimize(lr, coordinates);
 

--- a/tests/cmaes_test.cpp
+++ b/tests/cmaes_test.cpp
@@ -23,7 +23,7 @@ using namespace ens::test;
 TEST_CASE("SimpleTestFunction", "[CMAESTest]")
 {
   SGDTestFunction f;
-  CMAES<> optimizer(0, -1, 1, 32, 200, -1);
+  CMAES<> optimizer(0, 0.6, -1, 1, 32, 200, -1);
 
   arma::mat coordinates = f.GetInitialPoint();
   optimizer.Optimize(f, coordinates);
@@ -50,7 +50,7 @@ TEST_CASE("CMAESLogisticRegressionTest", "[CMAESTest]")
         responses, testResponses, shuffledResponses);
     LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
 
-    CMAES<> cmaes(0, -20, 20, 32, 200, 1e-3);
+    CMAES<> cmaes(0, 0.6, -20, 20, 32, 200, 1e-3);
     arma::mat coordinates = lr.GetInitialPoint();
     cmaes.Optimize(lr, coordinates);
 
@@ -85,7 +85,7 @@ TEST_CASE("ApproxCMAESLogisticRegressionTest", "[CMAESTest]")
         responses, testResponses, shuffledResponses);
     LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
 
-    ApproxCMAES<> cmaes(0, -20, 20, 32, 200, 1e-3);
+    ApproxCMAES<> cmaes(0, 0.6, -20, 20, 32, 200, 1e-3);
     arma::mat coordinates = lr.GetInitialPoint();
     cmaes.Optimize(lr, coordinates);
 


### PR DESCRIPTION
This is a fix for issue #70 . The boundary handler has been adapted from the python code for CMA-ES
I had to change the bounds in the test functions since they did not align with the solution.
I will update the documentation for the code in a couple hours if there are no problems