### PR TITLE
Update release scripts

### DIFF
--- a/scripts/ensmallen-release.sh
+++ b/scripts/ensmallen-release.sh
@@ -63,7 +63,6 @@ fi
 
 # Make sure 'gh' is installed.
 hub_output="`which hub`" || true;
-echo "hub output is $hub_output";
 if [ "a$hub_output" == "a" ]; then
   echo "The Hub command-line tool must be installed for this script to run" \
       "successfully.";

--- a/scripts/ensmallen-release.sh
+++ b/scripts/ensmallen-release.sh
@@ -3,66 +3,160 @@
 # Release a new version of ensmallen.
 #
 # Arguments:
-#   $ ensmallen-release.sh <major> <minor> <patch> [<name>]
+#   $ ensmallen-release.sh <github username> <major> <minor> <patch> [<name>]
 #
 # This should be run from the root of the repository.
-#
-# Make sure to update HISTORY.md manually first!
 set -e
 
-if [ "$#" -lt 3 ]; then
-  echo "At least three arguments required!";
-  echo "$ ensmallen-release.sh <major> <minor> <patch> [<name>]";
+if [ "$#" -lt 4 ]; then
+  echo "At least four arguments required!";
+  echo "$ ensmallen-release.sh <github username> <major> <minor> <patch>" \
+      "[<name>]";
   exit 1;
 fi
 
-if [ "$#" -gt 4 ]; then
-  echo "Too many arguments!"
-  echo "$ ensmallen-release.sh <major> <minor> <patch> [<name>]";
+if [ "$#" -gt 5 ]; then
+  echo "Too many arguments!";
+  echo "$ ensmallen-release.sh <github username> <major> <minor> <patch>" \
+      "[<name>]";
   exit 1;
 fi
 
+# Make sure that the branch is clean.
 lines=`git diff | wc -l`;
 if [ "$lines" != "0" ]; then
-  echo "git diff returned a nonzero result!"
-  git diff
+  echo "git diff returned a nonzero result!";
+  echo "";
+  git diff;
   exit 1;
 fi
 
-MAJOR=$1;
-MINOR=$2;
-PATCH=$3;
+# Make sure that the mlpack repository exists.
+dest_remote_name=`git remote -v |\
+                  grep "https://github.com/mlpack/ensmallen (fetch)" |\
+                  head -1 |\
+                  awk -F' ' '{ print $1 }'`;
 
-sed -i 's/ENS_VERSION_MAJOR[ ]*[0-9]*$/ENS_VERSION_MAJOR '$MAJOR'/' include/ensmallen_bits/ens_version.hpp;
-sed -i 's/ENS_VERSION_MINOR[ ]*[0-9]*$/ENS_VERSION_MINOR '$MINOR'/' include/ensmallen_bits/ens_version.hpp;
-sed -i 's/ENS_VERSION_PATCH[ ]*[0-9]*$/ENS_VERSION_PATCH '$PATCH'/' include/ensmallen_bits/ens_version.hpp;
-
-if [ "$#" -eq "4" ]; then
-  sed -i 's/ENS_VERSION_NAME[ ]*\".*\"$/ENS_VERSION_NAME \"'"$4"'\"/' include/ensmallen_bits/ens_version.hpp;
+if [ "a$dest_remote_name" == "a" ]; then
+  echo "No git remote found for https://github.com/mlpack/ensmallen!";
+  echo "Make sure that you've got the ensmallen repository as a remote, and" \
+      "that the master branch from that remote is checked out.";
+  echo "You can do this with a fresh repository via \`git clone" \
+      "https://github.com/mlpack/ensmallen\`.";
+  exit 1;
 fi
 
-# update CONTRIBUTING.md
-sed -i "s/ensmallen-[0-9]*\.[0-9]*\.[0-9]*/ensmallen-$MAJOR.$MINOR.$PATCH/g" CONTRIBUTING.md;
+# Also check that we're on the master branch, from the correct origin.
+current_branch=`git branch --no-color | grep '^\* ' | awk -F' ' '{ print $2 }'`;
+current_origin=`git rev-parse --abbrev-ref --symbolic-full-name @{u} |\
+                awk -F'/' '{ print $1 }'`;
+if [ "a$current_branch" != "amaster" ]; then
+  echo "Current branch is $current_branch."
+  echo "This script has to be run from the master branch."
+  exit 1;
+elif [ "a$current_origin" != "a$dest_remote_name" ]; then
+  echo "Current branch does not track from remote mlpack repository!";
+  echo "Instead, it tracks from $current_origin/master.";
+  echo "Make sure to check out a branch that tracks $dest_remote_name/master.";
+  exit 1;
+fi
 
