### PR TITLE
Fix float types and tolerances in some tests.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?
 ###### ????-??-??
+  * Minor test stability fixes on i386
+    ([#156](https://github.com/mlpack/ensmallen/pull/156)).
 
 ### ensmallen 2.11.1: "The Poster Session Is Full"
 ###### 2019-12-28

--- a/tests/lbfgs_test.cpp
+++ b/tests/lbfgs_test.cpp
@@ -47,11 +47,11 @@ TEST_CASE("RosenbrockFunctionFloatTest", "[LBFGSTest]")
   arma::fmat coords = f.GetInitialPoint<arma::fvec>();
   lbfgs.Optimize(f, coords);
 
-  double finalValue = f.Evaluate(coords);
+  float finalValue = f.Evaluate(coords);
 
-  REQUIRE(finalValue == Approx(0.0).margin(1e-5));
-  REQUIRE(coords(0) == Approx(1.0).epsilon(1e-7));
-  REQUIRE(coords(1) == Approx(1.0).epsilon(1e-7));
+  REQUIRE(finalValue == Approx(0.0f).margin(1e-3));
+  REQUIRE(coords(0) == Approx(1.0f).epsilon(1e-4));
+  REQUIRE(coords(1) == Approx(1.0f).epsilon(1e-4));
 }
 
 /**

--- a/tests/spsa_test.cpp
+++ b/tests/spsa_test.cpp
@@ -45,8 +45,8 @@ TEST_CASE("SPSASphereFunctionFMatTest", "[SPSATest]")
   arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
   optimizer.Optimize(f, coordinates);
 
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  REQUIRE(coordinates(0) == Approx(0.0f).margin(0.1));
+  REQUIRE(coordinates(1) == Approx(0.0f).margin(0.1));
 }
 
 /**


### PR DESCRIPTION
This comes out of the discussion of #142.  The issue being seen on some i386 tests is this:

```
-------------------------------------------------------------------------------
RosenbrockFunctionFloatTest
-------------------------------------------------------------------------------
/<<PKGBUILDDIR>>/tests/lbfgs_test.cpp:41
...............................................................................

/<<PKGBUILDDIR>>/tests/lbfgs_test.cpp:54: FAILED:
  REQUIRE( coords(1) == Approx(1.0).epsilon(1e-7) )
with expansion:
  1.0f == Approx( 1.0 )
```

This happens because the `epsilon()` is too small for `float`, and also it can't hurt to explicitly mark `1.0f` instead of `1.0`.  (However, that part's not totally necessary, so I only did it in a few places.)