### PR TITLE
fix: don't assume that arma::eig_sym() always succeeds

### DIFF
--- a/include/ensmallen_bits/sdp/primal_dual_impl.hpp
+++ b/include/ensmallen_bits/sdp/primal_dual_impl.hpp
@@ -132,7 +132,10 @@ Alpha(const arma::mat& A, const arma::mat& dA, double tau, double& alpha)
     return false;
   // TODO(stephentu): We only want the top eigenvalue, we should
   // be able to do better than full eigen-decomposition.
-  const arma::vec evals = arma::eig_sym(-Linv * dA * Linv.t());
+  arma::vec evals;
+  if (!arma::eig_sym(evals, -Linv * dA * Linv.t()))
+    return false;
+  
   const double alphahatinv = evals(evals.n_elem - 1);
   double alphahat = 1. / alphahatinv;
   if (alphahat < 0.)

--- a/tests/sdp_primal_dual_test.cpp
+++ b/tests/sdp_primal_dual_test.cpp
@@ -182,8 +182,11 @@ ConstructMaxCutSDPFromLaplacian(const std::string& laplacianFilename)
 
 static bool CheckPositiveSemiDefinite(const arma::mat& X)
 {
-  const auto evals = arma::eig_sym(X);
-  return (evals(0) > 1e-20);
+  arma::vec evals;
+  if(!arma::eig_sym(evals, X))
+    return false;
+  else
+    return (evals(0) > 1e-20);
 }
 
 template <typename SDPType>


### PR DESCRIPTION
if we assume arma::eig_sym() succeeds, but in fact it fails, accessing elements in the evals vector will result either in a crash or an out-of-bounds error.
