### PR TITLE
Fix memory leak

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,8 +2,9 @@
 ###### ????-??-??
   * Prevent spurious compiler warnings
     ([#161](https://github.com/mlpack/ensmallen/pull/161)).
-  
-  * ...
+
+  * Fix minor memory leaks
+    ([#167](https://github.com/mlpack/ensmallen/pull/167)).
 
 ### ensmallen 2.11.2: "The Poster Session Is Full"
 ###### 2020-01-16

--- a/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd.hpp
@@ -101,6 +101,12 @@ class BigBatchSGD
               const double tolerance = 1e-5,
               const bool shuffle = true,
               const bool exactObjective = false);
+
+  /**
+   * Clean any memory associated with the BigBatchSGD object.
+   */
+  ~BigBatchSGD();
+
   /**
    * Optimize the given function using big-batch SGD.  The given starting point
    * will be modified to store the finishing point of the algorithm, and the

--- a/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
@@ -38,6 +38,12 @@ BigBatchSGD<UpdatePolicyType>::BigBatchSGD(
     updatePolicy(UpdatePolicyType())
 { /* Nothing to do. */ }
 
+template<typename UpdatePolicyType>
+BigBatchSGD<UpdatePolicyType>::~BigBatchSGD()
+{
+  instUpdatePolicy.Clean();
+}
+
 //! Optimize the function (minimize).
 template<typename UpdatePolicyType>
 template<typename SeparableFunctionType,

--- a/include/ensmallen_bits/lookahead/lookahead.hpp
+++ b/include/ensmallen_bits/lookahead/lookahead.hpp
@@ -109,6 +109,11 @@ class Lookahead
             const bool exactObjective = false);
 
   /**
+   * Clean any memory associated with the Lookahead object.
+   */
+  ~Lookahead();
+
+  /**
    * Optimize the given function using Lookahead. The given starting point will
    * be modified to store the finishing point of the algorithm, and the final
    * objective value is returned.

--- a/include/ensmallen_bits/lookahead/lookahead_impl.hpp
+++ b/include/ensmallen_bits/lookahead/lookahead_impl.hpp
@@ -60,6 +60,12 @@ inline Lookahead<BaseOptimizerType, DecayPolicyType>::Lookahead(
     isInitialized(false)
 { /* Nothing to do. */ }
 
+template<typename BaseOptimizerType, typename DecayPolicyType>
+inline Lookahead<BaseOptimizerType, DecayPolicyType>::~Lookahead()
+{
+  instDecayPolicy.Clean();
+}
+
 //! Optimize the function (minimize).
 template<typename BaseOptimizerType, typename DecayPolicyType>
 template<typename SeparableFunctionType,

--- a/include/ensmallen_bits/pso/pso.hpp
+++ b/include/ensmallen_bits/pso/pso.hpp
@@ -111,6 +111,14 @@ class PSOType
   { /* Nothing to do. */ }
 
   /**
+   * Clean memory associated with the PSO object.
+   */
+  ~PSOType()
+  {
+    instUpdatePolicy.Clean();
+  }
+
+  /**
    * Construct the particle swarm optimizer with the given function and
    * parameters. The defaults here are not necessarily good for the given
    * problem, so it is suggested that the values used be tailored to the task

--- a/include/ensmallen_bits/pso/pso_impl.hpp
+++ b/include/ensmallen_bits/pso/pso_impl.hpp
@@ -18,7 +18,9 @@
 #include <queue>
 
 namespace ens {
-/* After the velocity of each particle is updated at the end of each iteration
+
+/**
+ * After the velocity of each particle is updated at the end of each iteration
  * in PSO, the position of particle i (in iteration j) is updated as:
  *
  * \f[

--- a/include/ensmallen_bits/sdp/lrsdp_function.hpp
+++ b/include/ensmallen_bits/sdp/lrsdp_function.hpp
@@ -59,6 +59,11 @@ class LRSDPFunction
                 const arma::Mat<typename SDPType::ElemType>& initialPoint);
 
   /**
+   * Clean any memory associated with the LRSDPFunction.
+   */
+  ~LRSDPFunction();
+
+  /**
    * Evaluate the objective function of the LRSDP (no constraints) at the given
    * coordinates.
    */

--- a/include/ensmallen_bits/sdp/lrsdp_function_impl.hpp
+++ b/include/ensmallen_bits/sdp/lrsdp_function_impl.hpp
@@ -50,6 +50,12 @@ LRSDPFunction<SDPType>::LRSDPFunction(
 }
 
 template<typename SDPType>
