### PR TITLE
Update static check terms to match documentation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
   * SGD callback test 32-bit safety (big number).
     ([#143](https://github.com/mlpack/ensmallen/pull/143)).
 
+  * Use "arbitrary" and "separable" terms in static function type checks
+    ([#145](https://github.com/mlpack/ensmallen/pull/145)).
+
 ### ensmallen 2.10.4: "Fried Chicken"
 ###### 2019-11-18
   * Add optional tests building.

--- a/include/ensmallen_bits/ada_delta/ada_delta.hpp
+++ b/include/ensmallen_bits/ada_delta/ada_delta.hpp
@@ -82,10 +82,10 @@ class AdaDelta
   /**
    * Optimize the given function using AdaDelta. The given starting point will
    * be modified to store the finishing point of the algorithm, and the final
-   * objective value is returned. The DecomposableFunctionType is checked for
+   * objective value is returned. The SeparableFunctionType is checked for
    * API consistency at compile time.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -94,29 +94,29 @@ class AdaDelta
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
-    return optimizer.Optimize<DecomposableFunctionType, MatType, GradType,
+    return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
         CallbackTypes...>(function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/ada_grad/ada_grad.hpp
+++ b/include/ensmallen_bits/ada_grad/ada_grad.hpp
@@ -81,7 +81,7 @@ class AdaGrad
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -90,29 +90,29 @@ class AdaGrad
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
-    return optimizer.Optimize<DecomposableFunctionType, MatType, GradType,
+    return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
         CallbackTypes...>(function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/adam/adam.hpp
+++ b/include/ensmallen_bits/adam/adam.hpp
@@ -107,7 +107,7 @@ class AdamType
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -116,30 +116,30 @@ class AdamType
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
     return optimizer.template Optimize<
-        DecomposableFunctionType, MatType, GradType, CallbackTypes...>(
+        SeparableFunctionType, MatType, GradType, CallbackTypes...>(
         function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/bigbatch_sgd/adaptive_stepsize.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/adaptive_stepsize.hpp
@@ -75,7 +75,7 @@ class AdaptiveStepsize
     /**
      * This function is called in each iteration.
      *
-     * @tparam DecomposableFunctionType Type of the function to be optimized.
+     * @tparam SeparableFunctionType Type of the function to be optimized.
      * @param function Function to be optimized (minimized).
      * @param stepSize Step size to be used for the given iteration.
      * @param iterate Parameters that minimize the function.
@@ -87,9 +87,9 @@ class AdaptiveStepsize
      *        given iteration.
      * @param reset Reset the step size decay parameter.
      */
-    template<typename DecomposableFunctionType,
+    template<typename SeparableFunctionType,
              typename GradType>
-    void Update(DecomposableFunctionType& function,
+    void Update(SeparableFunctionType& function,
                 double& stepSize,
                 MatType& iterate,
                 GradType& gradient,
@@ -186,7 +186,7 @@ class AdaptiveStepsize
      * Armijo–Goldstein condition to determine the maximum amount to move along
      * the given search direction.
      *
-     * @tparam DecomposableFunctionType Type of the function to be optimized.
+     * @tparam SeparableFunctionType Type of the function to be optimized.
      * @param function Function to be optimized (minimized).
      * @param stepSize Step size to be used for the given iteration.
      * @param iterate Parameters that minimize the function.
@@ -195,9 +195,9 @@ class AdaptiveStepsize
      * @param offset The batch offset to be used for the given iteration.
      * @param backtrackingBatchSize The backtracking batch size.
      */
-    template<typename DecomposableFunctionType,
+    template<typename SeparableFunctionType,
              typename GradType>
-    void Backtracking(DecomposableFunctionType& function,
+    void Backtracking(SeparableFunctionType& function,
                       double& stepSize,
                       const MatType& iterate,
                       const GradType& gradient,

--- a/include/ensmallen_bits/bigbatch_sgd/backtracking_line_search.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/backtracking_line_search.hpp
@@ -66,7 +66,7 @@ class BacktrackingLineSearch
     /**
      * This function is called in each iteration.
      *
-     * @tparam DecomposableFunctionType Type of the function to be optimized.
+     * @tparam SeparableFunctionType Type of the function to be optimized.
      * @param function Function to be optimized (minimized).
      * @param stepSize Step size to be used for the given iteration.
      * @param iterate Parameters that minimize the function.
@@ -78,9 +78,9 @@ class BacktrackingLineSearch
      *        given iteration.
      * @param reset Reset the step size decay parameter.
      */
-    template<typename DecomposableFunctionType,
+    template<typename SeparableFunctionType,
              typename GradType>
-    void Update(DecomposableFunctionType& function,
+    void Update(SeparableFunctionType& function,
                 double& stepSize,
                 MatType& iterate,
                 GradType& gradient,

--- a/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd.hpp
@@ -106,7 +106,7 @@ class BigBatchSGD
    * will be modified to store the finishing point of the algorithm, and the
    * final objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -115,25 +115,25 @@ class BigBatchSGD
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
@@ -40,14 +40,14 @@ BigBatchSGD<UpdatePolicyType>::BigBatchSGD(
 
 //! Optimize the function (minimize).
 template<typename UpdatePolicyType>
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
 BigBatchSGD<UpdatePolicyType>::Optimize(
-    DecomposableFunctionType& function,
+    SeparableFunctionType& function,
     MatType& iterateIn,
     CallbackTypes&&... callbacks)
 {
@@ -56,12 +56,12 @@ BigBatchSGD<UpdatePolicyType>::Optimize(
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
   typedef typename MatTypeTraits<GradType>::BaseMatType BaseGradType;
 
-  typedef Function<DecomposableFunctionType, BaseMatType, BaseGradType>
+  typedef Function<SeparableFunctionType, BaseMatType, BaseGradType>
       FullFunctionType;
   FullFunctionType& f(static_cast<FullFunctionType&>(function));
 
   // Make sure we have all the methods that we need.
-  traits::CheckDecomposableFunctionTypeAPI<FullFunctionType, BaseMatType,
+  traits::CheckSeparableFunctionTypeAPI<FullFunctionType, BaseMatType,
       BaseGradType>();
   RequireFloatingPointType<BaseMatType>();
   RequireFloatingPointType<BaseGradType>();

--- a/include/ensmallen_bits/cmaes/cmaes.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes.hpp
@@ -82,7 +82,7 @@ class CMAES
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize.
    * @tparam CallbackTypes Types of callback functions.
    * @param function Function to optimize.
@@ -90,10 +90,10 @@ class CMAES
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks);
 

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -41,11 +41,11 @@ CMAES<SelectionPolicyType>::CMAES(const size_t lambda,
 
 //! Optimize the function (minimize).
 template<typename SelectionPolicyType>
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename... CallbackTypes>
 typename MatType::elem_type CMAES<SelectionPolicyType>::Optimize(
-    DecomposableFunctionType& function,
+    SeparableFunctionType& function,
     MatType& iterateIn,
     CallbackTypes&&... callbacks)
 {
@@ -54,8 +54,8 @@ typename MatType::elem_type CMAES<SelectionPolicyType>::Optimize(
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
 
   // Make sure that we have the methods that we need.  Long name...
-  traits::CheckNonDifferentiableDecomposableFunctionTypeAPI<
-      DecomposableFunctionType, BaseMatType>();
+  traits::CheckArbitrarySeparableFunctionTypeAPI<
+      SeparableFunctionType, BaseMatType>();
   RequireDenseFloatingPointType<BaseMatType>();
 
   BaseMatType& iterate = (BaseMatType&) iterateIn;

--- a/include/ensmallen_bits/cmaes/full_selection.hpp
+++ b/include/ensmallen_bits/cmaes/full_selection.hpp
@@ -23,15 +23,15 @@ class FullSelection
   /**
    * Select the full dataset to calculate the objective function.
    *
-   * @tparam DecomposableFunctionType Type of the function to be evaluated.
+   * @tparam SeparableFunctionType Type of the function to be evaluated.
    * @param function Function to optimize.
    * @param batchSize Batch size to use for each step.
    * @param iterate starting point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  double Select(DecomposableFunctionType& function,
+  double Select(SeparableFunctionType& function,
                 const size_t batchSize,
                 const MatType& iterate,
                 CallbackTypes&... callbacks)

--- a/include/ensmallen_bits/cmaes/random_selection.hpp
+++ b/include/ensmallen_bits/cmaes/random_selection.hpp
@@ -38,15 +38,15 @@ class RandomSelection
   /**
    * Randomly select dataset points to calculate the objective function.
    *
-   * @tparam DecomposableFunctionType Type of the function to be evaluated.
+   * @tparam SeparableFunctionType Type of the function to be evaluated.
    * @param function Function to optimize.
    * @param batchSize Batch size to use for each step.
    * @param iterate starting point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  double Select(DecomposableFunctionType& function,
+  double Select(SeparableFunctionType& function,
                 const size_t batchSize,
                 const MatType& iterate,
                 CallbackTypes&... callbacks)

--- a/include/ensmallen_bits/cne/cne_impl.hpp
+++ b/include/ensmallen_bits/cne/cne_impl.hpp
@@ -49,7 +49,7 @@ typename MatType::elem_type CNE::Optimize(ArbitraryFunctionType& function,
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
 
   // Make sure that we have the methods that we need.  Long name...
-  traits::CheckNonDifferentiableFunctionTypeAPI<ArbitraryFunctionType,
+  traits::CheckArbitraryFunctionTypeAPI<ArbitraryFunctionType,
       BaseMatType>();
   RequireDenseFloatingPointType<BaseMatType>();
 

--- a/include/ensmallen_bits/de/de.hpp
+++ b/include/ensmallen_bits/de/de.hpp
@@ -83,7 +83,7 @@ class DE
    * starting point will be modified to store the finishing point of the
    * algorithm, and the final objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam FunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize.
    * @tparam CallbackTypes Types of callback functions.
    * @param function Function to optimize.
@@ -91,10 +91,10 @@ class DE
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename FunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(FunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks);
 

--- a/include/ensmallen_bits/de/de_impl.hpp
+++ b/include/ensmallen_bits/de/de_impl.hpp
@@ -30,10 +30,10 @@ inline DE::DE(const size_t populationSize ,
 { /* Nothing to do here. */ }
 
 //!Optimize the function
-template<typename DecomposableFunctionType,
+template<typename FunctionType,
          typename MatType,
          typename... CallbackTypes>
-typename MatType::elem_type DE::Optimize(DecomposableFunctionType& function,
+typename MatType::elem_type DE::Optimize(FunctionType& function,
                                          MatType& iterateIn,
                                          CallbackTypes&&... callbacks)
 {
@@ -50,8 +50,8 @@ typename MatType::elem_type DE::Optimize(DecomposableFunctionType& function,
   arma::Col<ElemType> fitnessValues;
 
   // Make sure that we have the methods that we need.  Long name...
-  traits::CheckNonDifferentiableDecomposableFunctionTypeAPI<
-      DecomposableFunctionType, BaseMatType>();
+  traits::CheckArbitraryFunctionTypeAPI<
+      FunctionType, BaseMatType>();
   RequireDenseFloatingPointType<BaseMatType>();
 
   // Population Size must be at least 3 for DE to work.

--- a/include/ensmallen_bits/eve/eve.hpp
+++ b/include/ensmallen_bits/eve/eve.hpp
@@ -32,7 +32,7 @@ namespace ens {
  *   url     = {http://arxiv.org/abs/1611.01505}
  * }
  *
- * For Eve to work, a DecomposableFunctionType template parameter is required.
+ * For Eve to work, a SeparableFunctionType template parameter is required.
  * This class must implement the following function:
  *
  *   size_t NumFunctions();
@@ -92,7 +92,7 @@ class Eve
    * starting point will be modified to store the finishing point of the
    * algorithm, and the final objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of the parameters matrix.
    * @tparam GradType Type of the gradient matrix.
    * @tparam CallbackTypes Types of callback functions.
@@ -101,25 +101,25 @@ class Eve
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/eve/eve_impl.hpp
+++ b/include/ensmallen_bits/eve/eve_impl.hpp
@@ -45,13 +45,13 @@ inline Eve::Eve(const double stepSize,
 { /* Nothing to do. */ }
 
 //! Optimize the function (minimize).
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
-Eve::Optimize(DecomposableFunctionType& function,
+Eve::Optimize(SeparableFunctionType& function,
               MatType& iterateIn,
               CallbackTypes&&... callbacks)
 {
@@ -60,12 +60,12 @@ Eve::Optimize(DecomposableFunctionType& function,
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
   typedef typename MatTypeTraits<GradType>::BaseMatType BaseGradType;
 
-  typedef Function<DecomposableFunctionType, BaseMatType, BaseGradType>
+  typedef Function<SeparableFunctionType, BaseMatType, BaseGradType>
       FullFunctionType;
   FullFunctionType& f(static_cast<FullFunctionType&>(function));
 
   // Make sure we have all the methods that we need.
-  traits::CheckDecomposableFunctionTypeAPI<FullFunctionType, BaseMatType,
+  traits::CheckSeparableFunctionTypeAPI<FullFunctionType, BaseMatType,
       BaseGradType>();
   RequireFloatingPointType<BaseMatType>();
   RequireFloatingPointType<BaseGradType>();

--- a/include/ensmallen_bits/ftml/ftml.hpp
+++ b/include/ensmallen_bits/ftml/ftml.hpp
@@ -85,7 +85,7 @@ class FTML
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -94,29 +94,29 @@ class FTML
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
-    return optimizer.Optimize<DecomposableFunctionType, MatType, GradType,
+    return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
         CallbackTypes...>(function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/function.hpp
+++ b/include/ensmallen_bits/function.hpp
@@ -25,9 +25,9 @@ class Function;
 #include "function/add_evaluate.hpp"
 #include "function/add_gradient.hpp"
 #include "function/add_evaluate_with_gradient.hpp"
-#include "function/add_decomposable_evaluate.hpp"
-#include "function/add_decomposable_gradient.hpp"
-#include "function/add_decomposable_evaluate_with_gradient.hpp"
+#include "function/add_separable_evaluate.hpp"
+#include "function/add_separable_gradient.hpp"
+#include "function/add_separable_evaluate_with_gradient.hpp"
 
 namespace ens {
 
@@ -56,17 +56,17 @@ namespace ens {
  */
 template<typename FunctionType, typename MatType, typename GradType>
 class Function :
-    public AddDecomposableEvaluateWithGradientStatic<FunctionType, MatType,
+    public AddSeparableEvaluateWithGradientStatic<FunctionType, MatType,
         GradType>,
-    public AddDecomposableEvaluateWithGradientConst<FunctionType, MatType,
+    public AddSeparableEvaluateWithGradientConst<FunctionType, MatType,
         GradType>,
-    public AddDecomposableEvaluateWithGradient<FunctionType, MatType, GradType>,
-    public AddDecomposableGradientStatic<FunctionType, MatType, GradType>,
-    public AddDecomposableGradientConst<FunctionType, MatType, GradType>,
-    public AddDecomposableGradient<FunctionType, MatType, GradType>,
-    public AddDecomposableEvaluateStatic<FunctionType, MatType, GradType>,
-    public AddDecomposableEvaluateConst<FunctionType, MatType, GradType>,
-    public AddDecomposableEvaluate<FunctionType, MatType, GradType>,
+    public AddSeparableEvaluateWithGradient<FunctionType, MatType, GradType>,
+    public AddSeparableGradientStatic<FunctionType, MatType, GradType>,
+    public AddSeparableGradientConst<FunctionType, MatType, GradType>,
+    public AddSeparableGradient<FunctionType, MatType, GradType>,
+    public AddSeparableEvaluateStatic<FunctionType, MatType, GradType>,
+    public AddSeparableEvaluateConst<FunctionType, MatType, GradType>,
+    public AddSeparableEvaluate<FunctionType, MatType, GradType>,
     public AddEvaluateWithGradientStatic<FunctionType, MatType, GradType>,
     public AddEvaluateWithGradientConst<FunctionType, MatType, GradType>,
     public AddEvaluateWithGradient<FunctionType, MatType, GradType>,
@@ -83,20 +83,20 @@ class Function :
   // an unconstructable overload with the same name, so we can use using
   // declarations here to ensure that they are all accessible.  Since we don't
   // know what FunctionType has, we can't use any using declarations there.
-  using AddDecomposableEvaluateWithGradientStatic<
+  using AddSeparableEvaluateWithGradientStatic<
       FunctionType, MatType, GradType>::EvaluateWithGradient;
-  using AddDecomposableEvaluateWithGradientConst<
+  using AddSeparableEvaluateWithGradientConst<
       FunctionType, MatType, GradType>::EvaluateWithGradient;
-  using AddDecomposableEvaluateWithGradient<
+  using AddSeparableEvaluateWithGradient<
       FunctionType, MatType, GradType>::EvaluateWithGradient;
-  using AddDecomposableGradientStatic<
+  using AddSeparableGradientStatic<
       FunctionType, MatType, GradType>::Gradient;
-  using AddDecomposableGradientConst<FunctionType, MatType, GradType>::Gradient;
-  using AddDecomposableGradient<FunctionType, MatType, GradType>::Gradient;
-  using AddDecomposableEvaluateStatic<
+  using AddSeparableGradientConst<FunctionType, MatType, GradType>::Gradient;
+  using AddSeparableGradient<FunctionType, MatType, GradType>::Gradient;
+  using AddSeparableEvaluateStatic<
       FunctionType, MatType, GradType>::Evaluate;
-  using AddDecomposableEvaluateConst<FunctionType, MatType, GradType>::Evaluate;
-  using AddDecomposableEvaluate<FunctionType, MatType, GradType>::Evaluate;
+  using AddSeparableEvaluateConst<FunctionType, MatType, GradType>::Evaluate;
+  using AddSeparableEvaluate<FunctionType, MatType, GradType>::Evaluate;
   using AddEvaluateWithGradientStatic<FunctionType, MatType, GradType>::EvaluateWithGradient;
   using AddEvaluateWithGradientConst<FunctionType, MatType, GradType>::EvaluateWithGradient;
   using AddEvaluateWithGradient<FunctionType, MatType, GradType>::EvaluateWithGradient;

--- a/include/ensmallen_bits/function/add_separable_evaluate.hpp
+++ b/include/ensmallen_bits/function/add_separable_evaluate.hpp
@@ -1,8 +1,8 @@
 /**
- * @file add_decomposable_evaluate.hpp
+ * @file add_separable_evaluate.hpp
  * @author Ryan Curtin
  *
- * Adds a decomposable Evaluate() function if a decomposable
+ * Adds a separable Evaluate() function if a separable
  * EvaluateWithGradient() function exists.
  *
  * ensmallen is free software; you may redistribute it and/or modify it under
@@ -18,23 +18,23 @@
 namespace ens {
 
 /**
- * The AddDecomposableEvaluate mixin class will add a decomposable Evaluate()
- * method if a decomposable EvaluateWithGradient() function exists, or nothing
+ * The AddSeparableEvaluate mixin class will add a separable Evaluate()
+ * method if a separable EvaluateWithGradient() function exists, or nothing
  * otherwise.
  */
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient =
+         bool HasSeparableEvaluateWithGradient =
              traits::HasEvaluateWithGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateWithGradientForm
+                     SeparableEvaluateWithGradientForm
              >::value,
-         bool HasDecomposableEvaluate =
+         bool HasSeparableEvaluate =
              traits::HasEvaluate<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                      DecomposableEvaluateForm>::value>
-class AddDecomposableEvaluate
+                      SeparableEvaluateForm>::value>
+class AddSeparableEvaluate
 {
  public:
   // Provide a dummy overload so the name 'Evaluate' exists for this object.
@@ -49,9 +49,9 @@ class AddDecomposableEvaluate
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient>
-class AddDecomposableEvaluate<FunctionType, MatType, GradType,
-    HasDecomposableEvaluateWithGradient, true>
+         bool HasSeparableEvaluateWithGradient>
+class AddSeparableEvaluate<FunctionType, MatType, GradType,
+    HasSeparableEvaluateWithGradient, true>
 {
  public:
   // Reflect the existing Evaluate().
@@ -69,16 +69,16 @@ class AddDecomposableEvaluate<FunctionType, MatType, GradType,
 };
 
 /**
- * If we have a decomposable EvaluateWithGradient() but not a decomposable
- * Evaluate(), add a decomposable Evaluate() method.
+ * If we have a separable EvaluateWithGradient() but not a separable
+ * Evaluate(), add a separable Evaluate() method.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-class AddDecomposableEvaluate<FunctionType, MatType, GradType, true, false>
+class AddSeparableEvaluate<FunctionType, MatType, GradType, true, false>
 {
  public:
   /**
    * Return the objective function for the given coordinates, starting at the
-   * given decomposable function using the given batch size.
+   * given separable function using the given batch size.
    *
    * @param coordinates Coordinates to evaluate the function at.
    * @param begin Index of first function to evaluate.
@@ -97,22 +97,22 @@ class AddDecomposableEvaluate<FunctionType, MatType, GradType, true, false>
 };
 
 /**
- * The AddDecomposableEvaluateConst mixin class will add a decomposable const
- * Evaluate() method if a decomposable const EvaluateWithGradient() function
+ * The AddSeparableEvaluateConst mixin class will add a separable const
+ * Evaluate() method if a separable const EvaluateWithGradient() function
  * exists, or nothing otherwise.
  */
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient =
+         bool HasSeparableEvaluateWithGradient =
              traits::HasEvaluateWithGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateWithGradientConstForm>::value,
-         bool HasDecomposableEvaluate =
+                     SeparableEvaluateWithGradientConstForm>::value,
+         bool HasSeparableEvaluate =
              traits::HasEvaluate<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateConstForm>::value>
-class AddDecomposableEvaluateConst
+                     SeparableEvaluateConstForm>::value>
+class AddSeparableEvaluateConst
 {
  public:
   // Provide a dummy overload so the name 'Evaluate' exists for this object.
@@ -127,9 +127,9 @@ class AddDecomposableEvaluateConst
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient>
-class AddDecomposableEvaluateConst<FunctionType, MatType, GradType,
-    HasDecomposableEvaluateWithGradient, true>
+         bool HasSeparableEvaluateWithGradient>
+class AddSeparableEvaluateConst<FunctionType, MatType, GradType,
+    HasSeparableEvaluateWithGradient, true>
 {
  public:
   // Reflect the existing Evaluate().
@@ -147,16 +147,16 @@ class AddDecomposableEvaluateConst<FunctionType, MatType, GradType,
 };
 
 /**
- * If we have a decomposable const EvaluateWithGradient() but not a decomposable
- * const Evaluate(), add a decomposable const Evaluate() method.
+ * If we have a separable const EvaluateWithGradient() but not a separable
+ * const Evaluate(), add a separable const Evaluate() method.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-class AddDecomposableEvaluateConst<FunctionType, MatType, GradType, true, false>
+class AddSeparableEvaluateConst<FunctionType, MatType, GradType, true, false>
 {
  public:
   /**
    * Return the objective function for the given coordinates, starting at the
-   * given decomposable function using the given batch size.
+   * given separable function using the given batch size.
    *
    * @param coordinates Coordinates to evaluate the function at.
    * @param begin Index of first function to evaluate.
@@ -175,22 +175,22 @@ class AddDecomposableEvaluateConst<FunctionType, MatType, GradType, true, false>
 };
 
 /**
- * The AddDecomposableEvaluateStatic mixin class will add a decomposable static
- * Evaluate() method if a decomposable static EvaluateWithGradient() function
+ * The AddSeparableEvaluateStatic mixin class will add a separable static
+ * Evaluate() method if a separable static EvaluateWithGradient() function
  * exists, or nothing otherwise.
  */
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient =
+         bool HasSeparableEvaluateWithGradient =
              traits::HasEvaluateWithGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateWithGradientStaticForm>::value,
-         bool HasDecomposableEvaluate =
+                     SeparableEvaluateWithGradientStaticForm>::value,
+         bool HasSeparableEvaluate =
              traits::HasEvaluate<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateStaticForm>::value>
-class AddDecomposableEvaluateStatic
+                     SeparableEvaluateStaticForm>::value>
+class AddSeparableEvaluateStatic
 {
  public:
   // Provide a dummy overload so the name 'Evaluate' exists for this object.
@@ -205,9 +205,9 @@ class AddDecomposableEvaluateStatic
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient>
-class AddDecomposableEvaluateStatic<FunctionType, MatType, GradType,
-    HasDecomposableEvaluateWithGradient, true>
+         bool HasSeparableEvaluateWithGradient>
+class AddSeparableEvaluateStatic<FunctionType, MatType, GradType,
+    HasSeparableEvaluateWithGradient, true>
 {
  public:
   // Reflect the existing Evaluate().
@@ -220,17 +220,17 @@ class AddDecomposableEvaluateStatic<FunctionType, MatType, GradType,
 };
 
 /**
- * If we have a decomposable EvaluateWithGradient() but not a decomposable
- * Evaluate(), add a decomposable Evaluate() method.
+ * If we have a separable EvaluateWithGradient() but not a separable
+ * Evaluate(), add a separable Evaluate() method.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-class AddDecomposableEvaluateStatic<FunctionType, MatType, GradType, true,
+class AddSeparableEvaluateStatic<FunctionType, MatType, GradType, true,
     false>
 {
  public:
   /**
    * Return the objective function for the given coordinates, starting at the
-   * given decomposable function using the given batch size.
+   * given separable function using the given batch size.
    *
    * @param coordinates Coordinates to evaluate the function at.
    * @param begin Index of first function to evaluate.

--- a/include/ensmallen_bits/function/add_separable_evaluate_with_gradient.hpp
+++ b/include/ensmallen_bits/function/add_separable_evaluate_with_gradient.hpp
@@ -1,9 +1,9 @@
 /**
- * @file add_decomposable_evaluate_with_gradient.hpp
+ * @file add_separable_evaluate_with_gradient.hpp
  * @author Ryan Curtin
  *
- * Adds a decomposable EvaluateWithGradient() function if both a decomposable
- * Evaluate() and a decomposable Gradient() function exist.
+ * Adds a separable EvaluateWithGradient() function if both a separable
+ * Evaluate() and a separable Gradient() function exist.
  *
  * ensmallen is free software; you may redistribute it and/or modify it under
  * the terms of the 3-clause BSD license.  You should have received a copy of
@@ -18,35 +18,35 @@
 namespace ens {
 
 /**
- * The AddDecomposableEvaluateWithGradient mixin class will add a decomposable
- * EvaluateWithGradient() method if a decomposable Evaluate() method and a
- * decomposable Gradient() method exists, or nothing otherwise.
+ * The AddSeparableEvaluateWithGradient mixin class will add a separable
+ * EvaluateWithGradient() method if a separable Evaluate() method and a
+ * separable Gradient() method exists, or nothing otherwise.
  */
 template<typename FunctionType,
          typename MatType,
          typename GradType,
          // Check if there is at least one non-const Evaluate() or Gradient().
-         bool HasDecomposableEvaluateGradient = traits::HasNonConstSignatures<
+         bool HasSeparableEvaluateGradient = traits::HasNonConstSignatures<
              FunctionType,
              traits::HasEvaluate,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableEvaluateForm,
+                 SeparableEvaluateForm,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableEvaluateConstForm,
+                 SeparableEvaluateConstForm,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableEvaluateStaticForm,
+                 SeparableEvaluateStaticForm,
              traits::HasGradient,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableGradientForm,
+                 SeparableGradientForm,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableGradientConstForm,
+                 SeparableGradientConstForm,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableGradientStaticForm>::value,
-         bool HasDecomposableEvaluateWithGradient =
+                 SeparableGradientStaticForm>::value,
+         bool HasSeparableEvaluateWithGradient =
              traits::HasEvaluateWithGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateWithGradientForm>::value>
-class AddDecomposableEvaluateWithGradient
+                     SeparableEvaluateWithGradientForm>::value>
+class AddSeparableEvaluateWithGradient
 {
  public:
   // Provide a dummy overload so the name 'EvaluateWithGradient' exists for this
@@ -63,9 +63,9 @@ class AddDecomposableEvaluateWithGradient
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateGradient>
-class AddDecomposableEvaluateWithGradient<FunctionType, MatType, GradType,
-    HasDecomposableEvaluateGradient, true>
+         bool HasSeparableEvaluateGradient>
+class AddSeparableEvaluateWithGradient<FunctionType, MatType, GradType,
+    HasSeparableEvaluateGradient, true>
 {
  public:
   // Reflect the existing EvaluateWithGradient().
@@ -83,24 +83,24 @@ class AddDecomposableEvaluateWithGradient<FunctionType, MatType, GradType,
 };
 
 /**
- * If we have a both decomposable Evaluate() and a decomposable Gradient() but
- * not a decomposable EvaluateWithGradient(), add a decomposable
+ * If we have a both separable Evaluate() and a separable Gradient() but
+ * not a separable EvaluateWithGradient(), add a separable
  * EvaluateWithGradient() method.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-class AddDecomposableEvaluateWithGradient<FunctionType, MatType, GradType, true,
+class AddSeparableEvaluateWithGradient<FunctionType, MatType, GradType, true,
     false>
 {
  public:
   /**
    * Return both the evaluated objective function and its gradient, storing the
-   * gradient in the given matrix, starting at the given decomposable function
+   * gradient in the given matrix, starting at the given separable function
    * and using the given batch size.
    *
    * @param coordinates Coordinates to evaluate the function at.
-   * @param begin Index of decomposable function to begin with.
+   * @param begin Index of separable function to begin with.
    * @param gradient Matrix to store the gradient into.
-   * @param batchSize Number of decomposable functions to evaluate.
+   * @param batchSize Number of separable functions to evaluate.
    */
   typename MatType::elem_type EvaluateWithGradient(const MatType& coordinates,
                                                    const size_t begin,
@@ -117,32 +117,32 @@ class AddDecomposableEvaluateWithGradient<FunctionType, MatType, GradType, true,
 };
 
 /**
- * The AddDecomposableEvaluateWithGradientConst mixin class will add a
- * decomposable const EvaluateWithGradient() method if both a decomposable const
- * Evaluate() and a decomposable const Gradient() function exist, or nothing
+ * The AddSeparableEvaluateWithGradientConst mixin class will add a
+ * separable const EvaluateWithGradient() method if both a separable const
+ * Evaluate() and a separable const Gradient() function exist, or nothing
  * otherwise.
  */
 template<typename FunctionType,
          typename MatType,
          typename GradType,
          // Check if there is at least one const Evaluate() or Gradient().
-         bool HasDecomposableEvaluateGradient = traits::HasConstSignatures<
+         bool HasSeparableEvaluateGradient = traits::HasConstSignatures<
              FunctionType,
              traits::HasEvaluate,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableEvaluateConstForm,
+                 SeparableEvaluateConstForm,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableEvaluateStaticForm,
+                 SeparableEvaluateStaticForm,
              traits::HasGradient,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableGradientConstForm,
+                 SeparableGradientConstForm,
              traits::TypedForms<MatType, GradType>::template
-                 DecomposableGradientStaticForm>::value,
-         bool HasDecomposableEvaluateWithGradient =
+                 SeparableGradientStaticForm>::value,
+         bool HasSeparableEvaluateWithGradient =
              traits::HasEvaluateWithGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateWithGradientConstForm>::value>
-class AddDecomposableEvaluateWithGradientConst
+                     SeparableEvaluateWithGradientConstForm>::value>
+class AddSeparableEvaluateWithGradientConst
 {
  public:
   // Provide a dummy overload so the name 'EvaluateWithGradient' exists for this
@@ -159,9 +159,9 @@ class AddDecomposableEvaluateWithGradientConst
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateGradient>
-class AddDecomposableEvaluateWithGradientConst<FunctionType, MatType, GradType,
-    HasDecomposableEvaluateGradient, true>
+         bool HasSeparableEvaluateGradient>
+class AddSeparableEvaluateWithGradientConst<FunctionType, MatType, GradType,
+    HasSeparableEvaluateGradient, true>
 {
  public:
   // Reflect the existing Evaluate().
@@ -179,24 +179,24 @@ class AddDecomposableEvaluateWithGradientConst<FunctionType, MatType, GradType,
 };
 
 /**
- * If we have both a decomposable const Evaluate() and a decomposable const
- * Gradient() but not a decomposable const EvaluateWithGradient(), add a
- * decomposable const EvaluateWithGradient() method.
+ * If we have both a separable const Evaluate() and a separable const
+ * Gradient() but not a separable const EvaluateWithGradient(), add a
+ * separable const EvaluateWithGradient() method.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-class AddDecomposableEvaluateWithGradientConst<FunctionType, MatType, GradType,
+class AddSeparableEvaluateWithGradientConst<FunctionType, MatType, GradType,
     true, false>
 {
  public:
   /**
    * Return both the evaluated objective function and its gradient, storing the
-   * gradient in the given matrix, starting at the given decomposable function
+   * gradient in the given matrix, starting at the given separable function
    * and using the given batch size.
    *
    * @param coordinates Coordinates to evaluate the function at.
-   * @param begin Index of decomposable function to begin with.
+   * @param begin Index of separable function to begin with.
    * @param gradient Matrix to store the gradient into.
-   * @param batchSize Number of decomposable functions to evaluate.
+   * @param batchSize Number of separable functions to evaluate.
    */
   typename MatType::elem_type EvaluateWithGradient(const MatType& coordinates,
                                                    const size_t begin,
@@ -217,26 +217,26 @@ class AddDecomposableEvaluateWithGradientConst<FunctionType, MatType, GradType,
 };
 
 /**
- * The AddDecomposableEvaluateWithGradientStatic mixin class will add a
- * decomposable static EvaluateWithGradient() method if both a decomposable
- * static Evaluate() and a decomposable static gradient() function exist, or
+ * The AddSeparableEvaluateWithGradientStatic mixin class will add a
+ * separable static EvaluateWithGradient() method if both a separable
+ * static Evaluate() and a separable static gradient() function exist, or
  * nothing otherwise.
  */
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateGradient =
+         bool HasSeparableEvaluateGradient =
              traits::HasEvaluate<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateStaticForm>::value &&
+                     SeparableEvaluateStaticForm>::value &&
              traits::HasGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableGradientStaticForm>::value,
-         bool HasDecomposableEvaluateWithGradient =
+                     SeparableGradientStaticForm>::value,
+         bool HasSeparableEvaluateWithGradient =
              traits::HasEvaluateWithGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateWithGradientStaticForm>::value>
-class AddDecomposableEvaluateWithGradientStatic
+                     SeparableEvaluateWithGradientStaticForm>::value>
+class AddSeparableEvaluateWithGradientStatic
 {
  public:
   // Provide a dummy overload so the name 'EvaluateWithGradient' exists for this
@@ -253,9 +253,9 @@ class AddDecomposableEvaluateWithGradientStatic
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateGradient>
-class AddDecomposableEvaluateWithGradientStatic<FunctionType, MatType, GradType,
-    HasDecomposableEvaluateGradient, true>
+         bool HasSeparableEvaluateGradient>
+class AddSeparableEvaluateWithGradientStatic<FunctionType, MatType, GradType,
+    HasSeparableEvaluateGradient, true>
 {
  public:
   // Reflect the existing Evaluate().
@@ -271,24 +271,24 @@ class AddDecomposableEvaluateWithGradientStatic<FunctionType, MatType, GradType,
 };
 
 /**
- * If we have a decomposable static Evaluate() and a decomposable static
- * Gradient() but not a decomposable static EvaluateWithGradient(), add a
- * decomposable static Gradient() method.
+ * If we have a separable static Evaluate() and a separable static
+ * Gradient() but not a separable static EvaluateWithGradient(), add a
+ * separable static Gradient() method.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-class AddDecomposableEvaluateWithGradientStatic<FunctionType, MatType, GradType,
+class AddSeparableEvaluateWithGradientStatic<FunctionType, MatType, GradType,
     true, false>
 {
  public:
   /**
    * Return both the evaluated objective function and its gradient, storing the
-   * gradient in the given matrix, starting at the given decomposable function
+   * gradient in the given matrix, starting at the given separable function
    * and using the given batch size.
    *
    * @param coordinates Coordinates to evaluate the function at.
-   * @param begin Index of decomposable function to begin with.
+   * @param begin Index of separable function to begin with.
    * @param gradient Matrix to store the gradient into.
-   * @param batchSize Number of decomposable functions to evaluate.
+   * @param batchSize Number of separable functions to evaluate.
    */
   typename MatType::elem_type EvaluateWithGradient(
       const MatType& coordinates,

--- a/include/ensmallen_bits/function/add_separable_gradient.hpp
+++ b/include/ensmallen_bits/function/add_separable_gradient.hpp
@@ -1,8 +1,8 @@
 /**
- * @file add_decomposable_gradient.hpp
+ * @file add_separable_gradient.hpp
  * @author Ryan Curtin
  *
- * Adds a decomposable Gradient() function if a decomposable
+ * Adds a separable Gradient() function if a separable
  * EvaluateWithGradient() function exists.
  *
  * ensmallen is free software; you may redistribute it and/or modify it under
@@ -18,22 +18,22 @@
 namespace ens {
 
 /**
- * The AddDecomposableGradient mixin class will add a decomposable Gradient()
- * method if a decomposable EvaluateWithGradient() function exists, or nothing
+ * The AddSeparableGradient mixin class will add a separable Gradient()
+ * method if a separable EvaluateWithGradient() function exists, or nothing
  * otherwise.
  */
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient =
+         bool HasSeparableEvaluateWithGradient =
              traits::HasEvaluateWithGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateWithGradientForm>::value,
-         bool HasDecomposableGradient =
+                     SeparableEvaluateWithGradientForm>::value,
+         bool HasSeparableGradient =
              traits::HasGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableGradientForm>::value>
-class AddDecomposableGradient
+                     SeparableGradientForm>::value>
+class AddSeparableGradient
 {
  public:
   // Provide a dummy overload so the name 'Gradient' exists for this object.
@@ -46,9 +46,9 @@ class AddDecomposableGradient
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient>
-class AddDecomposableGradient<FunctionType, MatType, GradType,
-    HasDecomposableEvaluateWithGradient, true>
+         bool HasSeparableEvaluateWithGradient>
+class AddSeparableGradient<FunctionType, MatType, GradType,
+    HasSeparableEvaluateWithGradient, true>
 {
  public:
   // Reflect the existing Gradient().
@@ -66,21 +66,21 @@ class AddDecomposableGradient<FunctionType, MatType, GradType,
 };
 
 /**
- * If we have a decomposable EvaluateWithGradient() but not a decomposable
- * Gradient(), add a decomposable Evaluate() method.
+ * If we have a separable EvaluateWithGradient() but not a separable
+ * Gradient(), add a separable Evaluate() method.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-class AddDecomposableGradient<FunctionType, MatType, GradType, true, false>
+class AddSeparableGradient<FunctionType, MatType, GradType, true, false>
 {
  public:
   /**
    * Calculate the gradient and store it in the given matrix, starting at the
-   * given decomposable function index and using the given batch size.
+   * given separable function index and using the given batch size.
    *
    * @param coordinates Coordinates to evaluate the function at.
-   * @param begin Index of decomposable function to start at.
+   * @param begin Index of separable function to start at.
    * @param gradient Matrix to store the gradient into.
-   * @param batchSize Number of decomposable functions to calculate for.
+   * @param batchSize Number of separable functions to calculate for.
    */
   void Gradient(const MatType& coordinates,
                 const size_t begin,
@@ -96,22 +96,22 @@ class AddDecomposableGradient<FunctionType, MatType, GradType, true, false>
 };
 
 /**
- * The AddDecomposableGradientConst mixin class will add a decomposable const
- * Gradient() method if a decomposable const EvaluateWithGradient() function
+ * The AddSeparableGradientConst mixin class will add a separable const
+ * Gradient() method if a separable const EvaluateWithGradient() function
  * exists, or nothing otherwise.
  */
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient =
+         bool HasSeparableEvaluateWithGradient =
              traits::HasEvaluateWithGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateWithGradientConstForm>::value,
-         bool HasDecomposableGradient =
+                     SeparableEvaluateWithGradientConstForm>::value,
+         bool HasSeparableGradient =
              traits::HasGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableGradientConstForm>::value>
-class AddDecomposableGradientConst
+                     SeparableGradientConstForm>::value>
+class AddSeparableGradientConst
 {
  public:
   // Provide a dummy overload so the name 'Gradient' exists for this object.
@@ -124,9 +124,9 @@ class AddDecomposableGradientConst
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient>
-class AddDecomposableGradientConst<FunctionType, MatType, GradType,
-    HasDecomposableEvaluateWithGradient, true>
+         bool HasSeparableEvaluateWithGradient>
+class AddSeparableGradientConst<FunctionType, MatType, GradType,
+    HasSeparableEvaluateWithGradient, true>
 {
  public:
   // Reflect the existing Gradient().
@@ -144,21 +144,21 @@ class AddDecomposableGradientConst<FunctionType, MatType, GradType,
 };
 
 /**
- * If we have a decomposable const EvaluateWithGradient() but not a decomposable
- * const Gradient(), add a decomposable const Gradient() method.
+ * If we have a separable const EvaluateWithGradient() but not a separable
+ * const Gradient(), add a separable const Gradient() method.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-class AddDecomposableGradientConst<FunctionType, MatType, GradType, true, false>
+class AddSeparableGradientConst<FunctionType, MatType, GradType, true, false>
 {
  public:
   /**
    * Calculate the gradient and store it in the given matrix, starting at the
-   * given decomposable function index and using the given batch size.
+   * given separable function index and using the given batch size.
    *
    * @param coordinates Coordinates to evaluate the function at.
-   * @param begin Index of decomposable function to start at.
+   * @param begin Index of separable function to start at.
    * @param gradient Matrix to store the gradient into.
-   * @param batchSize Number of decomposable functions to calculate for.
+   * @param batchSize Number of separable functions to calculate for.
    */
   void Gradient(const MatType& coordinates,
                 const size_t begin,
@@ -175,22 +175,22 @@ class AddDecomposableGradientConst<FunctionType, MatType, GradType, true, false>
 };
 
 /**
- * The AddDecomposableEvaluateStatic mixin class will add a decomposable static
- * Gradient() method if a decomposable static EvaluateWithGradient() function
+ * The AddSeparableEvaluateStatic mixin class will add a separable static
+ * Gradient() method if a separable static EvaluateWithGradient() function
  * exists, or nothing otherwise.
  */
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient =
+         bool HasSeparableEvaluateWithGradient =
              traits::HasEvaluateWithGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableEvaluateWithGradientStaticForm>::value,
-         bool HasDecomposableGradient =
+                     SeparableEvaluateWithGradientStaticForm>::value,
+         bool HasSeparableGradient =
              traits::HasGradient<FunctionType,
                  traits::TypedForms<MatType, GradType>::template
-                     DecomposableGradientStaticForm>::value>
-class AddDecomposableGradientStatic
+                     SeparableGradientStaticForm>::value>
+class AddSeparableGradientStatic
 {
  public:
   // Provide a dummy overload so the name 'Gradient' exists for this object.
@@ -205,9 +205,9 @@ class AddDecomposableGradientStatic
 template<typename FunctionType,
          typename MatType,
          typename GradType,
-         bool HasDecomposableEvaluateWithGradient>
-class AddDecomposableGradientStatic<FunctionType, MatType, GradType,
-    HasDecomposableEvaluateWithGradient, true>
+         bool HasSeparableEvaluateWithGradient>
+class AddSeparableGradientStatic<FunctionType, MatType, GradType,
+    HasSeparableEvaluateWithGradient, true>
 {
  public:
   // Reflect the existing Gradient().
@@ -221,22 +221,22 @@ class AddDecomposableGradientStatic<FunctionType, MatType, GradType,
 };
 
 /**
- * If we have a decomposable EvaluateWithGradient() but not a decomposable
- * Gradient(), add a decomposable Gradient() method.
+ * If we have a separable EvaluateWithGradient() but not a separable
+ * Gradient(), add a separable Gradient() method.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-class AddDecomposableGradientStatic<FunctionType, MatType, GradType, true,
+class AddSeparableGradientStatic<FunctionType, MatType, GradType, true,
     false>
 {
  public:
   /**
    * Calculate the gradient and store it in the given matrix, starting at the
-   * given decomposable function index and using the given batch size.
+   * given separable function index and using the given batch size.
    *
    * @param coordinates Coordinates to evaluate the function at.
-   * @param begin Index of decomposable function to start at.
+   * @param begin Index of separable function to start at.
    * @param gradient Matrix to store the gradient into.
-   * @param batchSize Number of decomposable functions to calculate for.
+   * @param batchSize Number of separable functions to calculate for.
    */
   static void Gradient(const MatType& coordinates,
                        const size_t begin,

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -57,7 +57,7 @@ struct CheckGradient
 /**
  * Check if a suitable overload of NumFunctions() is available.
  *
- * This is required by the DecomposableFunctionType API.
+ * This is required by the SeparableFunctionType API.
  */
 template<typename FunctionType, typename MatType, typename GradType>
 struct CheckNumFunctions
@@ -74,7 +74,7 @@ struct CheckNumFunctions
 /**
  * Check if a suitable overload of Shuffle() is available.
  *
- * This is required by the DecomposableFunctionType API.
+ * This is required by the SeparableFunctionType API.
  */
 template<typename FunctionType, typename MatType, typename GradType>
 struct CheckShuffle
@@ -89,37 +89,37 @@ struct CheckShuffle
 };
 
 /**
- * Check if a suitable decomposable overload of Evaluate() is available.
+ * Check if a suitable separable overload of Evaluate() is available.
  *
- * This is required by the DecomposableFunctionType API.
+ * This is required by the SeparableFunctionType API.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-struct CheckDecomposableEvaluate
+struct CheckSeparableEvaluate
 {
   const static bool value =
       HasEvaluate<FunctionType, TypedForms<MatType, GradType>::template
-          DecomposableEvaluateForm>::value ||
+          SeparableEvaluateForm>::value ||
       HasEvaluate<FunctionType, TypedForms<MatType, GradType>::template
-          DecomposableEvaluateConstForm>::value ||
+          SeparableEvaluateConstForm>::value ||
       HasEvaluate<FunctionType, TypedForms<MatType, GradType>::template
-          DecomposableEvaluateStaticForm>::value;
+          SeparableEvaluateStaticForm>::value;
 };
 
 /**
- * Check if a suitable decomposable overload of Gradient() is available.
+ * Check if a suitable separable overload of Gradient() is available.
  *
- * This is required by the DecomposableFunctionType API.
+ * This is required by the SeparableFunctionType API.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-struct CheckDecomposableGradient
+struct CheckSeparableGradient
 {
   const static bool value =
       HasGradient<FunctionType, TypedForms<MatType, GradType>::template
-          DecomposableGradientForm>::value ||
+          SeparableGradientForm>::value ||
       HasGradient<FunctionType, TypedForms<MatType, GradType>::template
-          DecomposableGradientConstForm>::value ||
+          SeparableGradientConstForm>::value ||
       HasGradient<FunctionType, TypedForms<MatType, GradType>::template
-          DecomposableGradientStaticForm>::value;
+          SeparableGradientStaticForm>::value;
 };
 
 /**
@@ -252,24 +252,24 @@ struct CheckEvaluateWithGradient
 };
 
 /**
- * Check if a suitable decomposable overload of EvaluateWithGradient() is
+ * Check if a suitable separable overload of EvaluateWithGradient() is
  * available.
  *
  * This is required by the FunctionType API.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-struct CheckDecomposableEvaluateWithGradient
+struct CheckSeparableEvaluateWithGradient
 {
   const static bool value =
       HasEvaluateWithGradient<FunctionType,
           TypedForms<MatType, GradType>::template
-              DecomposableEvaluateWithGradientForm>::value ||
+              SeparableEvaluateWithGradientForm>::value ||
       HasEvaluateWithGradient<FunctionType,
           TypedForms<MatType, GradType>::template
-              DecomposableEvaluateWithGradientConstForm>::value ||
+              SeparableEvaluateWithGradientConstForm>::value ||
       HasEvaluateWithGradient<FunctionType,
           TypedForms<MatType, GradType>::template
-              DecomposableEvaluateWithGradientStaticForm>::value;
+              SeparableEvaluateWithGradientStaticForm>::value;
 };
 
 /**
@@ -299,46 +299,46 @@ inline void CheckFunctionTypeAPI()
 }
 
 /**
- * Perform checks for the DecomposableFunctionType API.
+ * Perform checks for the SeparableFunctionType API.
  */
 template<typename FunctionType, typename MatType, typename GradType>
-inline void CheckDecomposableFunctionTypeAPI()
+inline void CheckSeparableFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
-  static_assert(CheckDecomposableEvaluate<FunctionType,
-                                          MatType,
-                                          GradType>::value,
-      "The FunctionType does not have a correct definition of a decomposable "
+  static_assert(CheckSeparableEvaluate<FunctionType,
+                                       MatType,
+                                       GradType>::value,
+      "The FunctionType does not have a correct definition of a separable "
       "Evaluate() method.  Please check that the FunctionType fully satisfies"
-      " the requirements of the DecomposableFunctionType API; see the optimizer"
+      " the requirements of the SeparableFunctionType API; see the optimizer"
       " tutorial for more details.");
 
-  static_assert(CheckDecomposableGradient<FunctionType,
-                                          MatType,
-                                          GradType>::value,
-      "The FunctionType does not have a correct definition of a decomposable "
+  static_assert(CheckSeparableGradient<FunctionType,
+                                       MatType,
+                                       GradType>::value,
+      "The FunctionType does not have a correct definition of a separable "
       "Gradient() method.  Please check that the FunctionType fully satisfies"
-      " the requirements of the DecomposableFunctionType API; see the optimizer"
+      " the requirements of the SeparableFunctionType API; see the optimizer"
       " tutorial for more details.");
 
-  static_assert(CheckDecomposableEvaluateWithGradient<FunctionType,
-                                                      MatType,
-                                                      GradType>::value,
-      "The FunctionType does not have a correct definition of a decomposable "
+  static_assert(CheckSeparableEvaluateWithGradient<FunctionType,
+                                                   MatType,
+                                                   GradType>::value,
+      "The FunctionType does not have a correct definition of a separable "
       "EvaluateWithGradient() method.  Please check that the FunctionType "
-      "fully satisfies the requirements of the DecomposableFunctionType API; "
+      "fully satisfies the requirements of the SeparableFunctionType API; "
       "see the optimizer tutorial for more details.");
 
   static_assert(CheckNumFunctions<FunctionType, MatType, GradType>::value,
       "The FunctionType does not have a correct definition of NumFunctions(). "
       "Please check that the FunctionType fully satisfies the requirements of "
-      "the DecomposableFunctionType API; see the optimizer tutorial for more "
+      "the SeparableFunctionType API; see the optimizer tutorial for more "
       "details.");
 
   static_assert(CheckShuffle<FunctionType, MatType, GradType>::value,
       "The FunctionType does not have a correct definition of Shuffle(). "
       "Please check that the FunctionType fully satisfies the requirements of "
-      "the DecomposableFunctionType API; see the optimizer tutorial for more "
+      "the SeparableFunctionType API; see the optimizer tutorial for more "
       "details.");
 #endif
 }
@@ -356,7 +356,7 @@ inline void CheckSparseFunctionTypeAPI()
       "the SparseFunctionType API; see the optimizer tutorial for more "
       "details.");
 
-  static_assert(CheckDecomposableEvaluate<FunctionType,
+  static_assert(CheckSeparableEvaluate<FunctionType,
                                           MatType,
                                           GradType>::value,
       "The FunctionType does not have a correct definition of Evaluate(). "
@@ -373,16 +373,16 @@ inline void CheckSparseFunctionTypeAPI()
 }
 
 /**
- * Perform checks for the NonDifferentiableFunctionType API.
+ * Perform checks for the ArbitraryFunctionType API.
  */
 template<typename FunctionType, typename MatType>
-inline void CheckNonDifferentiableFunctionTypeAPI()
+inline void CheckArbitraryFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
   static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
       "The FunctionType does not have a correct definition of Evaluate(). "
       "Please check that the FunctionType fully satisfies the requirements of "
-      "the NonDifferentiableFunctionType API; see the optimizer tutorial for "
+      "the ArbitraryFunctionType API; see the optimizer tutorial for "
       "more details.");
 #endif
 }
@@ -454,19 +454,19 @@ inline void CheckConstrainedFunctionTypeAPI()
 }
 
 /**
- * Perform checks for the NonDifferentiableDecomposableFunctionType API.  (I
+ * Perform checks for the ArbitrarySeparableFunctionType API.  (I
  * know, it is a long name...)
  */
 template<typename FunctionType, typename MatType>
-inline void CheckNonDifferentiableDecomposableFunctionTypeAPI()
+inline void CheckArbitrarySeparableFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
-  static_assert(CheckDecomposableEvaluate<FunctionType,
+  static_assert(CheckSeparableEvaluate<FunctionType,
                                           MatType,
                                           MatType>::value,
       "The FunctionType does not have a correct definition of Evaluate(). "
       "Please check that the FunctionType fully satisfies the requirements of "
-      "the NonDifferentiableDecomposableFunctionType API; see the optimizer "
+      "the ArbitrarySeparableFunctionType API; see the optimizer "
       "tutorial for more details.");
 #endif
 }

--- a/include/ensmallen_bits/function/traits.hpp
+++ b/include/ensmallen_bits/function/traits.hpp
@@ -115,60 +115,60 @@ struct TypedForms
   template<typename FunctionType>
   using ShuffleStaticForm = void(*)();
 
-  //! This is the form of a decomposable Evaluate() method.
+  //! This is the form of a separable Evaluate() method.
   template<typename FunctionType>
-  using DecomposableEvaluateForm =
+  using SeparableEvaluateForm =
       typename BaseMatType::elem_type(FunctionType::*)(const BaseMatType&,
                                                        const size_t,
                                                        const size_t);
 
-  //! This is the form of a decomposable const Evaluate() method.
+  //! This is the form of a separable const Evaluate() method.
   template<typename FunctionType>
-  using DecomposableEvaluateConstForm =
+  using SeparableEvaluateConstForm =
       typename BaseMatType::elem_type(FunctionType::*)(const BaseMatType&,
                                                        const size_t,
                                                        const size_t) const;
 
-  //! This is the form of a decomposable static Evaluate() method.
+  //! This is the form of a separable static Evaluate() method.
   template<typename FunctionType>
-  using DecomposableEvaluateStaticForm = typename BaseMatType::elem_type(*)(
+  using SeparableEvaluateStaticForm = typename BaseMatType::elem_type(*)(
         const BaseMatType&, const size_t, const size_t);
 
-  //! This is the form of a decomposable non-const Gradient() method.
+  //! This is the form of a separable non-const Gradient() method.
   template<typename FunctionType>
-  using DecomposableGradientForm = void(FunctionType::*)(
+  using SeparableGradientForm = void(FunctionType::*)(
       const BaseMatType&, const size_t, BaseGradType&, const size_t);
 
-  //! This the form of a decomposable const Gradient() method.
+  //! This the form of a separable const Gradient() method.
   template<typename FunctionType>
-  using DecomposableGradientConstForm = void(FunctionType::*)(
+  using SeparableGradientConstForm = void(FunctionType::*)(
       const BaseMatType&, const size_t, BaseGradType&, const size_t) const;
 
-  //! This is the form of a decomposable static Gradient() method.
+  //! This is the form of a separable static Gradient() method.
   template<typename FunctionType>
-  using DecomposableGradientStaticForm = void(*)(
+  using SeparableGradientStaticForm = void(*)(
       const BaseMatType&, const size_t, BaseGradType&, const size_t);
 
-  //! This is the form of a decomposable non-const EvaluateWithGradient()
+  //! This is the form of a separable non-const EvaluateWithGradient()
   //! method.
   template<typename FunctionType>
-  using DecomposableEvaluateWithGradientForm =
+  using SeparableEvaluateWithGradientForm =
       typename BaseMatType::elem_type(FunctionType::*)(const BaseMatType&,
                                                        const size_t,
                                                        BaseGradType&,
                                                        const size_t);
 
-  //! This is the form of a decomposable const EvaluateWithGradient() method.
+  //! This is the form of a separable const EvaluateWithGradient() method.
   template<typename FunctionType>
-  using DecomposableEvaluateWithGradientConstForm =
+  using SeparableEvaluateWithGradientConstForm =
       typename BaseMatType::elem_type(FunctionType::*)(const BaseMatType&,
                                                        const size_t,
                                                        BaseGradType&,
                                                        const size_t) const;
 
-  //! This is the form of a decomposable static EvaluateWithGradient() method.
+  //! This is the form of a separable static EvaluateWithGradient() method.
   template<typename FunctionType>
-  using DecomposableEvaluateWithGradientStaticForm =
+  using SeparableEvaluateWithGradientStaticForm =
       typename BaseMatType::elem_type(*)(const BaseMatType&,
                                          const size_t,
                                          BaseGradType&,

--- a/include/ensmallen_bits/gradient_descent/gradient_descent.hpp
+++ b/include/ensmallen_bits/gradient_descent/gradient_descent.hpp
@@ -84,14 +84,14 @@ class GradientDescent
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/grid_search/grid_search_impl.hpp
+++ b/include/ensmallen_bits/grid_search/grid_search_impl.hpp
@@ -70,7 +70,7 @@ void GridSearch::Optimize(
 
   // Make sure we have the methods that we need.  No restrictions on the matrix
   // type are needed.
-  traits::CheckNonDifferentiableFunctionTypeAPI<FunctionType, BaseMatType>();
+  traits::CheckArbitraryFunctionTypeAPI<FunctionType, BaseMatType>();
 
   if (i < categoricalDimensions.size())
   {

--- a/include/ensmallen_bits/iqn/iqn.hpp
+++ b/include/ensmallen_bits/iqn/iqn.hpp
@@ -74,7 +74,7 @@ class IQN
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -83,25 +83,25 @@ class IQN
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/iqn/iqn_impl.hpp
+++ b/include/ensmallen_bits/iqn/iqn_impl.hpp
@@ -32,13 +32,13 @@ inline IQN::IQN(const double stepSize,
 { /* Nothing to do. */ }
 
 //! Optimize the function (minimize).
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
-IQN::Optimize(DecomposableFunctionType& functionIn,
+IQN::Optimize(SeparableFunctionType& functionIn,
               MatType& iterateIn,
               CallbackTypes&&... callbacks)
 {
@@ -47,18 +47,18 @@ IQN::Optimize(DecomposableFunctionType& functionIn,
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
   typedef typename MatTypeTraits<GradType>::BaseMatType BaseGradType;
 
-  typedef Function<DecomposableFunctionType, BaseMatType, BaseGradType>
+  typedef Function<SeparableFunctionType, BaseMatType, BaseGradType>
       FullFunctionType;
   FullFunctionType& function(static_cast<FullFunctionType&>(functionIn));
 
   // Make sure we have all the methods that we need.
-  traits::CheckDecomposableFunctionTypeAPI<FullFunctionType, BaseMatType,
+  traits::CheckSeparableFunctionTypeAPI<FullFunctionType, BaseMatType,
       BaseGradType>();
   RequireDenseFloatingPointType<BaseMatType>();
   RequireDenseFloatingPointType<BaseGradType>();
   RequireSameInternalTypes<BaseMatType, BaseGradType>();
 
-  traits::CheckDecomposableFunctionTypeAPI<DecomposableFunctionType,
+  traits::CheckSeparableFunctionTypeAPI<SeparableFunctionType,
       BaseMatType, BaseGradType>();
 
   // Find the number of functions.

--- a/include/ensmallen_bits/katyusha/katyusha.hpp
+++ b/include/ensmallen_bits/katyusha/katyusha.hpp
@@ -80,7 +80,7 @@ class KatyushaType
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -89,25 +89,25 @@ class KatyushaType
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/katyusha/katyusha_impl.hpp
+++ b/include/ensmallen_bits/katyusha/katyusha_impl.hpp
@@ -41,14 +41,14 @@ KatyushaType<Proximal>::KatyushaType(
 
 //! Optimize the function (minimize).
 template<bool Proximal>
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
 KatyushaType<Proximal>::Optimize(
-    DecomposableFunctionType& function,
+    SeparableFunctionType& function,
     MatType& iterateIn,
     CallbackTypes&&... callbacks)
 {
@@ -57,7 +57,7 @@ KatyushaType<Proximal>::Optimize(
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
   typedef typename MatTypeTraits<GradType>::BaseMatType BaseGradType;
 
-  traits::CheckDecomposableFunctionTypeAPI<DecomposableFunctionType,
+  traits::CheckSeparableFunctionTypeAPI<SeparableFunctionType,
       BaseMatType, BaseGradType>();
   RequireFloatingPointType<BaseMatType>();
   RequireFloatingPointType<BaseGradType>();

--- a/include/ensmallen_bits/lbfgs/lbfgs.hpp
+++ b/include/ensmallen_bits/lbfgs/lbfgs.hpp
@@ -87,14 +87,14 @@ class L_BFGS
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/padam/padam.hpp
+++ b/include/ensmallen_bits/padam/padam.hpp
@@ -94,7 +94,7 @@ class Padam
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to optimize.
+   * @tparam SeparableFunctionType Type of the function to optimize.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -103,28 +103,28 @@ class Padam
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
     return optimizer.template Optimize<
-        DecomposableFunctionType, MatType, GradType, CallbackTypes...>(
+        SeparableFunctionType, MatType, GradType, CallbackTypes...>(
         function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/parallel_sgd/parallel_sgd.hpp
+++ b/include/ensmallen_bits/parallel_sgd/parallel_sgd.hpp
@@ -92,14 +92,14 @@ class ParallelSGD
            CallbackTypes&&... callbacks);
 
   //! Forward arma::SpMat<typename MatType::elem_type> as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType,
+    return Optimize<SeparableFunctionType, MatType,
         arma::SpMat<typename MatType::elem_type>, CallbackTypes...>(
         function, iterate, std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/problems/generalized_rosenbrock_function.hpp
+++ b/include/ensmallen_bits/problems/generalized_rosenbrock_function.hpp
@@ -25,7 +25,7 @@ namespace test {
  * This should optimize to f(x) = 0, at x = [1, 1, 1, 1, ...].
  *
  * This function can also be used for stochastic gradient descent (SGD) as a
- * decomposable function (DecomposableFunctionType), so there are other
+ * decomposable function (SeparableFunctionType), so there are other
  * overloads of Evaluate() and Gradient() implemented, as well as
  * NumFunctions().
  *

--- a/include/ensmallen_bits/pso/pso_impl.hpp
+++ b/include/ensmallen_bits/pso/pso_impl.hpp
@@ -51,7 +51,7 @@ typename MatType::elem_type PSOType<VelocityUpdatePolicy, InitPolicy>::Optimize(
       InstUpdatePolicyType;
 
   // Make sure that we have the methods that we need.  Long name...
-  traits::CheckNonDifferentiableFunctionTypeAPI<ArbitraryFunctionType,
+  traits::CheckArbitraryFunctionTypeAPI<ArbitraryFunctionType,
       BaseMatType>();
   RequireDenseFloatingPointType<BaseMatType>();
 

--- a/include/ensmallen_bits/qhadam/qhadam.hpp
+++ b/include/ensmallen_bits/qhadam/qhadam.hpp
@@ -87,7 +87,7 @@ class QHAdam
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to optimize.
+   * @tparam SeparableFunctionType Type of the function to optimize.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -96,29 +96,29 @@ class QHAdam
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
-    return optimizer.Optimize<DecomposableFunctionType, MatType, GradType,
+    return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
         CallbackTypes...>(function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/rmsprop/rmsprop.hpp
+++ b/include/ensmallen_bits/rmsprop/rmsprop.hpp
@@ -96,7 +96,7 @@ class RMSProp
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -105,29 +105,29 @@ class RMSProp
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
-    return optimizer.Optimize<DecomposableFunctionType, MatType, GradType,
+    return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
         CallbackTypes...>(function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/sa/sa_impl.hpp
+++ b/include/ensmallen_bits/sa/sa_impl.hpp
@@ -55,7 +55,7 @@ typename MatType::elem_type SA<CoolingScheduleType>::Optimize(
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
 
   // Make sure we have the methods that we need.
-  traits::CheckNonDifferentiableFunctionTypeAPI<FunctionType, BaseMatType>();
+  traits::CheckArbitraryFunctionTypeAPI<FunctionType, BaseMatType>();
   RequireFloatingPointType<BaseMatType>();
 
   BaseMatType& iterate = (BaseMatType&) iterateIn;

--- a/include/ensmallen_bits/sarah/sarah.hpp
+++ b/include/ensmallen_bits/sarah/sarah.hpp
@@ -84,7 +84,7 @@ class SARAHType
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -93,25 +93,25 @@ class SARAHType
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/sarah/sarah_impl.hpp
+++ b/include/ensmallen_bits/sarah/sarah_impl.hpp
@@ -41,14 +41,14 @@ SARAHType<UpdatePolicyType>::SARAHType(
 
 //! Optimize the function (minimize).
 template<typename UpdatePolicyType>
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
 SARAHType<UpdatePolicyType>::Optimize(
-    DecomposableFunctionType& functionIn,
+    SeparableFunctionType& functionIn,
     MatType& iterateIn,
     CallbackTypes&&... callbacks)
 {
@@ -57,11 +57,11 @@ SARAHType<UpdatePolicyType>::Optimize(
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
   typedef typename MatTypeTraits<GradType>::BaseMatType BaseGradType;
 
-  typedef Function<DecomposableFunctionType, BaseMatType, BaseGradType>
+  typedef Function<SeparableFunctionType, BaseMatType, BaseGradType>
       FullFunctionType;
   FullFunctionType& function(static_cast<FullFunctionType&>(functionIn));
 
-  traits::CheckDecomposableFunctionTypeAPI<DecomposableFunctionType,
+  traits::CheckSeparableFunctionTypeAPI<SeparableFunctionType,
       BaseMatType, BaseGradType>();
   RequireFloatingPointType<BaseMatType>();
   RequireFloatingPointType<BaseGradType>();

--- a/include/ensmallen_bits/scd/scd.hpp
+++ b/include/ensmallen_bits/scd/scd.hpp
@@ -101,14 +101,14 @@ class SCD
            CallbackTypes&&... callbacks);
 
   //! Forward arma::SpMat<typename MatType::elem_type> as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType,
+    return Optimize<SeparableFunctionType, MatType,
         arma::SpMat<typename MatType::elem_type>, CallbackTypes...>(
         function, iterate, std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/sgd/sgd.hpp
+++ b/include/ensmallen_bits/sgd/sgd.hpp
@@ -106,7 +106,7 @@ class SGD
    * starting point will be modified to store the finishing point of the
    * algorithm, and the final objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam v Types of callback functions.
@@ -115,25 +115,25 @@ class SGD
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/sgd/sgd_impl.hpp
+++ b/include/ensmallen_bits/sgd/sgd_impl.hpp
@@ -46,14 +46,14 @@ SGD<UpdatePolicyType, DecayPolicyType>::SGD(
 
 //! Optimize the function (minimize).
 template<typename UpdatePolicyType, typename DecayPolicyType>
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
 SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
-    DecomposableFunctionType& function,
+    SeparableFunctionType& function,
     MatType& iterateIn,
     CallbackTypes&&... callbacks)
 {
@@ -62,7 +62,7 @@ SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
   typedef typename MatTypeTraits<GradType>::BaseMatType BaseGradType;
 
-  typedef Function<DecomposableFunctionType, BaseMatType, BaseGradType>
+  typedef Function<SeparableFunctionType, BaseMatType, BaseGradType>
       FullFunctionType;
   FullFunctionType& f(static_cast<FullFunctionType&>(function));
 
@@ -74,7 +74,7 @@ SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
       InstDecayPolicyType;
 
   // Make sure we have all the methods that we need.
-  traits::CheckDecomposableFunctionTypeAPI<FullFunctionType, BaseMatType,
+  traits::CheckSeparableFunctionTypeAPI<FullFunctionType, BaseMatType,
       BaseGradType>();
   RequireFloatingPointType<BaseMatType>();
   RequireFloatingPointType<BaseGradType>();

--- a/include/ensmallen_bits/sgdr/sgdr.hpp
+++ b/include/ensmallen_bits/sgdr/sgdr.hpp
@@ -90,7 +90,7 @@ class SGDR
    * will be modified to store the finishing point of the algorithm, and the
    * final objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -99,25 +99,25 @@ class SGDR
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/sgdr/sgdr_impl.hpp
+++ b/include/ensmallen_bits/sgdr/sgdr_impl.hpp
@@ -47,12 +47,12 @@ SGDR<UpdatePolicyType>::SGDR(
 }
 
 template<typename UpdatePolicyType>
-template<typename DecomposableFunctionType, typename MatType, typename GradType,
+template<typename SeparableFunctionType, typename MatType, typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
 SGDR<UpdatePolicyType>::Optimize(
-    DecomposableFunctionType& function,
+    SeparableFunctionType& function,
     MatType& iterate,
     CallbackTypes&&... callbacks)
 {

--- a/include/ensmallen_bits/sgdr/snapshot_sgdr.hpp
+++ b/include/ensmallen_bits/sgdr/snapshot_sgdr.hpp
@@ -107,7 +107,7 @@ class SnapshotSGDR
    * will be modified to store the finishing point of the algorithm, and the
    * final objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of function to optimize.
+   * @tparam SeparableFunctionType Type of function to optimize.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -116,25 +116,25 @@ class SnapshotSGDR
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/sgdr/snapshot_sgdr_impl.hpp
+++ b/include/ensmallen_bits/sgdr/snapshot_sgdr_impl.hpp
@@ -53,14 +53,14 @@ SnapshotSGDR<UpdatePolicyType>::SnapshotSGDR(
 }
 
 template<typename UpdatePolicyType>
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
 SnapshotSGDR<UpdatePolicyType>::Optimize(
-    DecomposableFunctionType& function,
+    SeparableFunctionType& function,
     MatType& iterate,
     CallbackTypes&&... callbacks)
 {

--- a/include/ensmallen_bits/smorms3/smorms3.hpp
+++ b/include/ensmallen_bits/smorms3/smorms3.hpp
@@ -79,7 +79,7 @@ class SMORMS3
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -88,31 +88,31 @@ class SMORMS3
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
     // TODO: disallow sp_mat
 
-    return optimizer.Optimize<DecomposableFunctionType, MatType, GradType,
+    return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
         CallbackTypes...>(function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/spalera_sgd/spalera_sgd.hpp
+++ b/include/ensmallen_bits/spalera_sgd/spalera_sgd.hpp
@@ -117,7 +117,7 @@ class SPALeRASGD
    * will be modified to store the finishing point of the algorithm, and the
    * final objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -126,25 +126,25 @@ class SPALeRASGD
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/spalera_sgd/spalera_sgd_impl.hpp
+++ b/include/ensmallen_bits/spalera_sgd/spalera_sgd_impl.hpp
@@ -47,14 +47,14 @@ SPALeRASGD<DecayPolicyType>::SPALeRASGD(const double stepSize,
 
 //! Optimize the function (minimize).
 template<typename DecayPolicyType>
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
 SPALeRASGD<DecayPolicyType>::Optimize(
-    DecomposableFunctionType& function,
+    SeparableFunctionType& function,
     MatType& iterateIn,
     CallbackTypes&&... callbacks)
 {
@@ -63,11 +63,11 @@ SPALeRASGD<DecayPolicyType>::Optimize(
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
   typedef typename MatTypeTraits<GradType>::BaseMatType BaseGradType;
 
-  typedef Function<DecomposableFunctionType, BaseMatType, BaseGradType>
+  typedef Function<SeparableFunctionType, BaseMatType, BaseGradType>
       FullFunctionType;
   FullFunctionType& f(static_cast<FullFunctionType&>(function));
 
-  traits::CheckDecomposableFunctionTypeAPI<FullFunctionType, BaseMatType,
+  traits::CheckSeparableFunctionTypeAPI<FullFunctionType, BaseMatType,
       BaseGradType>();
   RequireDenseFloatingPointType<BaseMatType>();
   RequireFloatingPointType<BaseGradType>();

--- a/include/ensmallen_bits/spsa/spsa_impl.hpp
+++ b/include/ensmallen_bits/spsa/spsa_impl.hpp
@@ -48,7 +48,7 @@ typename MatType::elem_type SPSA::Optimize(ArbitraryFunctionType& function,
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
 
   // Make sure that we have the methods that we need.
-  traits::CheckNonDifferentiableFunctionTypeAPI<ArbitraryFunctionType,
+  traits::CheckArbitraryFunctionTypeAPI<ArbitraryFunctionType,
       MatType>();
   RequireFloatingPointType<MatType>();
 

--- a/include/ensmallen_bits/svrg/svrg.hpp
+++ b/include/ensmallen_bits/svrg/svrg.hpp
@@ -125,7 +125,7 @@ class SVRGType
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -134,25 +134,25 @@ class SVRGType
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks);
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/svrg/svrg_impl.hpp
+++ b/include/ensmallen_bits/svrg/svrg_impl.hpp
@@ -44,14 +44,14 @@ SVRGType<UpdatePolicyType, DecayPolicyType>::SVRGType(
 
 //! Optimize the function (minimize).
 template<typename UpdatePolicyType, typename DecayPolicyType>
-template<typename DecomposableFunctionType,
+template<typename SeparableFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsArmaType<GradType>::value,
 typename MatType::elem_type>::type
 SVRGType<UpdatePolicyType, DecayPolicyType>::Optimize(
-    DecomposableFunctionType& functionIn,
+    SeparableFunctionType& functionIn,
     MatType& iterateIn,
     CallbackTypes&&... callbacks)
 {
@@ -60,11 +60,11 @@ SVRGType<UpdatePolicyType, DecayPolicyType>::Optimize(
   typedef typename MatTypeTraits<MatType>::BaseMatType BaseMatType;
   typedef typename MatTypeTraits<GradType>::BaseMatType BaseGradType;
 
-  typedef Function<DecomposableFunctionType, BaseMatType, BaseGradType>
+  typedef Function<SeparableFunctionType, BaseMatType, BaseGradType>
       FullFunctionType;
   FullFunctionType& function(static_cast<FullFunctionType&>(functionIn));
 
-  traits::CheckDecomposableFunctionTypeAPI<DecomposableFunctionType,
+  traits::CheckSeparableFunctionTypeAPI<SeparableFunctionType,
       BaseMatType, BaseGradType>();
   RequireFloatingPointType<BaseMatType>();
   RequireFloatingPointType<BaseGradType>();

--- a/include/ensmallen_bits/swats/swats.hpp
+++ b/include/ensmallen_bits/swats/swats.hpp
@@ -85,7 +85,7 @@ class SWATS
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -94,29 +94,29 @@ class SWATS
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
-    return optimizer.Optimize<DecomposableFunctionType, MatType, GradType,
+    return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
         CallbackTypes...>(function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/include/ensmallen_bits/wn_grad/wn_grad.hpp
+++ b/include/ensmallen_bits/wn_grad/wn_grad.hpp
@@ -74,7 +74,7 @@ class WNGrad
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.
    *
-   * @tparam DecomposableFunctionType Type of the function to be optimized.
+   * @tparam SeparableFunctionType Type of the function to be optimized.
    * @tparam MatType Type of matrix to optimize with.
    * @tparam GradType Type of matrix to use to represent function gradients.
    * @tparam CallbackTypes Types of callback functions.
@@ -83,29 +83,29 @@ class WNGrad
    * @param callbacks Callback functions.
    * @return Objective value of the final point.
    */
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename GradType,
            typename... CallbackTypes>
   typename std::enable_if<IsArmaType<GradType>::value,
       typename MatType::elem_type>::type
-  Optimize(DecomposableFunctionType& function,
+  Optimize(SeparableFunctionType& function,
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
-    return optimizer.Optimize<DecomposableFunctionType, MatType, GradType,
+    return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
         CallbackTypes...>(function, iterate, callbacks...);
   }
 
   //! Forward the MatType as GradType.
-  template<typename DecomposableFunctionType,
+  template<typename SeparableFunctionType,
            typename MatType,
            typename... CallbackTypes>
-  typename MatType::elem_type Optimize(DecomposableFunctionType& function,
+  typename MatType::elem_type Optimize(SeparableFunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks)
   {
-    return Optimize<DecomposableFunctionType, MatType, MatType,
+    return Optimize<SeparableFunctionType, MatType, MatType,
         CallbackTypes...>(function, iterate,
         std::forward<CallbackTypes>(callbacks)...);
   }

--- a/tests/function_test.cpp
+++ b/tests/function_test.cpp
@@ -366,20 +366,20 @@ TEST_CASE("SDPTest", "[FunctionTest]")
 /**
  * Make sure that an empty class doesn't have any methods added to it.
  */
-TEST_CASE("AddDecomposableEvaluateWithGradientEmptyTest", "[FunctionTest]")
+TEST_CASE("AddSeparableEvaluateWithGradientEmptyTest", "[FunctionTest]")
 {
   const bool hasEvaluate = HasEvaluate<
       Function<EmptyTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateForm>::value;
+          SeparableEvaluateForm>::value;
   const bool hasGradient = HasGradient<
       Function<EmptyTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableGradientForm>::value;
+          SeparableGradientForm>::value;
   const bool hasEvaluateWithGradient = HasEvaluateWithGradient<
       Function<EmptyTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateWithGradientForm>::value;
+          SeparableEvaluateWithGradientForm>::value;
 
   REQUIRE(hasEvaluate == false);
   REQUIRE(hasGradient == false);
@@ -389,21 +389,21 @@ TEST_CASE("AddDecomposableEvaluateWithGradientEmptyTest", "[FunctionTest]")
 /**
  * Make sure we don't add any functions if we only have Evaluate().
  */
-TEST_CASE("AddDecomposableEvaluateWithGradientEvaluateOnlyTest",
+TEST_CASE("AddSeparableEvaluateWithGradientEvaluateOnlyTest",
           "[FunctionTest]")
 {
   const bool hasEvaluate = HasEvaluate<
       Function<EvaluateTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateForm>::value;
+          SeparableEvaluateForm>::value;
   const bool hasGradient = HasGradient<
       Function<EvaluateTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableGradientForm>::value;
+          SeparableGradientForm>::value;
   const bool hasEvaluateWithGradient = HasEvaluateWithGradient<
       Function<EvaluateTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateWithGradientForm>::value;
+          SeparableEvaluateWithGradientForm>::value;
 
   REQUIRE(hasEvaluate == true);
   REQUIRE(hasGradient == false);
@@ -413,21 +413,21 @@ TEST_CASE("AddDecomposableEvaluateWithGradientEvaluateOnlyTest",
 /**
  * Make sure we don't add any functions if we only have Gradient().
  */
-TEST_CASE("AddDecomposableEvaluateWithGradientGradientOnlyTest",
+TEST_CASE("AddSeparableEvaluateWithGradientGradientOnlyTest",
           "[FunctionTest]")
 {
   const bool hasEvaluate = HasEvaluate<
       Function<GradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateForm>::value;
+          SeparableEvaluateForm>::value;
   const bool hasGradient = HasGradient<
       Function<GradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableGradientForm>::value;
+          SeparableGradientForm>::value;
   const bool hasEvaluateWithGradient = HasEvaluateWithGradient<
       Function<GradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateWithGradientForm>::value;
+          SeparableEvaluateWithGradientForm>::value;
 
   REQUIRE(hasEvaluate == false);
   REQUIRE(hasGradient == true);
@@ -438,20 +438,20 @@ TEST_CASE("AddDecomposableEvaluateWithGradientGradientOnlyTest",
  * Make sure we add EvaluateWithGradient() when we have both Evaluate() and
  * Gradient().
  */
-TEST_CASE("AddDecomposableEvaluateWithGradientBothTest", "[FunctionTest]")
+TEST_CASE("AddSeparableEvaluateWithGradientBothTest", "[FunctionTest]")
 {
   const bool hasEvaluate = HasEvaluate<
       Function<EvaluateGradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateForm>::value;
+          SeparableEvaluateForm>::value;
   const bool hasGradient = HasGradient<
       Function<EvaluateGradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableGradientForm>::value;
+          SeparableGradientForm>::value;
   const bool hasEvaluateWithGradient = HasEvaluateWithGradient<
       Function<EvaluateGradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateWithGradientForm>::value;
+          SeparableEvaluateWithGradientForm>::value;
 
   REQUIRE(hasEvaluate == true);
   REQUIRE(hasGradient == true);
@@ -462,21 +462,21 @@ TEST_CASE("AddDecomposableEvaluateWithGradientBothTest", "[FunctionTest]")
  * Make sure we add Evaluate() and Gradient() when we have only
  * EvaluateWithGradient().
  */
-TEST_CASE("AddDecomposableEvaluateWGradientEvaluateWithGradientTest",
+TEST_CASE("AddSeparableEvaluateWGradientEvaluateWithGradientTest",
           "[FunctionTest]")
 {
   const bool hasEvaluate = HasEvaluate<
       Function<EvaluateWithGradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateForm>::value;
+          SeparableEvaluateForm>::value;
   const bool hasGradient = HasGradient<
       Function<EvaluateWithGradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableGradientForm>::value;
+          SeparableGradientForm>::value;
   const bool hasEvaluateWithGradient = HasEvaluateWithGradient<
       Function<EvaluateWithGradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateWithGradientForm>::value;
+          SeparableEvaluateWithGradientForm>::value;
 
   Function<EvaluateWithGradientTestFunction, arma::mat, arma::mat> f;
   arma::mat coordinates(10, 10, arma::fill::ones);
@@ -491,20 +491,20 @@ TEST_CASE("AddDecomposableEvaluateWGradientEvaluateWithGradientTest",
 /**
  * Make sure we add no methods when we already have all three.
  */
-TEST_CASE("AddDecomposableEvaluateWithGradientAllThreeTest", "[FunctionTest]")
+TEST_CASE("AddSeparableEvaluateWithGradientAllThreeTest", "[FunctionTest]")
 {
   const bool hasEvaluate = HasEvaluate<
       Function<EvaluateAndWithGradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateForm>::value;
+          SeparableEvaluateForm>::value;
   const bool hasGradient = HasGradient<
       Function<EvaluateAndWithGradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableGradientForm>::value;
+          SeparableGradientForm>::value;
   const bool hasEvaluateWithGradient = HasEvaluateWithGradient<
       Function<EvaluateAndWithGradientTestFunction, arma::mat, arma::mat>,
       TypedForms<arma::mat, arma::mat>::template
-          DecomposableEvaluateWithGradientForm>::value;
+          SeparableEvaluateWithGradientForm>::value;
 
   REQUIRE(hasEvaluate == true);
   REQUIRE(hasGradient == true);
@@ -600,9 +600,9 @@ class D
 
 
 /**
- * Test the correctness of the static check for DecomposableFunctionType API.
+ * Test the correctness of the static check for SeparableFunctionType API.
  */
-TEST_CASE("DecomposableFunctionTypeCheckTest", "[FunctionTest]")
+TEST_CASE("SeparableFunctionTypeCheckTest", "[FunctionTest]")
 {
   static_assert(CheckNumFunctions<A, arma::mat, arma::mat>::value,
       "CheckNumFunctions static check failed.");
@@ -613,23 +613,23 @@ TEST_CASE("DecomposableFunctionTypeCheckTest", "[FunctionTest]")
   static_assert(!CheckNumFunctions<D, arma::mat, arma::mat>::value,
       "CheckNumFunctions static check failed.");
 
-  static_assert(CheckDecomposableEvaluate<A, arma::mat, arma::mat>::value,
-      "CheckDecomposableEvaluate static check failed.");
-  static_assert(CheckDecomposableEvaluate<B, arma::mat, arma::mat>::value,
-      "CheckDecomposableEvaluate static check failed.");
-  static_assert(!CheckDecomposableEvaluate<C, arma::mat, arma::mat>::value,
-      "CheckDecomposableEvaluate static check failed.");
-  static_assert(!CheckDecomposableEvaluate<D, arma::mat, arma::mat>::value,
-      "CheckDecomposableEvaluate static check failed.");
+  static_assert(CheckSeparableEvaluate<A, arma::mat, arma::mat>::value,
+      "CheckSeparableEvaluate static check failed.");
+  static_assert(CheckSeparableEvaluate<B, arma::mat, arma::mat>::value,
+      "CheckSeparableEvaluate static check failed.");
+  static_assert(!CheckSeparableEvaluate<C, arma::mat, arma::mat>::value,
+      "CheckSeparableEvaluate static check failed.");
+  static_assert(!CheckSeparableEvaluate<D, arma::mat, arma::mat>::value,
+      "CheckSeparableEvaluate static check failed.");
 
-  static_assert(CheckDecomposableGradient<A, arma::mat, arma::mat>::value,
-      "CheckDecomposableGradient static check failed.");
-  static_assert(CheckDecomposableGradient<B, arma::mat, arma::mat>::value,
-      "CheckDecomposableGradient static check failed.");
-  static_assert(!CheckDecomposableGradient<C, arma::mat, arma::mat>::value,
-      "CheckDecomposableGradient static check failed.");
-  static_assert(!CheckDecomposableGradient<D, arma::mat, arma::mat>::value,
-      "CheckDecomposableGradient static check failed.");
+  static_assert(CheckSeparableGradient<A, arma::mat, arma::mat>::value,
+      "CheckSeparableGradient static check failed.");
+  static_assert(CheckSeparableGradient<B, arma::mat, arma::mat>::value,
+      "CheckSeparableGradient static check failed.");
+  static_assert(!CheckSeparableGradient<C, arma::mat, arma::mat>::value,
+      "CheckSeparableGradient static check failed.");
+  static_assert(!CheckSeparableGradient<D, arma::mat, arma::mat>::value,
+      "CheckSeparableGradient static check failed.");
 }
 
 /**


### PR DESCRIPTION
This solves #144.  The original code for the static function type checks used the terms `decomposable` and `non-differentiable`, but in the documentation we use `separable` and `arbitrary` to represent those two concepts.  This PR changes all of the code to match the terms in the documentation.