### PR TITLE
Better output if the optimization process gets terminated during the execution of an epoch.

### DIFF
--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -170,12 +170,12 @@ class ProgressBar
     {
       if (progress == (size_t)((double)(optimizer.MaxIterations()) /
                                 (double)(function.NumFunctions()) * 100) &&
-                      (int)(step * optimizer.BatchSize() -
+                      (int)(steps * optimizer.BatchSize() -
                       optimizer.MaxIterations()) >= 0)
       {
         output << "\n" << "Optimization terminated because of the entire "
                        << "dataset not being passed to the optimizer."
-                       << "\r";
+                       << "\n" << "\r";
       }
     }
 

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -183,7 +183,7 @@ class ProgressBar
           }
           else if (i == progress)
           {
-            output << ">";
+            output << "|";
           }
           else
           {

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -132,8 +132,8 @@ class ProgressBar
    * @param objective Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void StepTaken(OptimizerType& /* optimizer */,
-                 FunctionType& /* function */,
+  void StepTaken(OptimizerType& optimizer,
+                 FunctionType& function,
                  const MatType& /* coordinates */)
   {
     if (newEpoch)
@@ -164,8 +164,22 @@ class ProgressBar
     output << "] " << progress << "% - ETA: " << (size_t) stepTimer.toc() *
         (epochSize - step + 1) % 60 << "s - loss: " <<
         objective / (double) step <<  "\r";
-    output.flush();
 
+    if (optimizer.MaxIterations() < function.NumFunctions() &&
+        optimizer.MaxIterations() != 0)
+    {
+      if (progress == (size_t)((double)(optimizer.MaxIterations()) /
+                                (double)(function.NumFunctions()) * 100) &&
+                      (double)(step*optimizer.BatchSize() -
+                      optimizer.MaxIterations()) >= 0.0)
+      {
+        output << "\n" << "Optimization terminated because of the entire "
+                       << "dataset not being passed to the optimizer."
+                       << "\r";
+      }
+    }
+
+    output.flush();
     stepTimer.tic();
   }
 

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -170,7 +170,7 @@ class ProgressBar
     {
       if (progress == (size_t)((double)(optimizer.MaxIterations()) /
                                 (double)(function.NumFunctions()) * 100) &&
-                      (int)(step*optimizer.BatchSize() -
+                      (int)(step * optimizer.BatchSize() -
                       optimizer.MaxIterations()) >= 0)
       {
         output << "\n" << "Optimization terminated because of the entire "

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -170,8 +170,8 @@ class ProgressBar
     {
       if (progress == (size_t)((double)(optimizer.MaxIterations()) /
                                 (double)(function.NumFunctions()) * 100) &&
-                      (double)(step*optimizer.BatchSize() -
-                      optimizer.MaxIterations()) >= 0.0)
+                      (int)(step*optimizer.BatchSize() -
+                      optimizer.MaxIterations()) >= 0)
       {
         output << "\n" << "Optimization terminated because of the entire "
                        << "dataset not being passed to the optimizer."

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -173,9 +173,30 @@ class ProgressBar
                       (int)(steps * optimizer.BatchSize() -
                       optimizer.MaxIterations()) >= 0)
       {
-        output << "\n" << "Optimization terminated because of the entire "
-                       << "dataset not being passed to the optimizer."
-                       << "\n" << "\r";
+        const size_t progress = ((double) step / epochSize) * 100;
+        output << step++ << "/" << epochSize << " [";
+        for (size_t i = 0; i < 100; i += width)
+        {
+          if (i < progress)
+          {
+            output << "=";
+          }
+          else if (i == progress)
+          {
+            output << ">";
+          }
+          else
+          {
+            output << "x";
+          }
+        }
+
+        output << "] " << progress << "% - ETA: " << (size_t) stepTimer.toc() *
+            (epochSize - step + 1) % 60 << "s - loss: " <<
+            objective / (double) step <<  "\r";
+        output << "\n" << "Optimization finished before the end of an epoch "
+                       << "because of the entire dataset not being passed to "
+                       << "the optimizer." << "\n" << "\r";
       }
     }
 

--- a/include/ensmallen_bits/cmaes/cmaes.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes.hpp
@@ -21,7 +21,7 @@
 namespace ens {
 
 /**
- * CMA-ES - Covariance Matrix Adaptation Evolution Strategy is s a stochastic
+ * CMA-ES - Covariance Matrix Adaptation Evolution Strategy is a stochastic
  * search algorithm. CMA-ES is a second order approach estimating a positive
  * definite matrix within an iterative procedure using the covariance matrix.
  *

--- a/include/ensmallen_bits/sgd/sgd.hpp
+++ b/include/ensmallen_bits/sgd/sgd.hpp
@@ -25,7 +25,7 @@ namespace ens {
 
 /**
  * Stochastic Gradient Descent is a technique for minimizing a function which
- * can be expressed as a sum of other functions.  That is, suppose we have
+ * can be expressed as a sum of other functions. That is, suppose we have
  *
  * \f[
  * f(A) = \sum_{i = 0}^{n} f_i(A)

--- a/include/ensmallen_bits/sgd/sgd.hpp
+++ b/include/ensmallen_bits/sgd/sgd.hpp
@@ -25,7 +25,7 @@ namespace ens {
 
 /**
  * Stochastic Gradient Descent is a technique for minimizing a function which
- * can be expressed as a sum of other functions. That is, suppose we have
+ * can be expressed as a sum of other functions.  That is, suppose we have
  *
  * \f[
  * f(A) = \sum_{i = 0}^{n} f_i(A)


### PR DESCRIPTION
- Issue reference #150 
Earlier if the entire dataset was not passed to the optimizer the output used to be like
```
Epoch 1/54
1563/1875 [===================================================================================>................] 83% - ETA: 0s - loss: 249.826
```

After the feature which has been implemented in this pull request the output is like
```
Epoch 1/54
1562/1875 [===================================================================================>................] 83% - ETA: 0s - loss: 249.985
1563/1875 [===================================================================================>................] 83% - ETA: 0s - loss: 249.826
Optimization terminated because of the entire dataset not being passed to the optimizer.
```

As it can be seen that there is an improvement in the output shown but if there is any way if the progress bar is shown only once rather than being shown twice as it can be seen from the above-pasted output kindly suggest it. Thanks.