### PR TITLE
Remove 'using namespace std' from problems.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
   * SGD callback test 32-bit safety (big number).
     ([#143](https://github.com/mlpack/ensmallen/pull/143)).
 
+  * Remove 'using namespace std' from problems/ files.
+    ([#147](https://github.com/mlpack/ensmallen/pull/147)).
+
 ### ensmallen 2.10.4: "Fried Chicken"
 ###### 2019-11-18
   * Add optional tests building.

--- a/include/ensmallen_bits/problems/ackley_function_impl.hpp
+++ b/include/ensmallen_bits/problems/ackley_function_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't been included yet.
 #include "ackley_function.hpp"
-using namespace std;
 
 namespace ens {
 namespace test {
@@ -38,8 +37,9 @@ typename MatType::elem_type AckleyFunction::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType objective = -20 * exp(-0.2 * sqrt(0.5 * (x1 * x1 + x2 * x2))) -
-      exp(0.5 * (cos(c * x1) + cos(c * x2))) + exp(1) + 20;
+  const ElemType objective = -20 * std::exp(
+      -0.2 * std::sqrt(0.5 * (x1 * x1 + x2 * x2))) -
+      std::exp(0.5 * (std::cos(c * x1) + std::cos(c * x2))) + std::exp(1) + 20;
 
   return objective;
 }
@@ -65,13 +65,14 @@ inline void AckleyFunction::Gradient(const MatType& coordinates,
   const ElemType x2 = coordinates(1);
 
   // Aliases for different terms in the expression of the gradient.
-  const ElemType t0 = sqrt(0.5 * (x1 * x1 + x2 * x2));
-  const ElemType t1 = 2.0 * exp(- 0.2 * t0) / (t0 + epsilon);
-  const ElemType t2 = 0.5 * c * exp(0.5 * (cos(c * x1) + cos(c * x2)));
+  const ElemType t0 = std::sqrt(0.5 * (x1 * x1 + x2 * x2));
+  const ElemType t1 = 2.0 * std::exp(- 0.2 * t0) / (t0 + epsilon);
+  const ElemType t2 = 0.5 * c *
+      std::exp(0.5 * (std::cos(c * x1) + std::cos(c * x2)));
 
   gradient.set_size(2, 1);
-  gradient(0) = (x1 * t1) + (t2 * sin(c * x1));
-  gradient(1) = (x2 * t1) + (t2 * sin(c * x2));
+  gradient(0) = (x1 * t1) + (t2 * std::sin(c * x1));
+  gradient(1) = (x2 * t1) + (t2 * std::sin(c * x2));
 }
 
 template<typename MatType, typename GradType>

--- a/include/ensmallen_bits/problems/beale_function_impl.hpp
+++ b/include/ensmallen_bits/problems/beale_function_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't been included yet.
 #include "beale_function.hpp"
-using namespace std;
 
 namespace ens {
 namespace test {
@@ -36,8 +35,9 @@ typename MatType::elem_type BealeFunction::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType objective = pow(1.5 - x1 + x1 * x2, 2) +
-      pow(2.25 - x1 + x1 * x2 * x2, 2) +  pow(2.625 - x1 + x1 * pow(x2, 3), 2);
+  const ElemType objective = std::pow(1.5 - x1 + x1 * x2, 2) +
+      std::pow(2.25 - x1 + x1 * x2 * x2, 2) +
+      std::pow(2.625 - x1 + x1 * pow(x2, 3), 2);
 
   return objective;
 }

--- a/include/ensmallen_bits/problems/cross_in_tray_function_impl.hpp
+++ b/include/ensmallen_bits/problems/cross_in_tray_function_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't been included yet.
 #include "cross_in_tray_function.hpp"
-using namespace std;
 
 namespace ens {
 namespace test {
@@ -36,9 +35,9 @@ typename MatType::elem_type CrossInTrayFunction::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType objective = -0.0001 * pow(abs(sin(x1) * sin(x2) *
-      exp(abs(100 - (sqrt(pow(x1, 2) + pow(x2, 2)) /
-      arma::datum::pi))) + 1), 0.1);
+  const ElemType objective = -0.0001 * std::pow(std::abs(std::sin(x1) *
+      std::sin(x2) * std::exp(std::abs(100 - (std::sqrt(std::pow(x1, 2) +
+      std::pow(x2, 2)) / arma::datum::pi))) + 1), 0.1);
   return objective;
 }
 

--- a/include/ensmallen_bits/problems/goldstein_price_function_impl.hpp
+++ b/include/ensmallen_bits/problems/goldstein_price_function_impl.hpp
@@ -12,8 +12,6 @@
 #ifndef ENSMALLEN_PROBLEMS_GOLDSTEIN_PRICE_FUNCTION_IMPL_HPP
 #define ENSMALLEN_PROBLEMS_GOLDSTEIN_PRICE_FUNCTION_IMPL_HPP
 
-using namespace std;
-
 // In case it hasn't been included yet.
 #include "goldstein_price_function.hpp"
 
@@ -38,12 +36,12 @@ typename MatType::elem_type GoldsteinPriceFunction::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType x1Sq = pow(x1, 2);
-  const ElemType x2Sq = pow(x2, 2);
+  const ElemType x1Sq = std::pow(x1, 2);
+  const ElemType x2Sq = std::pow(x2, 2);
   const ElemType x1x2 = x1 * x2;
-  const ElemType objective = (1 + pow(x1 + x2 + 1, 2) * (19 - 14 * x1 + 3 *
-      x1Sq - 14 * x2 + 6 * x1x2 + 3 * x2Sq)) * (30 + pow(2 * x1 - 3 * x2, 2) *
-      (18 - 32 * x1 + 12 * x1Sq + 48 * x2 - 36 * x1x2 + 27 * x2Sq));
+  const ElemType objective = (1 + std::pow(x1 + x2 + 1, 2) * (19 - 14 * x1 + 3 *
+      x1Sq - 14 * x2 + 6 * x1x2 + 3 * x2Sq)) * (30 + std::pow(2 * x1 - 3 * x2,
+      2) * (18 - 32 * x1 + 12 * x1Sq + 48 * x2 - 36 * x1x2 + 27 * x2Sq));
 
   return objective;
 }
@@ -69,24 +67,22 @@ inline void GoldsteinPriceFunction::Gradient(const MatType& coordinates,
   const ElemType x2 = coordinates(1);
 
   gradient.set_size(2, 1);
-  gradient(0) = (pow(2 * x1 - 3 * x2, 2) * (24 * x1 - 36 * x2 - 32) +
-      (8 * x1 - 12 * x2) * (12 * x1 * x1 - 36 * x1 * x2 - 32 * x1 +
-      27 * x2 * x2 + 48 * x2 + 18)) * (pow(x1 + x2 + 1, 2) *
-      (3 * x1 * x1 + 6 * x1 * x2 - 14 * x1 + 3 * x2 * x2 - 14 * x2 +
-      19) + 1) + (pow(2 * x1 - 3 * x2, 2) * (12 * x1 * x1 - 36 *
-      x1 * x2 - 32 * x1 + 27 * x2 * x2 + 48 * x2 + 18) + 30) *
-      (pow(x1 + x2 + 1, 2) * (6 * x1 + 6 * x2 - 14) + (2 * x1 +
-      2 * x2 + 2) * (3 * x1 * x1 + 6 * x1 * x2 - 14 * x1 + 3 * x2 *
-      x2 - 14 * x2 + 19));
+  gradient(0) = (std::pow(2 * x1 - 3 * x2, 2) * (24 * x1 - 36 * x2 - 32) + (8 *
+      x1 - 12 * x2) * (12 * x1 * x1 - 36 * x1 * x2 - 32 * x1 + 27 * x2 * x2 +
+      48 * x2 + 18)) * (std::pow(x1 + x2 + 1, 2) * (3 * x1 * x1 + 6 * x1 * x2 -
+      14 * x1 + 3 * x2 * x2 - 14 * x2 + 19) + 1) + (std::pow(2 * x1 - 3 * x2,
+      2) * (12 * x1 * x1 - 36 * x1 * x2 - 32 * x1 + 27 * x2 * x2 + 48 * x2 +
+      18) + 30) * (std::pow(x1 + x2 + 1, 2) * (6 * x1 + 6 * x2 - 14) + (2 * x1 +
+      2 * x2 + 2) * (3 * x1 * x1 + 6 * x1 * x2 - 14 * x1 + 3 * x2 * x2 - 14 *
+      x2 + 19));
   gradient(1) = ((- 12 * x1 + 18 * x2) * (12 * x1 * x1 - 36 * x1 * x2 - 32 *
-      x1 + 27 * x2 * x2 + 48 * x2 + 18) + pow(2 * x1 - 3 * x2, 2) *
-      (-36 * x1 + 54 * x2 + 48)) * (pow(x1 + x2 + 1, 2) * (3 * x1 *
-      x1 + 6 * x1 * x2 - 14 * x1 + 3 * x2 * x2 - 14 * x2 + 19) + 1) +
-      (pow(2 * x1 - 3 * x2, 2) * (12 * x1 * x1 - 36 * x1 * x2 -
-      32 * x1 + 27 * x2 * x2 + 48 * x2 + 18) + 30) *
-      (pow(x1 + x2 + 1, 2) * (6 * x1 + 6 * x2 - 14) + (2 * x1 +
-      2 * x2 + 2) * (3 * x1 * x1 + 6 * x1 * x2 - 14 * x1 + 3 * x2 *
-      x2 - 14 * x2 + 19));
+      x1 + 27 * x2 * x2 + 48 * x2 + 18) + std::pow(2 * x1 - 3 * x2, 2) * (-36 *
+      x1 + 54 * x2 + 48)) * (std::pow(x1 + x2 + 1, 2) * (3 * x1 * x1 + 6 * x1 *
+      x2 - 14 * x1 + 3 * x2 * x2 - 14 * x2 + 19) + 1) + (std::pow(2 * x1 - 3 *
+      x2, 2) * (12 * x1 * x1 - 36 * x1 * x2 - 32 * x1 + 27 * x2 * x2 + 48 * x2 +
+      18) + 30) * (std::pow(x1 + x2 + 1, 2) * (6 * x1 + 6 * x2 - 14) + (2 * x1 +
+      2 * x2 + 2) * (3 * x1 * x1 + 6 * x1 * x2 - 14 * x1 + 3 * x2 * x2 - 14 *
+      x2 + 19));
 }
 
 template<typename MatType, typename GradType>

--- a/include/ensmallen_bits/problems/himmelblau_function_impl.hpp
+++ b/include/ensmallen_bits/problems/himmelblau_function_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't been included yet.
 #include "himmelblau_function.hpp"
-using namespace std;
 
 namespace ens {
 namespace test {
@@ -36,8 +35,8 @@ typename MatType::elem_type HimmelblauFunction::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType objective = pow(x1 * x1 + x2  - 11 , 2) +
-      pow(x1 + x2 * x2 - 7, 2);
+  const ElemType objective = std::pow(x1 * x1 + x2  - 11 , 2) +
+      std::pow(x1 + x2 * x2 - 7, 2);
   return objective;
 }
 

--- a/include/ensmallen_bits/problems/holder_table_function_impl.hpp
+++ b/include/ensmallen_bits/problems/holder_table_function_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't been included yet.
 #include "holder_table_function.hpp"
-using namespace std;
 
 namespace ens {
 namespace test {
@@ -36,8 +35,8 @@ typename MatType::elem_type HolderTableFunction::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType objective = - abs(sin(x1) * cos(x2) * exp(abs(1 -
-      (sqrt(x1 * x1 + x2 * x2) / arma::datum::pi))));
+  const ElemType objective = -std::abs(std::sin(x1) * std::cos(x2) *
+      std::exp(std::abs(1 - (std::sqrt(x1 * x1 + x2 * x2) / arma::datum::pi))));
 
   return objective;
 }

--- a/include/ensmallen_bits/problems/levy_function_n13_impl.hpp
+++ b/include/ensmallen_bits/problems/levy_function_n13_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't been included yet.
 #include "levy_function_n13.hpp"
-using namespace std;
 
 namespace ens {
 namespace test {
@@ -36,9 +35,11 @@ typename MatType::elem_type LevyFunctionN13::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType objective = pow(sin(3 * arma::datum::pi * x1), 2) +
-      (pow(x1 - 1, 2) * (1 + pow(sin(3 * arma::datum::pi * x2), 2))) +
-      (pow(x2 - 1, 2) * (1 + pow(sin(2 * arma::datum::pi * x2), 2)));
+  const ElemType objective = std::pow(std::sin(3 * arma::datum::pi * x1), 2) +
+      (std::pow(x1 - 1, 2) * (1 + std::pow(
+          std::sin(3 * arma::datum::pi * x2), 2))) +
+      (std::pow(x2 - 1, 2) * (1 + std::pow(
+          std::sin(2 * arma::datum::pi * x2), 2)));
 
   return objective;
 }
@@ -64,15 +65,15 @@ inline void LevyFunctionN13::Gradient(const MatType& coordinates,
   const ElemType x2 = coordinates(1);
   gradient.set_size(2, 1);
 
-  gradient(0) = (2 * x1 - 2) * (pow(sin(3 * arma::datum::pi * x2), 2) + 1) +
-    6 * arma::datum::pi * sin(3 * arma::datum::pi * x1) *
-    cos(3 * arma::datum::pi * x1);
+  gradient(0) = (2 * x1 - 2) * (std::pow(std::sin(3 * arma::datum::pi * x2),
+      2) + 1) + 6 * arma::datum::pi * std::sin(3 * arma::datum::pi * x1) *
+      std::cos(3 * arma::datum::pi * x1);
 
-  gradient(1) = 6 * arma::datum::pi * pow(x1 - 1, 2) * sin(3 *
-      arma::datum::pi * x2) * cos(3 * arma::datum::pi * x2) +
-      4 * arma::datum::pi * pow(x2 - 1, 2) * sin(2 *
-      arma::datum::pi * x2) * cos(2 * arma::datum::pi * x2) +
-      (2 * x2 - 2) * (pow(sin(2 * arma::datum::pi * x2), 2) + 1);
+  gradient(1) = 6 * arma::datum::pi * std::pow(x1 - 1, 2) * std::sin(3 *
+      arma::datum::pi * x2) * std::cos(3 * arma::datum::pi * x2) +
+      4 * arma::datum::pi * std::pow(x2 - 1, 2) * std::sin(2 *
+      arma::datum::pi * x2) * std::cos(2 * arma::datum::pi * x2) +
+      (2 * x2 - 2) * (std::pow(std::sin(2 * arma::datum::pi * x2), 2) + 1);
 }
 
 template<typename MatType, typename GradType>

--- a/include/ensmallen_bits/problems/schaffer_function_n2_impl.hpp
+++ b/include/ensmallen_bits/problems/schaffer_function_n2_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't been included yet.
 #include "schaffer_function_n2.hpp"
-using namespace std;
 
 namespace ens {
 namespace test {
@@ -36,8 +35,9 @@ typename MatType::elem_type SchafferFunctionN2::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType objective = 0.5 + (pow(sin(pow(x1, 2) -
-      pow(x2, 2)), 2) - 0.5) / pow(1 + 0.001 * (pow(x1, 2) + pow(x2, 2)), 2);
+  const ElemType objective = 0.5 + (std::pow(std::sin(std::pow(x1, 2) -
+      std::pow(x2, 2)), 2) - 0.5) / std::pow(1 + 0.001 *
+      (std::pow(x1, 2) + std::pow(x2, 2)), 2);
 
   return objective;
 }

--- a/include/ensmallen_bits/problems/schaffer_function_n4_impl.hpp
+++ b/include/ensmallen_bits/problems/schaffer_function_n4_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't been included yet.
 #include "schaffer_function_n4.hpp"
-using namespace std;
 
 namespace ens {
 namespace test {
@@ -36,8 +35,9 @@ typename MatType::elem_type SchafferFunctionN4::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType objective = 0.5 + (pow(cos(sin(abs(pow(x1, 2) -
-      pow(x2, 2)))), 2) - 0.5) / pow(1 + 0.001 * (pow(x1, 2) + pow(x2, 2)), 2);
+  const ElemType objective = 0.5 + (std::pow(std::cos(std::sin(std::abs(
+      std::pow(x1, 2) - std::pow(x2, 2)))), 2) - 0.5) / std::pow(1 + 0.001 *
+      (std::pow(x1, 2) + std::pow(x2, 2)), 2);
 
   return objective;
 }

--- a/include/ensmallen_bits/problems/three_hump_camel_function_impl.hpp
+++ b/include/ensmallen_bits/problems/three_hump_camel_function_impl.hpp
@@ -14,7 +14,6 @@
 
 // In case it hasn't been included yet.
 #include "three_hump_camel_function.hpp"
-using namespace std;
 
 namespace ens {
 namespace test {
@@ -37,8 +36,8 @@ typename MatType::elem_type ThreeHumpCamelFunction::Evaluate(
   const ElemType x1 = coordinates(0);
   const ElemType x2 = coordinates(1);
 
-  const ElemType objective = (2 * pow(x1, 2)) - (1.05 * pow(x1, 4)) +
-      (pow(x1, 6) / 6) + (x1 * x2) + pow(x2, 2);
+  const ElemType objective = (2 * std::pow(x1, 2)) - (1.05 * std::pow(x1, 4)) +
+      (std::pow(x1, 6) / 6) + (x1 * x2) + std::pow(x2, 2);
   return objective;
 }
 
@@ -63,7 +62,7 @@ inline void ThreeHumpCamelFunction::Gradient(const MatType& coordinates,
   const ElemType x2 = coordinates(1);
 
   gradient.set_size(2, 1);
-  gradient(0) = pow(x1, 5) - (4.2 * pow(x1, 3)) + (4 * x1) + x2;
+  gradient(0) = std::pow(x1, 5) - (4.2 * std::pow(x1, 3)) + (4 * x1) + x2;
   gradient(1) = x1 + (2 * x2);
 }
 

--- a/tests/pso_test.cpp
+++ b/tests/pso_test.cpp
@@ -15,6 +15,7 @@
 
 using namespace ens;
 using namespace ens::test;
+using namespace std;
 
 /**
  * Test the PSO optimizer on the Sphere Function.  Use arma::mat.


### PR DESCRIPTION
It made for a bit more `std::pow()`, `std::sin()`, etc., but anyway, now including anything in the `problems/` directory should not cause any problems for downstream code.  This fixes #146.