### PR TITLE
ensure armadillo version check uses the same numbers as CMakeLists.txt

### DIFF
--- a/include/ensmallen.hpp
+++ b/include/ensmallen.hpp
@@ -29,8 +29,8 @@
   #error "please enable C++11/C++14 mode in your compiler"
 #endif
 
-#if ((ARMA_VERSION_MAJOR < 6) || ((ARMA_VERSION_MAJOR == 6) && (ARMA_VERSION_MINOR < 500)))
-  #error "need Armadillo version 6.500 or later"
+#if ((ARMA_VERSION_MAJOR < 8) || ((ARMA_VERSION_MAJOR == 8) && (ARMA_VERSION_MINOR < 400)))
+  #error "need Armadillo version 8.400 or later"
 #endif
 
 #include <cmath>


### PR DESCRIPTION
CMakeLists.txt enforces Armadillo 8.400, so for consistency we need to do that in `include/ensmallen.hpp` as well

https://github.com/mlpack/ensmallen/blob/master/CMakeLists.txt#L55
