### PR TITLE
`cyclical_decay.hpp` BibTeX fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 ###### ????-??-??
   * Minor documentation fixes (#95).
 
+  * Fix newlines at end of file (#92).
+
 ### ensmallen 1.14.1
 ###### 2019-03-09
   * Fixes for SPSA (#87).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+### ensmallen 1.14.2
+###### ????-??-??
+  * Minor documentation fixes (#95).
+
 ### ensmallen 1.14.1
 ###### 2019-03-09
   * Fixes for SPSA (#87).

--- a/include/ensmallen_bits/sgdr/cyclical_decay.hpp
+++ b/include/ensmallen_bits/sgdr/cyclical_decay.hpp
@@ -27,7 +27,6 @@ namespace ens {
  *
  * @code
  * @article{Loshchilov2016,
- *   title   = {Learning representations by back-propagating errors},
  *   author  = {Ilya Loshchilov and Frank Hutter},
  *   title   = {{SGDR:} Stochastic Gradient Descent with Restarts},
  *   journal = {CoRR},


### PR DESCRIPTION
It had two titles... not sure how that happened. :)