### PR TITLE
Add optional test building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 2.8.10)
 project(ensmallen C CXX)
 
 option(USE_OPENMP "If available, use OpenMP for parallelization." ON)
+option(BUILD_TESTS "Build tests." ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
 
@@ -66,4 +67,6 @@ install(FILES ${CMAKE_SOURCE_DIR}/include/ensmallen.hpp
 
 enable_testing()
 
-add_subdirectory(tests)
+if (BUILD_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -36,6 +36,7 @@ Copyright:
   Copyright 2018, Conrad Sanderson
   Copyright 2018, Dan Timson
   Copyright 2019, Rahul Ganesh Prabhu
+  Copyright 2019, Roberto Hueso <robertohueso96@gmail.com>
   
 License: BSD-3-clause
   All rights reserved.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+### ensmallen ?.??.?
+###### ????-??-??
+  * Add optional tests building.
+    ([#141](https://github.com/mlpack/ensmallen/pull/141)).
+
 ### ensmallen 2.10.3: "Fried Chicken"
 ###### 2019-09-26
   * Fix ParallelSGD runtime bug.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ the library.
 * Conrad Sanderson
 * Dan Timson
 * N Rajiv Vaidyanathan
+* Roberto Hueso


### PR DESCRIPTION
According to `CMakeLists.txt`

> This project has no configurable options---it just installs the headers to the install location, and optionally builds the test program.

but it's not optional at the moment. This PR adds the option in CMake :smile:.