### PR TITLE
Check L-BFGS scaling factor for convergence

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+### ensmallen ?.??.?
+###### ????-??-??
+  * Add additional L-BFGS convergence check
+    ([#136](https://github.com/mlpack/ensmallen/pull/136)).
+
 ### ensmallen 2.10.2: "Fried Chicken"
 ###### 2019-09-11
   * Add release script to rel/ for maintainers

--- a/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
+++ b/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
@@ -409,6 +409,12 @@ L_BFGS::Optimize(FunctionType& function,
 
     // Choose the scaling factor.
     double scalingFactor = ChooseScalingFactor(itNum, gradient, s, y);
+    if (scalingFactor == 0.0)
+    {
+      Info << "L-BFGS scaling factor computed as 0 (terminating successfully)."
+          << std::endl;
+      break;
+    }
 
     // Build an approximation to the Hessian and choose the search
     // direction for the current iteration.


### PR DESCRIPTION
While debugging some mlpack test failures I discovered that it is possible that `scalingFactor` for L-BFGS can be computed as `0.0` when the optimization is getting very close to convergence.  This, then, causes a division by 0 later on in the code, and the returned iterate goes to a bunch of NaN garbage.

So, this change addresses that by catching the case where the scaling factor is computed as 0, and terminates successfully in that case.