### PR TITLE
Clean up tests (runtime and failure probability)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+### ensmallen 1.15.2
+###### ????-??-??
+  * Fix handling of curvature for BigBatchSGD (#118).
+
+  * Reduce runtime of tests (#118).
+
 ### ensmallen 1.15.1
 ###### 2019-05-22
   * Fix -Wreorder in `qhadam` warning (#115).

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -1427,8 +1427,9 @@ SGD.
  Attributes of the optimizer may also be modified via the member methods
  `StepSize()`, `BatchSize()`, `MaxIterations()`, `Tolerance()`, and `Shuffle()`.
 
- Note that the `QHUpdate` class has the constructor  `QHUpdate(`_`v, momentum`_`)` with a
- default value of `0.7` for the quasi hyperbolic term and `0.999` for the momentum term.
+ Note that the `QHUpdate` class has the constructor  `QHUpdate(`_`v,
+momentum`_`)` with a default value of `0.7` for the quasi-hyperbolic term `v`
+and `0.999` for the momentum term.
 
 #### Examples
 

--- a/include/ensmallen_bits/bigbatch_sgd/adaptive_stepsize.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/adaptive_stepsize.hpp
@@ -126,20 +126,24 @@ class AdaptiveStepsize
 
     // Update sample variance & norm of the gradient.
     sampleVariance = vB;
-    gradientNorm = std::pow(arma::norm(gradient / backtrackingBatchSize, 2), 2.0);
+    gradientNorm = std::pow(arma::norm(gradient / backtrackingBatchSize, 2),
+        2.0);
 
-    // Compute curvature.
-    double v = arma::trace(arma::trans(iterate - iteratePrev) *
-        (gradient - gradPrevIterate)) /
-        std::pow(arma::norm(iterate - iteratePrev, 2), 2.0);
+    // Compute curvature.  If it can't be computed (typically due to floating
+    // point representation issues), call it 0.  If the curvature is 0, the step
+    // size will not decay.
+    const double vNum = arma::trace(arma::trans(iterate - iteratePrev) *
+        (gradient - gradPrevIterate));
+    const double vDenom = std::pow(arma::norm(iterate - iteratePrev, 2), 2.0);
+    const double v = (vNum == 0.0 && vDenom == 0.0) ? 0.0 : (vNum / vDenom);
 
     // Update previous iterate.
     iteratePrev = iterate;
 
     // TODO: Develop an absolute strategy to deal with stepSizeDecay updates in
-    // case we arrive at local minima. See #1469 for more details.
+    // case we arrive at local minima. See mlpack#1469 for more details.
     double stepSizeDecay = 0;
-    if (gradientNorm && sampleVariance && batchSize)
+    if (gradientNorm && sampleVariance && batchSize && v)
     {
       if (batchSize < function.NumFunctions())
       {

--- a/include/ensmallen_bits/bigbatch_sgd/adaptive_stepsize.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/adaptive_stepsize.hpp
@@ -135,7 +135,8 @@ class AdaptiveStepsize
     const double vNum = arma::trace(arma::trans(iterate - iteratePrev) *
         (gradient - gradPrevIterate));
     const double vDenom = std::pow(arma::norm(iterate - iteratePrev, 2), 2.0);
-    const double v = (vNum == 0.0 && vDenom == 0.0) ? 0.0 : (vNum / vDenom);
+    const double vTmp = vNum / vDenom;
+    const double v = std::isfinite(vTmp) ? vTmp : 0.0;
 
     // Update previous iterate.
     iteratePrev = iterate;

--- a/include/ensmallen_bits/fw/proximal/proximal_impl.hpp
+++ b/include/ensmallen_bits/fw/proximal/proximal_impl.hpp
@@ -44,7 +44,7 @@ inline void Proximal::ProjectToL1Ball(arma::vec& v, double tau)
   arma::vec simplexSum = arma::cumsum(simplexSol);
 
   double nu = 0;
-  size_t rho;
+  size_t rho = 0;
   for (size_t j = 1; j <= simplexSol.n_rows; j++)
   {
     rho = simplexSol.n_rows - j;

--- a/tests/bigbatch_sgd_test.cpp
+++ b/tests/bigbatch_sgd_test.cpp
@@ -31,7 +31,7 @@ TEST_CASE("BBSBBLogisticRegressionTest", "[BigBatchSGDTest]")
   // Now run big-batch SGD with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 40; batchSize += 5)
   {
-    BBS_BB bbsgd(batchSize, 0.01, 0.1, 8000, 1e-4);
+    BBS_BB bbsgd(batchSize, 0.005, 0.1, 20000, 1e-4);
 
     LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
     arma::mat coordinates = lr.GetInitialPoint();
@@ -62,7 +62,7 @@ TEST_CASE("BBSArmijoLogisticRegressionTest", "[BigBatchSGDTest]")
   // Now run big-batch SGD with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 40; batchSize += 1)
   {
-    BBS_Armijo bbsgd(batchSize, 0.01, 0.1, 8000, 1e-4);
+    BBS_Armijo bbsgd(batchSize, 0.005, 0.1, 20000, 1e-4);
 
     LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
     arma::mat coordinates = lr.GetInitialPoint();

--- a/tests/cne_test.cpp
+++ b/tests/cne_test.cpp
@@ -18,26 +18,81 @@ using namespace ens;
 using namespace ens::test;
 
 /**
- * Train and test a logistic regression function using CNE optimizer
+ * Optimize the Sphere function using CNE.
  */
-TEST_CASE("CNELogisticRegressionTest", "[CNETest]")
+TEST_CASE("CNESphereFunctionTest", "[CNETest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
+  SphereFunction f(2);
+  CNE optimizer(200, 1000, 0.2, 0.2, 0.2, 1e-5);
 
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
+  arma::mat coordinates = f.GetInitialPoint();
+  optimizer.Optimize(f, coordinates);
 
-  CNE opt(200, 1000, 0.2, 0.2, 0.2, 1e-5);
-  arma::mat coordinates = lr.GetInitialPoint();
-  opt.Optimize(lr, coordinates);
+  REQUIRE(coordinates[0] == Approx(0.0).margin(0.1));
+  REQUIRE(coordinates[1] == Approx(0.0).margin(0.1));
+}
 
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
+/**
+ * Test the CNE optimizer on the Wood function.
+ */
+TEST_CASE("CNEStyblinskiTangFunctionTest", "[AdamTest]")
+{
+  StyblinskiTangFunction f(2);
+  CNE optimizer(200, 1000, 0.2, 0.2, 0.2, 1e-5);
 
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  arma::mat coordinates = f.GetInitialPoint();
+  optimizer.Optimize(f, coordinates);
+
+  REQUIRE(coordinates[0] == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
+  REQUIRE(coordinates[1] == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
+}
+
+/**
+ * Test the CNE optimizer on the Matyas function.
+ */
+TEST_CASE("CNEMatyasFunctionTest", "[AdamTest]")
+{
+  MatyasFunction f;
+  CNE optimizer(200, 1000, 0.2, 0.2, 0.2, 1e-5);
+
+  arma::mat coordinates = f.GetInitialPoint();
+  optimizer.Optimize(f, coordinates);
+
+  // 3% error tolerance.
+  REQUIRE(coordinates[0] == Approx(0.0).margin(0.03));
+  REQUIRE(coordinates[1] == Approx(0.0).margin(0.03));
+}
+
+/**
+ * Test the CNE optimizer on the Easom function.
+ */
+TEST_CASE("CNEEasomFunctionTest", "[AdamTest]")
+{
+  EasomFunction f;
+  CNE optimizer(200, 1000, 0.2, 0.2, 0.2, 1e-5);
+
+  arma::mat coordinates = arma::mat("2.9; 2.9");
+  optimizer.Optimize(f, coordinates);
+
+  // 5% error tolerance.
+  REQUIRE((std::trunc(100.0 * coordinates[0]) / 100.0) ==
+      Approx(3.14).epsilon(0.005));
+  REQUIRE((std::trunc(100.0 * coordinates[1]) / 100.0) ==
+      Approx(3.14).epsilon(0.005));
+}
+
+/**
+ * Test the CNE optimizer on the Booth function.
+ */
+TEST_CASE("CNEBoothFunctionTest", "[AdamTest]")
+{
+  BoothFunction f;
+  CNE optimizer(200, 1000, 0.2, 0.2, 0.2, 1e-5);
+
+  arma::mat coordinates = f.GetInitialPoint();
+  optimizer.Optimize(f, coordinates);
+
+  // 2% tolerance.
+  REQUIRE(coordinates[0] == Approx(1.0).epsilon(0.02));
+  REQUIRE(coordinates[1] == Approx(3.0).epsilon(0.02));
 }

--- a/tests/quasi_hyperbolic_momentum_sgd_test.cpp
+++ b/tests/quasi_hyperbolic_momentum_sgd_test.cpp
@@ -19,8 +19,8 @@ using namespace ens::test;
 TEST_CASE("QHSGDTestFunction", "[QHMomentumSGDTest]")
 {
   SGDTestFunction f;
-  QHUpdate update(0.9, 0.9);
-  QHSGD s(0.005, 1, 2500000, 1e-9, true, update);
+  QHUpdate update(0.4, 0.9);
+  QHSGD s(0.0025, 1, 500000, 1e-10, true, update);
 
   arma::mat coordinates = f.GetInitialPoint();
   double result = s.Optimize(f, coordinates);
@@ -40,7 +40,7 @@ TEST_CASE("QHSGDSGDGeneralizedRosenbrockTest", "[QHMomentumSGDTest]")
   {
     // Create the generalized Rosenbrock function.
     GeneralizedRosenbrockFunction f(i);
-    QHUpdate update(0.99, 0.999);
+    QHUpdate update(0.9, 0.99);
     QHSGD s(0.0005, 1, 2500000, 1e-15, true, update);
 
     arma::mat coordinates = f.GetInitialPoint();


### PR DESCRIPTION
I noticed that the tests took a long time, so I investigated and found that the CNE test can take a really long time.  So, I switched it to optimize simpler functions.  Then, I checked to make sure that the test failure probability was low, and had to tune a couple tests.

But probably the more interesting thing I did here was that I noticed the `BigBatchSGD` test sometimes failed after taking a `NaN` step size.  After some investigation, I traced this down to the estimation of the curvature---when the step size gets really small, there is no noticeable different in the iterates, and so `arma::norm(iterate - lastIterate, 2) == 0`, and the curvature estimate divides by that.

Therefore, the solution I settled on was just to avoid step size decay in this situation by taking the curvature estimate to be 0.  @manish7294 I know you were working with `BigBatchSGD` most recently---let me know what you think of this fix or if something better should be done.