### PR TITLE
32-bit safety in big random number

### DIFF
--- a/tests/callbacks_test.cpp
+++ b/tests/callbacks_test.cpp
@@ -394,7 +394,7 @@ TEST_CASE("EarlyStopAtMinLossCallbackTest", "[CallbacksTest]")
 
   // Instantiate the optimizer with a number of iterations that will take a
   // long time to finish.
-  StandardSGD s(0.0003, 1, 10000000000, -10);
+  StandardSGD s(0.0003, 1, 2000000000, -10);
   s.ExactObjective() = true;
 
   // The optimization process should return in one second.
@@ -470,7 +470,7 @@ TEST_CASE("TimerStopCallbackTest", "[CallbacksTest]")
 
   // Instantiate the optimizer with a number of iterations that will take a
   // long time to finish.
-  StandardSGD s(0.0003, 1, 10000000000, -100, true);
+  StandardSGD s(0.0003, 1, 2000000000, -100, true);
 
   arma::wall_clock timer;
   timer.tic();


### PR DESCRIPTION
This patch fixes a compile-time warning and test case failure on
32-bit architectures, including i386.

    cd /<<PKGBUILDDIR>>/obj-i686-linux-gnu/tests && /usr/bin/c++   -I/<<PKGBUILDDIR>>/include  -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fopenmp -Wall -Wpedantic -Wunused-parameter   -std=gnu++11 -o CMakeFiles/ensmallen_tests.dir/cmaes_test.cpp.o -c /<<PKGBUILDDIR>>/tests/cmaes_test.cpp
    /<<PKGBUILDDIR>>/tests/callbacks_test.cpp: In function ‘void ____C_A_T_C_H____T_E_S_T____46()’:
    /<<PKGBUILDDIR>>/tests/callbacks_test.cpp:397:28: warning: unsigned conversion from ‘long long int’ to ‘size_t’ {aka ‘unsigned int’} changes value from ‘10000000000’ to ‘1410065408’ [-Woverflow]
      397 |   StandardSGD s(0.0003, 1, 10000000000, -10);
	  |                            ^~~~~~~~~~~
    /<<PKGBUILDDIR>>/tests/callbacks_test.cpp: In function ‘void ____C_A_T_C_H____T_E_S_T____54()’:
    /<<PKGBUILDDIR>>/tests/callbacks_test.cpp:473:28: warning: unsigned conversion from ‘long long int’ to ‘size_t’ {aka ‘unsigned int’} changes value from ‘10000000000’ to ‘1410065408’ [-Woverflow]
      473 |   StandardSGD s(0.0003, 1, 10000000000, -100, true);
	  |                            ^~~~~~~~~~~

    ...

    Test project /<<PKGBUILDDIR>>/obj-i686-linux-gnu
	Start 1: ensmallen_tests
    1/1 Test #1: ensmallen_tests ..................***Failed  5163.40 sec

The SGD maxIterations parameter to the SGD routine is stored in a
size_t. Arguably inappropriate; it belongs in something guaranteed to
be at least 64 bits, perhaps long long int.

Be that as it may, a test routine was passing a number meant to be so
large it would not be exceeded, to test a mechanism that should
terminate the optimization early. The large number chosen was
10000000000, ten billion, which exceeds the maximum value of an
unsigned 32-bit integer of 4 billion plus change.

This patch changes the maxIterations parameter passed to two billion,
2000000000, which is both sufficiently large for the purposes here and
safely below the maximum value for a 32-bit signed integer.