-git pull
+# Make sure 'gh' is installed.
+hub_output="`which hub`" || true;
+echo "hub output is $hub_output";
+if [ "a$hub_output" == "a" ]; then
+  echo "The Hub command-line tool must be installed for this script to run" \
+      "successfully.";
+  echo "See https://hub.github.com for more details and installation" \
+      "instructions.";
+  echo "";
+  echo "(apt-get install hub on Debian and Ubuntu)";
+  echo "(brew install hub via Homebrew)";
+  exit 1;
+fi
+
+# Check git remotes: we need to make sure we have a fork to push to.
+github_user=$1;
+remote_name=`git remote -v |\
+             grep "https://github.com/$github_user/ensmallen (push)" |\
+             head -1 |\
+             awk -F' ' '{ print $1 }'`;
+if [ "a$remote_name" == "a" ]; then
+  echo "No git remote found for https://github.com/$github_user/ensmallen!";
+  echo "Adding remote '$github_user'.";
+  git remote add $github_user https://github.com/$github_user/ensmallen;
+  remote_name="$github_user";
+fi
+git fetch $github_user;
+
+# Make sure everything is up to date.
+git pull;
+
+# Make updates to files that will be needed for the release.
+MAJOR=$2;
+MINOR=$3;
+PATCH=$4;
+
+sed -i 's/ENS_VERSION_MAJOR[ ]*[0-9]*$/ENS_VERSION_MAJOR '$MAJOR'/' \
+    include/ensmallen_bits/ens_version.hpp;
+sed -i 's/ENS_VERSION_MINOR[ ]*[0-9]*$/ENS_VERSION_MINOR '$MINOR'/' \
+    include/ensmallen_bits/ens_version.hpp;
+sed -i 's/ENS_VERSION_PATCH[ ]*[0-9]*$/ENS_VERSION_PATCH '$PATCH'/' \
+    include/ensmallen_bits/ens_version.hpp;
+
+if [ "$#" -eq "5" ]; then
+  sed -i 's/ENS_VERSION_NAME[ ]*\".*\"$/ENS_VERSION_NAME \"'"$5"'\"/' \
+      include/ensmallen_bits/ens_version.hpp;
+fi
+
+# Update CONTRIBUTING.md.
+sed -i "s/ensmallen-[0-9]*\.[0-9]*\.[0-9]*/ensmallen-$MAJOR.$MINOR.$PATCH/g" \
+    CONTRIBUTING.md;
+
+# Update HISTORY.md with the release date and possibly name.
+version_name=`grep ENS_VERSION_NAME include/ensmallen_bits/ens_version.hpp |\
+              head -1 |\
+              sed 's/.*\"\(.*\)\"/\1/'`;
+year=`date +%Y`;
+month=`date +%m`;
+day=`date +%d`;
+new_line="ensmallen $MAJOR.$MINOR.$PATCH: \"$version_name\"";
+sed -i "s/### ensmallen ?.??.?: \"???\"/### $new_line/" HISTORY.md;
+sed -i "s/###### ????-??-??/###### $year-$month-$day/" HISTORY.md;
+
+# Now, we'll do all this on a new release branch.
+git checkout -b release-$MAJOR.$MINOR.$PATCH;
+
 git add include/ensmallen_bits/ens_version.hpp;
-git add CONTRIBUTING.md
+git add CONTRIBUTING.md;
+git add HISTORY.md;
 git commit -m "Update and release version $MAJOR.$MINOR.$PATCH.";
-git tag $MAJOR.$MINOR.$PATCH;
-git push origin $MAJOR.$MINOR.$PATCH;
-git push origin master;
 
-git clone https://github.com/mlpack/ensmallen.org /tmp/ensmallen.org/;
-git archive --prefix=ensmallen-$MAJOR.$MINOR.$PATCH/ $MAJOR.$MINOR.$PATCH | gzip > /tmp/ensmallen.org/files/ensmallen-$MAJOR.$MINOR.$PATCH.tar.gz;
-cd /tmp/ensmallen.org/;
-git add files/ensmallen-$MAJOR.$MINOR.$PATCH.tar.gz;
-cd files/;
-rm ensmallen-latest.tar.gz;
-ln -s ensmallen-$MAJOR.$MINOR.$PATCH.tar.gz ensmallen-latest.tar.gz;
-cd ../
-git add files/ensmallen-latest.tar.gz;
-git commit -m "Release version $MAJOR.$MINOR.$PATCH.";
-git push origin;
-cd -
+# Add one more commit to create the new HISTORY block.
+echo "### ensmallen ?.??.?: \"???\"" > HISTORY.md.new;
+echo "###### ????-??-??" >> HISTORY.md.new;
+echo "" >> HISTORY.md.new;
+cat HISTORY.md >> HISTORY.md.new;
+mv HISTORY.md.new HISTORY.md;
+git add HISTORY.md;
+git commit -m "Add new block for next release to HISTORY.md.";
 
