### PR TITLE
Fix Lookahead MaxIterations() check

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,9 @@
   * Minor test stability fixes on i386
     ([#156](https://github.com/mlpack/ensmallen/pull/156)).
 
+  * Fix Lookahead MaxIterations() check.
+    ([#159](https://github.com/mlpack/ensmallen/pull/159)).
+
 ### ensmallen 2.11.1: "The Poster Session Is Full"
 ###### 2019-12-28
   * Fix Lookahead Synchronization period type

--- a/include/ensmallen_bits/lookahead/lookahead.hpp
+++ b/include/ensmallen_bits/lookahead/lookahead.hpp
@@ -188,6 +188,31 @@ class Lookahead
   bool& ExactObjective() { return exactObjective; }
 
  private:
+  /**
+   * Set the maximum number of iterations if the given optimizer implements
+   * MaxIterations().
+   *
+   * @param optimizer Optimizer to check for MaxIterations().
+   * @param k The number of iterations.
+   */
+  template<typename OptimizerType>
+  static typename std::enable_if<traits::HasMaxIterationsSignature<
+      OptimizerType>::value, void>::type
+  SetMaxIterations(OptimizerType& optimizer, const size_t k)
+  {
+    optimizer.MaxIterations() = k;
+  }
+
+  template<typename OptimizerType>
+  static typename std::enable_if<!traits::HasMaxIterationsSignature<
+      OptimizerType>::value, void>::type
+  SetMaxIterations(const OptimizerType& /* optimizer */, const size_t /* k */)
+  {
+    Warn << "The base optimizer does not have a definition of "
+        << "MaxIterations(), the base optimizer will have its configuration "
+        << "unchanged.";
+  }
+
   //! The base optimizer for the forward step.
   BaseOptimizerType baseOptimizer;
 

--- a/include/ensmallen_bits/lookahead/lookahead_impl.hpp
+++ b/include/ensmallen_bits/lookahead/lookahead_impl.hpp
@@ -98,16 +98,7 @@ Lookahead<BaseOptimizerType, DecayPolicyType>::Optimize(
 
   // Check if the optimizer implements HasMaxIterations() and override the
   // parameter with k.
-  if (traits::HasMaxIterationsSignature<BaseOptimizerType>::value)
-  {
-    baseOptimizer.MaxIterations() = k;
-  }
-  else
-  {
-    Warn << "The base optimizer does not have a definition of "
-        << "MaxIterations(), the base optimizer will have its configuration "
-        << "unchanged.";
-  }
+  SetMaxIterations(baseOptimizer, k);
 
   // Check if the optimizer implements ResetPolicy() and override the reset
   // policy.


### PR DESCRIPTION
In the previous version each optimizer passed to Lookahead had to implement `MaxIterations()`.