### PR TITLE
Change 'mathematical optimization' to 'numerical optimization'

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
+### ensmallen ?.??.?: "???"
+###### ????-??-??
+  * Change "mathematical optimization" term to "numerical optimization" in the
+    documentation ([#177](https://github.com/mlpack/ensmallen/pull/177)).
+
 ### ensmallen 2.11.4: "The Poster Session Is Full"
 ###### 2020-03-03
-
   * Require new HISTORY.md entry for each PR.
     ([#171](https://github.com/mlpack/ensmallen/pull/171),
      [#172](https://github.com/mlpack/ensmallen/pull/172),

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-**ensmallen** is a C++ header-only library for mathematical optimization.
+**ensmallen** is a C++ header-only library for numerical optimization.
 
 Documentation and downloads: http://ensmallen.org
 
 ensmallen provides a simple set of abstractions for writing an objective
 function to optimize. It also provides a large set of standard and cutting-edge
-optimizers that can be used for virtually any mathematical optimization task.
+optimizers that can be used for virtually any numerical optimization task.
 These include full-batch gradient descent techniques, small-batch techniques,
 gradient-free optimizers, and constrained optimization.
 


### PR DESCRIPTION
This better matches the existing literature and is likely to be less confusing to people who come across the term.

See also mlpack/ensmallen.org#10, and the tech report we're about to submit where we used this term instead of 'mathematical optimization'.