### PR TITLE
Rectified Big Batch SGD implementation

### DIFF
--- a/include/ensmallen_bits/bigbatch_sgd/adaptive_stepsize.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/adaptive_stepsize.hpp
@@ -81,12 +81,6 @@ class AdaptiveStepsize
               const size_t backtrackingBatchSize,
               const bool /* reset */)
   {
-    // Initialize previous iterate, if not already initialized
-    if (iteratePrev.is_empty())
-    {
-      iteratePrev.zeros(iterate.n_rows, iterate.n_cols);
-    }
-
     Backtracking(function, stepSize, iterate, gradient, gradientNorm, offset,
         backtrackingBatchSize);
 
@@ -99,6 +93,12 @@ class AdaptiveStepsize
 
     size_t k = 1;
     double vB = 0;
+
+    // Initialize previous iterate, if not already initialized.
+    if (iteratePrev.is_empty())
+    {
+      iteratePrev.zeros(iterate.n_rows, iterate.n_cols);
+    }
 
     // Compute the stochastic gradient estimation.
     function.Gradient(iteratePrev, offset, gradPrevIterate, 1);
@@ -119,8 +119,11 @@ class AdaptiveStepsize
     }
 
     double v = arma::trace(arma::trans(iterate - iteratePrev) *
-        (iterate - gradPrevIterate)) /
+        (gradient - gradPrevIterate)) /
         std::pow(arma::norm(iterate - iteratePrev, 2), 2.0);
+
+    // Update previous iterate.
+    iteratePrev = iterate;
 
     // TODO: Develop an absolute strategy to deal with stepSizeDecay updates in
     // case we arrive at local minima. See #1469 for more details.

--- a/include/ensmallen_bits/bigbatch_sgd/backtracking_line_search.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/backtracking_line_search.hpp
@@ -89,7 +89,7 @@ class BacktrackingLineSearch
         offset, backtrackingBatchSize);
 
     while (overallObjectiveUpdate >
-        (overallObjective + searchParameter * stepSize * gradientNorm))
+        (overallObjective - searchParameter * stepSize * gradientNorm))
     {
       stepSize /= 2;
 
@@ -97,6 +97,9 @@ class BacktrackingLineSearch
       overallObjectiveUpdate = function.Evaluate(iterateUpdate,
         offset, backtrackingBatchSize);
     }
+
+    // Update the iterate.
+    iterate -= stepSize * gradient;
   }
 
  private:

--- a/include/ensmallen_bits/bigbatch_sgd/backtracking_line_search.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/backtracking_line_search.hpp
@@ -97,9 +97,6 @@ class BacktrackingLineSearch
       overallObjectiveUpdate = function.Evaluate(iterateUpdate,
         offset, backtrackingBatchSize);
     }
-
-    // Update the iterate.
-    iterate -= stepSize * gradient;
   }
 
  private:

--- a/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
@@ -173,9 +173,6 @@ double BigBatchSGD<UpdatePolicyType>::Optimize(
     updatePolicy.Update(f, stepSize, iterate, gradient, gB, vB,
         currentFunction, batchSize, effectiveBatchSize, reset);
 
-    // Update the iterate.
-    iterate -= stepSize * gradient;
-
     overallObjective += f.Evaluate(iterate, currentFunction,
         effectiveBatchSize);
 

--- a/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
@@ -173,6 +173,9 @@ double BigBatchSGD<UpdatePolicyType>::Optimize(
     updatePolicy.Update(f, stepSize, iterate, gradient, gB, vB,
         currentFunction, batchSize, effectiveBatchSize, reset);
 
+    // Update the iterate.
+    iterate -= stepSize * gradient;
+
     overallObjective += f.Evaluate(iterate, currentFunction,
         effectiveBatchSize);
 


### PR DESCRIPTION
Solves below issues : 

- [x] Use  curvature of the quadratic approximation while calculating `stepSizeDecay`.
- [x] Update Gradient, Sample Variance and Gradient Norm before second backtrack call within the iteration.
- [x] Correct backtracking line search termination condition.
- [x] Use 1/2 as default back track step size.