### PR TITLE
Minor compatibility fixes for ensmallen 1.x

### DIFF
--- a/include/ensmallen_bits/function/arma_traits.hpp
+++ b/include/ensmallen_bits/function/arma_traits.hpp
@@ -30,7 +30,7 @@ struct MatTypeTraits<arma::Col<eT>>
 template<typename eT>
 struct MatTypeTraits<arma::Row<eT>>
 {
-  typedef arma::Row<eT> BaseMatType;
+  typedef arma::Mat<eT> BaseMatType;
 };
 
 template<typename eT>

--- a/include/ensmallen_bits/sdp/lrsdp_function.hpp
+++ b/include/ensmallen_bits/sdp/lrsdp_function.hpp
@@ -94,9 +94,10 @@ class LRSDPFunction
 
   //! Get the initial point of the LRSDP.
   template<typename MatType>
-  const MatType& GetInitialPoint() const
+  MatType GetInitialPoint() const
   {
-    return arma::conv_to<MatType>::from(initialPoint);
+    MatType result = arma::conv_to<MatType>::from(initialPoint);
+    return result;
   }
 
   //! Return the SDP object representing the problem.

--- a/include/ensmallen_bits/sdp/lrsdp_function.hpp
+++ b/include/ensmallen_bits/sdp/lrsdp_function.hpp
@@ -93,7 +93,7 @@ class LRSDPFunction
   size_t NumConstraints() const { return sdp.NumConstraints(); }
 
   //! Get the initial point of the LRSDP.
-  template<typename MatType>
+  template<typename MatType = arma::mat>
   MatType GetInitialPoint() const
   {
     MatType result = arma::conv_to<MatType>::from(initialPoint);

--- a/include/ensmallen_bits/sdp/sdp.hpp
+++ b/include/ensmallen_bits/sdp/sdp.hpp
@@ -133,11 +133,11 @@ class SDP
   bool HasLinearlyIndependentConstraints() const;
 
   //! Get an initial point for the primal coordinates.
-  template<typename MatType>
+  template<typename MatType = arma::mat>
   MatType GetInitialPoint() const;
 
   //! Get initial points for the primal and dual coordinates.
-  template<typename MatType>
+  template<typename MatType = arma::mat>
   void GetInitialPoints(MatType& coordinates,
                         MatType& ySparse,
                         MatType& yDense,


### PR DESCRIPTION
These simple fixes make it easier for older code to work with ensmallen 2.x.  There's no functionality change (although `GetInitialPoint()` for `LRSDP` had a bug, and this fixes that).