### PR TITLE
best practice: set bash option to terminate shell upon expected error

### DIFF
--- a/rel/ensmallen-release.sh
+++ b/rel/ensmallen-release.sh
@@ -6,6 +6,7 @@
 #   $ ensmallen-release.sh <major> <minor> <patch> [<name>]
 #
 # This should be run from the root of the repository.
+set -e
 
 if [ "$#" -lt 3 ]; then
   echo "At least three arguments required!";


### PR DESCRIPTION
When earlier commands fail, it might not be such a great idea to run later git commands which do things like tagging and pushing.