### PR TITLE
Fix Callback passing for SGD based optimizers.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?
 ###### ????-??-??
+  * Allow callback instantiation for SGD based optimizer 
+    ([#138](https://github.com/mlpack/ensmallen/pull/155)).
 
 ### ensmallen 2.11.0: "The Poster Session Is Full"
 ###### 2019-12-24

--- a/include/ensmallen_bits/ada_bound/ada_bound.hpp
+++ b/include/ensmallen_bits/ada_bound/ada_bound.hpp
@@ -113,8 +113,9 @@ class AdaBoundType
            MatType& iterate,
            CallbackTypes&&... callbacks)
   {
-    return optimizer.template Optimize<DecomposableFunctionType, MatType, GradType,
-        CallbackTypes...>(function, iterate, callbacks...);
+    return optimizer.template Optimize<DecomposableFunctionType, MatType,
+        GradType, CallbackTypes...>(function, iterate,
+        std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/ada_delta/ada_delta.hpp
+++ b/include/ensmallen_bits/ada_delta/ada_delta.hpp
@@ -105,7 +105,8 @@ class AdaDelta
            CallbackTypes&&... callbacks)
   {
     return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
-        CallbackTypes...>(function, iterate, callbacks...);
+        CallbackTypes...>(function, iterate,
+        std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/ada_grad/ada_grad.hpp
+++ b/include/ensmallen_bits/ada_grad/ada_grad.hpp
@@ -101,7 +101,8 @@ class AdaGrad
            CallbackTypes&&... callbacks)
   {
     return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
-        CallbackTypes...>(function, iterate, callbacks...);
+        CallbackTypes...>(function, iterate,
+        std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/adam/adam.hpp
+++ b/include/ensmallen_bits/adam/adam.hpp
@@ -128,7 +128,7 @@ class AdamType
   {
     return optimizer.template Optimize<
         SeparableFunctionType, MatType, GradType, CallbackTypes...>(
-        function, iterate, callbacks...);
+        function, iterate, std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/ftml/ftml.hpp
+++ b/include/ensmallen_bits/ftml/ftml.hpp
@@ -105,7 +105,8 @@ class FTML
            CallbackTypes&&... callbacks)
   {
     return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
-        CallbackTypes...>(function, iterate, callbacks...);
+        CallbackTypes...>(function, iterate,
+        std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/padam/padam.hpp
+++ b/include/ensmallen_bits/padam/padam.hpp
@@ -113,7 +113,7 @@ class Padam
   {
     return optimizer.template Optimize<
         SeparableFunctionType, MatType, GradType, CallbackTypes...>(
-        function, iterate, callbacks...);
+        function, iterate, std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/qhadam/qhadam.hpp
+++ b/include/ensmallen_bits/qhadam/qhadam.hpp
@@ -107,7 +107,8 @@ class QHAdam
            CallbackTypes&&... callbacks)
   {
     return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
-        CallbackTypes...>(function, iterate, callbacks...);
+        CallbackTypes...>(function, iterate,
+        std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/rmsprop/rmsprop.hpp
+++ b/include/ensmallen_bits/rmsprop/rmsprop.hpp
@@ -116,7 +116,8 @@ class RMSProp
            CallbackTypes&&... callbacks)
   {
     return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
-        CallbackTypes...>(function, iterate, callbacks...);
+        CallbackTypes...>(function, iterate,
+        std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/smorms3/smorms3.hpp
+++ b/include/ensmallen_bits/smorms3/smorms3.hpp
@@ -101,7 +101,8 @@ class SMORMS3
     // TODO: disallow sp_mat
 
     return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
-        CallbackTypes...>(function, iterate, callbacks...);
+        CallbackTypes...>(function, iterate,
+        std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/swats/swats.hpp
+++ b/include/ensmallen_bits/swats/swats.hpp
@@ -105,7 +105,8 @@ class SWATS
            CallbackTypes&&... callbacks)
   {
     return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
-        CallbackTypes...>(function, iterate, callbacks...);
+        CallbackTypes...>(function, iterate,
+        std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/include/ensmallen_bits/wn_grad/wn_grad.hpp
+++ b/include/ensmallen_bits/wn_grad/wn_grad.hpp
@@ -94,7 +94,8 @@ class WNGrad
            CallbackTypes&&... callbacks)
   {
     return optimizer.Optimize<SeparableFunctionType, MatType, GradType,
-        CallbackTypes...>(function, iterate, callbacks...);
+        CallbackTypes...>(function, iterate,
+        std::forward<CallbackTypes>(callbacks)...);
   }
 
   //! Forward the MatType as GradType.

--- a/tests/callbacks_test.cpp
+++ b/tests/callbacks_test.cpp
@@ -152,6 +152,18 @@ void CallbacksFullFunctionTest(OptimizerType& optimizer,
   REQUIRE(cb.calledStepTaken == calledStepTaken);
 }
 
+
+/**
+ * Make sure we invoke all callbacks (AdaBound).
+ */
+TEST_CASE("AdaBoundCallbacksFullFunctionTest", "[CallbacksTest]")
+{
+  AdaBound optimizer(0.001, 2, 0.1, 1e-3, 0.9, 0.999, 1e-8, 1000,
+      1e-3, false);
+  CallbacksFullFunctionTest(optimizer, true, true, true, true, true, true,
+      false, false, true);
+}
+
 /**
  * Make sure we invoke all callbacks (AdaDelta).
  */
@@ -273,6 +285,47 @@ TEST_CASE("KatyushaCallbacksFullFunctionTest", "[CallbacksTest]")
 }
 
 /**
+ * Make sure we invoke all callbacks (Lookahead).
+ */
+TEST_CASE("LookaheadCallbacksFullFunctionTest", "[CallbacksTest]")
+{
+  Adam adam(0.001, 1, 0.9, 0.999, 1e-8, 100, 1e-10, false, true);
+  Lookahead<Adam> optimizer(adam, 0.5, 1000, 10, -10, NoDecay(),
+      false, true);
+  CallbacksFullFunctionTest(optimizer, true, true, true, true, true, true,
+      false, false, true);
+}
+
+/**
+ * Make sure we invoke all callbacks (Padam).
+ */
+TEST_CASE("PadamCallbacksFullFunctionTest", "[CallbacksTest]")
+{
+  Padam optimizer(1e-2, 1, 0.9, 0.99, 0.25, 1e-5, 1000);
+  CallbacksFullFunctionTest(optimizer, true, true, true, true, true, true,
+      false, false, true);
+}
+
+/**
+ * Make sure we invoke all callbacks (QHAdam).
+ */
+TEST_CASE("QHAdamCallbacksFullFunctionTest", "[CallbacksTest]")
+{
+  QHAdam optimizer(0.02, 2, 0.6, 0.9, 0.9, 0.999, 1e-8, 1000, 1e-7, true);
+  CallbacksFullFunctionTest(optimizer, true, true, true, true, true, true,
+      false, false, true);
+}
+
+/**
+ * Make sure we invoke all callbacks (RMSProp).
+ */
+TEST_CASE("RMSPropCallbacksFullFunctionTest", "[CallbacksTest]")
+{
+  RMSProp optimizer(1e-3, 1, 0.99, 1e-8, 1000, 1e-9, true);
+  CallbacksFullFunctionTest(optimizer, true, true, true, true, true, true,
+      false, false, true);
+}
+/**
  * Make sure we invoke all callbacks (SARAH).
  */
 TEST_CASE("SARAHCallbacksFullFunctionTest", "[CallbacksTest]")
@@ -313,6 +366,16 @@ TEST_CASE("SGDRCallbacksFullFunctionTest", "[CallbacksTest]")
 }
 
 /**
+ * Make sure we invoke all callbacks (SMORMS3).
+ */
+TEST_CASE("SMORMS3CallbacksFullFunctionTest", "[CallbacksTest]")
+{
+  SMORMS3 optimizer(0.001, 1, 1e-16, 1000, 1e-9, true);
+  CallbacksFullFunctionTest(optimizer, true, true, true, true, true, true,
+      false, false, true);
+}
+
+/**
  * Make sure we invoke all callbacks (SPALeRASGD).
  */
 TEST_CASE("SPALeRASGDCallbacksFullFunctionTest", "[CallbacksTest]")
@@ -339,6 +402,26 @@ TEST_CASE("SVRGCallbacksFullFunctionTest", "[CallbacksTest]")
 {
   SVRG optimizer(0.005, 2, 4, 0, 1e-5, true);
   CallbacksFullFunctionTest(optimizer, true, true, false, false, true, true,
+      false, false, true);
+}
+
+/**
+ * Make sure we invoke all callbacks (SWATS).
+ */
+TEST_CASE("SWATSCallbacksFullFunctionTest", "[CallbacksTest]")
+{
+  SWATS optimizer(0.01, 10, 0.9, 0.999, 1e-6, 1000, 1e-9, true);
+  CallbacksFullFunctionTest(optimizer, true, true, true, true, true, true,
+      false, false, true);
+}
+
+/**
+ * Make sure we invoke all callbacks (WNGrad).
+ */
+TEST_CASE("WNGradCallbacksFullFunctionTest", "[CallbacksTest]")
+{
+  WNGrad optimizer(0.56, 1, 1000, 1e-9, true);
+  CallbacksFullFunctionTest(optimizer, true, true, true, true, true, true,
       false, false, true);
 }
 
@@ -467,17 +550,15 @@ TEST_CASE("TimerStopCallbackTest", "[CallbacksTest]")
 {
   SGDTestFunction f;
   arma::mat coordinates = f.GetInitialPoint();
-
+  
   // Instantiate the optimizer with a number of iterations that will take a
   // long time to finish.
-  StandardSGD s(0.0003, 1, 2000000000, -100, true);
-
+  Adam opt(0.5, 2, 0.7, 0.999, 1e-8, 2000000000, -100, false);
   arma::wall_clock timer;
+  
   timer.tic();
-
   // The optimization process should return in one second.
-  s.Optimize(f, coordinates, TimerStop(0.5));
-
+  opt.Optimize(f, coordinates, TimerStop(0.5));
   // Add some time to account for the function to return.
   REQUIRE(timer.toc() < 2);
 }


### PR DESCRIPTION
This allows a user to a Callback with:

```c++
Optimize(..., ProgressBar());
```

instead of:


```c++
ProgressBar cb;
Optimize(..., cb);
```

which I thought already worked, but it turns out it only worked for optimizers that aren't based on another one, e.g. the `Adam` optimizer uses `SGD` as basis.