### PR TITLE
Fix typo

### DIFF
--- a/include/ensmallen_bits/problems/schaffer_function_n2.hpp
+++ b/include/ensmallen_bits/problems/schaffer_function_n2.hpp
@@ -41,7 +41,7 @@ namespace test {
 class SchafferFunctionN2
 {
  public:
-  //! Initialize the SchafferFunctionN4.
+  //! Initialize the SchafferFunctionN2.
   SchafferFunctionN2();
 
   /**


### PR DESCRIPTION
Fix a typo in the comment for the constructor of Schaffer function N.2.