### PR TITLE
Lookahead - Synchronization period type fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?
 ###### ????-??-??
+  * Fix Lookahead Synchronization period type
+    ([#153](https://github.com/mlpack/ensmallen/pull/138)).
 
 ### ensmallen 2.11.0: "The Poster Session Is Full"
 ###### 2019-12-24

--- a/include/ensmallen_bits/lookahead/lookahead.hpp
+++ b/include/ensmallen_bits/lookahead/lookahead.hpp
@@ -156,9 +156,9 @@ class Lookahead
   double& StepSize() { return stepSize; }
 
   //! Get the synchronization period.
-  double K() const { return k; }
+  size_t K() const { return k; }
   //! Modify the synchronization period.
-  double& K() { return k; }
+  size_t& K() { return k; }
 
   //! Get the maximum number of iterations (0 indicates no limit).
   size_t MaxIterations() const { return maxIterations; }


### PR DESCRIPTION
The builds fails (gcc 9.2.1), if the return type is wrong.