### PR TITLE
Fix compilation warnings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+### ensmallen 1.15.1
+###### 2019-MM-DD
+  * Fix -Wreorder in `qhadam` warning (#115).
+  * Fix -Wunused-private-field warning in `spsa` (#115).
+
 ### ensmallen 1.15.0
 ###### 2019-05-14
   * Added QHAdam and QHSGD optimizers (#81).

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -1636,7 +1636,7 @@ differences along stochastic directions.
 
 #### Constructors
 
- * `SPSA(`_`alpha, gamma, stepSize, evaluationStepSize, maxIterations, tolerance, shuffle`_`)`
+ * `SPSA(`_`alpha, gamma, stepSize, evaluationStepSize, maxIterations, tolerance`_`)`
 
 #### Attributes
 

--- a/include/ensmallen_bits/qhadam/qhadam_update.hpp
+++ b/include/ensmallen_bits/qhadam/qhadam_update.hpp
@@ -147,14 +147,14 @@ class QHAdamUpdate
   // The exponential moving average of squared gradient values.
   arma::mat v;
 
-  // The number of iterations.
-  double iteration;
-
   // The first quasi-hyperbolic term.
   double v1;
 
   // The second quasi-hyperbolic term.
   double v2;
+  
+  // The number of iterations.
+  double iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/spsa/spsa.hpp
+++ b/include/ensmallen_bits/spsa/spsa.hpp
@@ -54,16 +54,13 @@ class SPSA
    * @param maxIterations Maximum number of iterations allowed (0 means no
    *     limit).
    * @param tolerance Maximum absolute tolerance to terminate algorithm.
-   * @param shuffle If true, the function order is shuffled; otherwise, each
-   *     function is visited in linear order.
    */
   SPSA(const double alpha = 0.602,
        const double gamma = 0.101,
        const double stepSize = 0.16,
        const double evaluationStepSize = 0.3,
        const size_t maxIterations = 100000,
-       const double tolerance = 1e-5,
-       const bool shuffle = true);
+       const double tolerance = 1e-5);
 
   template<typename DecomposableFunctionType>
   double Optimize(DecomposableFunctionType& function, arma::mat& iterate);
@@ -114,10 +111,6 @@ class SPSA
 
   //! The tolerance for termination.
   double tolerance;
-
-  //! Controls whether or not the individual functions are shuffled when
-  //! iterating.
-  bool shuffle;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/spsa/spsa_impl.hpp
+++ b/include/ensmallen_bits/spsa/spsa_impl.hpp
@@ -26,16 +26,14 @@ inline SPSA::SPSA(const double alpha,
                   const double stepSize,
                   const double evaluationStepSize,
                   const size_t maxIterations,
-                  const double tolerance,
-                  const bool shuffle) :
+                  const double tolerance) :
     alpha(alpha),
     gamma(gamma),
     stepSize(stepSize),
     evaluationStepSize(evaluationStepSize),
     ak(0.001 * maxIterations),
     maxIterations(maxIterations),
-    tolerance(tolerance),
-    shuffle(shuffle)
+    tolerance(tolerance)
 { /* Nothing to do. */ }
 
 template<typename ArbitraryFunctionType>


### PR DESCRIPTION
 Addresses the variable initialization issue highlighted under -Wreorder, c.f.

```
 ../inst/include/ensmallen_bits/qhadam/qhadam_update.hpp:57:5: 
warning: field 'v2' will be initialized after field 'iteration' [-Wreorder]
```

@rcurtin + @zoq  I can tackle #114 if need be in this as well.