### PR TITLE
Enable minimal code style checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - cmake . && make && sudo make install && cd ..
 
 install:
-  - mkdir build && cd build && cmake .. && make -j2
+  - mkdir build && cd build && cmake -DSHOW_COMPILE_WARNINGS=ON .. && make -j2
 
 script:
   - CTEST_OUTPUT_ON_FAILURE=1 travis_wait 30 ctest -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - cmake . && make && sudo make install && cd ..
 
 install:
-  - mkdir build && cd build && cmake -DSHOW_COMPILE_WARNINGS=ON .. && make -j2
+  - mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_FLAGS="-Werror" .. && make -j2
 
 script:
   - CTEST_OUTPUT_ON_FAILURE=1 travis_wait 30 ctest -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 2.8.10)
 project(ensmallen C CXX)
 
 option(USE_OPENMP "If available, use OpenMP for parallelization." ON)
+option(SHOW_COMPILE_WARNINGS "Verify compilation is free from warnings." OFF) 
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
 
@@ -39,6 +40,15 @@ if (OPENMP_FOUND)
 else ()
   # Disable warnings for all the unknown OpenMP pragmas.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+endif ()
+
+# Verify the code conforms to ISO standards regarding C++ as
+# indicated in the GCC options
+# https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
+# Moreover, treat any compilation warning as an error.
+if ( SHOW_COMPILE_WARNINGS )
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wpedantic -Wextra -Werror -fdiagnostics-color")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Wextra -Werror -fdiagnostics-color")
 endif ()
 
 # The only dependency we need is Armadillo.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,8 @@ endif ()
 # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
 # Moreover, treat any compilation warning as an error.
 if ( SHOW_COMPILE_WARNINGS )
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wpedantic -Wextra -Werror -fdiagnostics-color")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Wextra -Werror -fdiagnostics-color")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wpedantic -Wextra -Werror")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Wextra -Werror")
 endif ()
 
 # The only dependency we need is Armadillo.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ cmake_minimum_required(VERSION 2.8.10)
 project(ensmallen C CXX)
 
 option(USE_OPENMP "If available, use OpenMP for parallelization." ON)
-option(SHOW_COMPILE_WARNINGS "Verify compilation is free from warnings." OFF) 
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
 
@@ -42,14 +41,12 @@ else ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
 endif ()
 
-# Verify the code conforms to ISO standards regarding C++ as
-# indicated in the GCC options
-# https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
-# Moreover, treat any compilation warning as an error.
-if ( SHOW_COMPILE_WARNINGS )
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wpedantic -Wextra -Werror")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Wextra -Werror")
-endif ()
+# Set the CFLAGS and CXXFLAGS depending on the options the user specified.
+if(CMAKE_COMPILER_IS_GNUCC OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Wunused-parameter")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wpedantic -Wunused-parameter")
+endif()
 
 # The only dependency we need is Armadillo.
 #


### PR DESCRIPTION
When building ensmallen on TravisCI, verify the code passes traditional ISO checks given by:

```
-Wall -Wpedantic -Wextra
```

If not, treat any warnings that arise as errors with `-Werror`. Show the errors clearly by colorizing the diagnostic output using `-fdiagnostics-color`.

These checks are generally used by CRAN:

https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Writing-portable-packages