-rm -rf /tmp/ensmallen.org;
+# Push to new branch.
+git push --set-upstream $github_user release-$MAJOR.$MINOR.$PATCH;
+
+# Next, we have to actually open the PR for the release.  These lines would be
+# hard to wrap so they are longer than the length limit. :)
+hub pull-request \
+    -b mlpack:master \
+    -h $github_user:release-$MAJOR.$MINOR.$PATCH \
+    -m "Release version $MAJOR.$MINOR.$PATCH" \
+    -m "This automatically-generated pull request adds the commits necessary to make the $MAJOR.$MINOR.$PATCH release." \
+    -m "Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it." \
+    -m "Or, well, hopefully that will happen someday." \
+    -l "t: release"
+
+echo "";
+echo "Switching back to 'master' branch.";
+echo "If you want to access the release branch again, use \`git checkout" \
+    "release-$MAJOR.$MINOR.$PATCH\`.";
+exit 0;

--- a/scripts/update-website-after-release.sh
+++ b/scripts/update-website-after-release.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# This script is used to update the website after a release is made.  Push
+# access to the ensmallen.org website is needed.  Generally, this script will be
+# run by mlpack-bot, so it never needs to be run by hand.
+#
+# Usage: update-website.sh <major> <minor> <patch>
+
+# Make sure that the mlpack repository exists.
+dest_remote_name=`git remote -v |\
+                  grep "https://github.com/mlpack/ensmallen (fetch)" |\
+                  head -1 |\
+                  awk -F' ' '{ print $1 }'`;
+
+if [ "a$dest_remote_name" == "a" ]; then
+  echo "No git remote found for https://github.com/mlpack/ensmallen!";
+  echo "Make sure that you've got the ensmallen repository as a remote, and" \
+      "that the master branch from that remote is checked out.";
+  echo "You can do this with a fresh repository via \`git clone" \
+      "https://github.com/mlpack/ensmallen\`.";
+  exit 1;
+fi
+
+# Update the checked out repository, so that we can get the tags.
+git fetch $dest_remote_name;
+
+# Check out a copy of the ensmallen.org repository.
+git clone https://github.com/mlpack/ensmallen.org /tmp/ensmallen.org/;
+
+# Create the release file.
+git archive --prefix=ensmallen-$MAJOR.$MINOR.$PATCH/ $MAJOR.$MINOR.$PATCH |\
+    gzip > /tmp/ensmallen.org/files/ensmallen-$MAJOR.$MINOR.$PATCH.tar.gz;
+
+# Now update the website.
+wd=`pwd`;
+cd /tmp/ensmallen.org/;
+git add files/ensmallen-$MAJOR.$MINOR.$PATCH.tar.gz;
+
+# Update the link to the latest version.
+cd files/;
+rm ensmallen-latest.tar.gz;
+ln -s ensmallen-$MAJOR.$MINOR.$PATCH.tar.gz ensmallen-latest.tar.gz;
+cd ../
+
+git add files/ensmallen-latest.tar.gz;
+git commit -m "Release version $MAJOR.$MINOR.$PATCH.";
+
+# Finally, push, and we're done.
+git push origin;
+cd $wd;
+
+rm -rf /tmp/ensmallen.org;


### PR DESCRIPTION
I noticed in #185 that @favre49 wasn't able to push any extra commits during merge, and I ended up with a better understanding of Github branch protection permissions.  Anyway, what it means is that folks in the Contributors team can't push directly to `master` (and now, neither can I, I shouldn't have been able to to begin with given my propensity for typing before thinking :smile:), and so the release scripts have to be updated.

Here's the new idea for the workflow:

1. Anyone (actually even including folks not on the Contributors team) can run the `scripts/ensmallen-release.sh` script, like this:

```
$ scripts/ensmallen-release.sh rcurtin 2 13 0 "New Release Name"
```

(The Github username is necessary so that it's known where the fork is.)  This script will create a new branch in the given user's fork (i.e., `rcurtin/ensmallen:release-2.13.0` in the example), and automatically open a PR for that release.  The PR will actually include one *extra* commit to create a new HISTORY block.  These PRs will look exactly like this: #191 and will be tagged `t: release`.

2. Once that PR is approved and merged, @mlpack-bot will tag the release and automatically push a new release to Github.  @mlpack-bot will also run the `update-website-after-release.sh` script to push any changes to the website (which is then rebuilt and deployed by Jenkins).

Anyway, this is a much easier and more automatic process than before.  I wonder if I should make a *second* bot so we can quickly and automatically get two reviews for these automatic PRs, but maybe having a human do sanity checks here isn't a bad thing.  It shouldn't take more than 30 seconds to review anyway. :)  (I do think that I'll have mlpack-bot automatically approve immediately if the PR was opened by someone on the Contributors team.)

I still have some amount of homework to do: I need to implement the mlpack-bot code.  But since I don't want to release over and over and over again while I debug, I'll just do it iteratively, and each time it fails I'll just do the `git tag` and `update-website-after-release.sh` myself, which is easy enough.