### PR TITLE
Example doc fix + add/use default argument.

### DIFF
--- a/doc/function_types.md
+++ b/doc/function_types.md
@@ -1105,7 +1105,7 @@ int main()
   // Create simulated annealing optimizer with default options.
   // The ens::SA<> type can be replaced with any suitable ensmallen optimizer
   // that is able to handle arbitrary functions.
-  ens::L_BFGS<> optimizer;
+  ens::L_BFGS optimizer;
   SquaredFunction f; // Create function to be optimized.
   optimizer.Optimize(f, x); // The optimizer will infer arma::fmat!
 

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -554,11 +554,11 @@ RosenbrockFunction f;
 arma::mat coordinates = f.GetInitialPoint();
 
 // Big-Batch SGD with the adaptive stepsize policy.
-BBS_BB optimizer(batchSize, 0.01, 0.1, 8000, 1e-4);
+BBS_BB optimizer(10, 0.01, 0.1, 8000, 1e-4);
 optimizer.Optimize(f, coordinates);
 
 // Big-Batch SGD with backtracking line search.
-BBS_Armijo optimizer2(batchSize, 0.01, 0.1, 8000, 1e-4);
+BBS_Armijo optimizer2(10, 0.01, 0.1, 8000, 1e-4);
 optimizer2.Optimize(f, coordinates);
 ```
 
@@ -629,11 +629,11 @@ RosenbrockFunction f;
 arma::mat coordinates = f.GetInitialPoint();
 
 // CMAES with the FullSelection policy.
-CMAES<> optimizer(0, -1, 1, 32, 200, 0.1e-4);
+CMAES<> optimizer(0, -1, 1, 32, 200, 1e-4);
 optimizer.Optimize(f, coordinates);
 
 // CMAES with the RandomSelection policy.
-ApproxCMAES<> approxOptimizer(batchSize, 0.01, 0.1, 8000, 1e-4);
+ApproxCMAES<> approxOptimizer(0, -1, 1. 32, 200, 1e-4);
 approxOptimizer.Optimize(f, coordinates);
 ```
 
@@ -2068,7 +2068,7 @@ shorter type `SA<>` may be used instead of the equivalent
 
 | **type** | **name** | **description** | **default** |
 |----------|----------|-----------------|-------------|
-| `CoolingScheduleType` | **`coolingSchedule`** | Instantiated cooling schedule (default ExponentialSchedule). | **n/a** |
+| `CoolingScheduleType` | **`coolingSchedule`** | Instantiated cooling schedule (default ExponentialSchedule). | **CoolingScheduleType()** |
 | `size_t` | **`maxIterations`** | Maximum number of iterations allowed (0 indicates no limit). | `1000000` |
 | `double` | **`initT`** | Initial temperature. | `10000.0` |
 | `size_t` | **`initMoves`** | Number of initial iterations without changing temperature. | `1000` |

--- a/include/ensmallen_bits/sa/sa.hpp
+++ b/include/ensmallen_bits/sa/sa.hpp
@@ -73,7 +73,7 @@ class SA
    * @param initMoveCoef Initial move size.
    * @param gain Proportional control in feedback move control.
    */
-  SA(CoolingScheduleType& coolingSchedule,
+  SA(const CoolingScheduleType& coolingSchedule = CoolingScheduleType(),
      const size_t maxIterations = 1000000,
      const double initT = 10000.,
      const size_t initMoves = 1000,
@@ -101,6 +101,11 @@ class SA
   typename MatType::elem_type Optimize(FunctionType& function,
                                        MatType& iterate,
                                        CallbackTypes&&... callbacks);
+
+  //! Get the cooling schedule.
+  CoolingScheduleType CoolingSchedule() const { return coolingSchedule; }
+  //! Modify the cooling schedule.
+  CoolingScheduleType& CoolingSchedule() { return coolingSchedule; }
 
   //! Get the temperature.
   double Temperature() const { return temperature; }
@@ -139,7 +144,7 @@ class SA
 
  private:
   //! The cooling schedule being used.
-  CoolingScheduleType& coolingSchedule;
+  CoolingScheduleType coolingSchedule;
   //! The maximum number of iterations.
   size_t maxIterations;
   //! The current temperature.

--- a/include/ensmallen_bits/sa/sa_impl.hpp
+++ b/include/ensmallen_bits/sa/sa_impl.hpp
@@ -18,7 +18,7 @@ namespace ens {
 
 template<typename CoolingScheduleType>
 SA<CoolingScheduleType>::SA(
-    CoolingScheduleType& coolingSchedule,
+    const CoolingScheduleType& coolingSchedule,
     const size_t maxIterations,
     const double initT,
     const size_t initMoves,


### PR DESCRIPTION
There are some examples in the documentation that can't be copy/pasted, which is either because we didn't use the correct syntax or because some of the parameters are missing.