### PR TITLE
Fix cmake package export.

### DIFF
--- a/CMake/ensmallen-config.cmake.in
+++ b/CMake/ensmallen-config.cmake.in
@@ -1,4 +1,4 @@
 @PACKAGE_INIT@
 
-include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake)
 check_required_components(ensmallen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,9 @@ target_include_directories(ensmallen INTERFACE
 
 # Set warning flags for target.
 if(MSVC)
-  target_compile_options(ensmallen INTERFACE /Wall )
+  target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:/Wall>)
 else()
-  target_compile_options(ensmallen INTERFACE -Wall -Wpedantic -Wunused-parameter)
+  target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:-Wall -Wpedantic -Wunused-parameter>)
 endif()
 
 # Find OpenMP and link it.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Fix CMake package export
+    ([#198](https://github.com/mlpack/ensmallen/pull/198)).
 
 ### ensmallen 2.12.1: "Stir Crazy"
 ###### 2020-04-20


### PR DESCRIPTION
Just some minor fixes for cmake package export:

 * Fix spelling mistake introduced in 369046f
 * Don't export compiler warning flags to interface.