+LRSDPFunction<SDPType>::~LRSDPFunction()
+{
+  rrt.Clean();
+}
+
+template<typename SDPType>
 template<typename MatType>
 typename MatType::elem_type LRSDPFunction<SDPType>::Evaluate(
     const MatType& /* coordinates */) const

--- a/include/ensmallen_bits/sgd/sgd.hpp
+++ b/include/ensmallen_bits/sgd/sgd.hpp
@@ -102,6 +102,11 @@ class SGD
       const bool exactObjective = false);
 
   /**
+   * Clean any memory associated with the SGD object.
+   */
+  ~SGD();
+
+  /**
    * Optimize the given function using stochastic gradient descent.  The given
    * starting point will be modified to store the finishing point of the
    * algorithm, and the final objective value is returned.

--- a/include/ensmallen_bits/sgd/sgd_impl.hpp
+++ b/include/ensmallen_bits/sgd/sgd_impl.hpp
@@ -44,6 +44,14 @@ SGD<UpdatePolicyType, DecayPolicyType>::SGD(
     isInitialized(false)
 { /* Nothing to do. */ }
 
+template<typename UpdatePolicyType, typename DecayPolicyType>
+SGD<UpdatePolicyType, DecayPolicyType>::~SGD()
+{
+  // Clean decay and update policies, if they were initialized.
+  instDecayPolicy.Clean();
+  instUpdatePolicy.Clean();
+}
+
 //! Optimize the function (minimize).
 template<typename UpdatePolicyType, typename DecayPolicyType>
 template<typename SeparableFunctionType,

--- a/include/ensmallen_bits/spalera_sgd/spalera_sgd.hpp
+++ b/include/ensmallen_bits/spalera_sgd/spalera_sgd.hpp
@@ -113,6 +113,11 @@ class SPALeRASGD
              const bool exactObjective = false);
 
   /**
+   * Clean any memory associated with the SPALeRA SGD object.
+   */
+  ~SPALeRASGD();
+
+  /**
    * Optimize the given function using SPALeRA SGD.  The given starting point
    * will be modified to store the finishing point of the algorithm, and the
    * final objective value is returned.

--- a/include/ensmallen_bits/spalera_sgd/spalera_sgd_impl.hpp
+++ b/include/ensmallen_bits/spalera_sgd/spalera_sgd_impl.hpp
@@ -45,6 +45,13 @@ SPALeRASGD<DecayPolicyType>::SPALeRASGD(const double stepSize,
     isInitialized(false)
 { /* Nothing to do. */ }
 
+template<typename DecayPolicyType>
+SPALeRASGD<DecayPolicyType>::~SPALeRASGD()
+{
+  instUpdatePolicy.Clean();
+  instDecayPolicy.Clean();
+}
+
 //! Optimize the function (minimize).
 template<typename DecayPolicyType>
 template<typename SeparableFunctionType,

--- a/include/ensmallen_bits/svrg/svrg.hpp
+++ b/include/ensmallen_bits/svrg/svrg.hpp
@@ -121,6 +121,11 @@ class SVRGType
            const bool exactObjective = false);
 
   /**
+   * Clean any memory associated with the SVRGType object.
+   */
+  ~SVRGType();
+
+  /**
    * Optimize the given function using SVRG. The given starting point will be
    * modified to store the finishing point of the algorithm, and the final
    * objective value is returned.

--- a/include/ensmallen_bits/svrg/svrg_impl.hpp
+++ b/include/ensmallen_bits/svrg/svrg_impl.hpp
@@ -42,6 +42,13 @@ SVRGType<UpdatePolicyType, DecayPolicyType>::SVRGType(
     isInitialized(false)
 { /* Nothing to do. */ }
 
+template<typename UpdatePolicyType, typename DecayPolicyType>
+SVRGType<UpdatePolicyType, DecayPolicyType>::~SVRGType()
+{
+  instUpdatePolicy.Clean();
+  instDecayPolicy.Clean();
+}
+
 //! Optimize the function (minimize).
 template<typename UpdatePolicyType, typename DecayPolicyType>
 template<typename SeparableFunctionType,


### PR DESCRIPTION
While using `valgrind` I noticed that the `instDecayPolicy` and `instUpdatePolicy` used by SGD actually aren't properly deallocated.  So this adds destructors to any optimizer that uses an `Any` internally, and that destructor calls `Clear()` to correctly free any allocated memory.

There are a few PRs now that have been merged since the last release, so I think we can do another release after this is merged.