### PR TITLE
Fix constrained optimizer documentation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,12 @@
  * Fix CMake package export
     ([#198](https://github.com/mlpack/ensmallen/pull/198)).
 
+ * Clarify and fix documentation for constrained optimizers
+    ([#201](https://github.com/mlpack/ensmallen/pull/201)).
+
+ * Fix L-BFGS convergence when starting from a minimum
+    ([#201](https://github.com/mlpack/ensmallen/pull/201)).
+
 ### ensmallen 2.12.1: "Stir Crazy"
 ###### 2020-04-20
  * Fix total number of epochs and time estimation for ProgressBar callback

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -424,7 +424,7 @@ optimizer uses [L-BFGS](#l-bfgs).
 
 #### Constructors
 
- * `AugLagrangian(`_`maxIterations, penaltyThresholdFactor sigmaUpdateFactor`_`)`
+ * `AugLagrangian(`_`maxIterations, penaltyThresholdFactor, sigmaUpdateFactor`_`)`
 
 #### Attributes
 

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
@@ -134,6 +134,7 @@ AugLagrangian::Optimize(
     if (!lbfgs.Optimize(augfunc, coordinates, callbacks...))
       Info << "L-BFGS reported an error during optimization."
           << std::endl;
+    Info << "Done with L-BFGS: " << coordinates << "\n";
 
     const ElemType objective = function.Evaluate(coordinates);
 

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
@@ -27,7 +27,8 @@ inline AugLagrangian::AugLagrangian(const size_t maxIterations,
     penaltyThresholdFactor(penaltyThresholdFactor),
     sigmaUpdateFactor(sigmaUpdateFactor),
     lbfgs(lbfgs),
-    terminate(false)
+    terminate(false),
+    sigma(0.0)
 {
 }
 

--- a/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
+++ b/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
@@ -114,10 +114,8 @@ void L_BFGS::SearchDirection(const MatType& gradient,
                              const CubeType& y,
                              MatType& searchDirection)
 {
-  std::cout << "SearchDirection(): \n";
   // Start from this point.
   searchDirection = gradient;
-  std::cout << " - searchDirection " << searchDirection;
 
   // See "A Recursive Formula to Compute H * g" in "Updating quasi-Newton
   // matrices with limited storage" (Nocedal, 1980).
@@ -128,29 +126,20 @@ void L_BFGS::SearchDirection(const MatType& gradient,
   arma::Col<CubeElemType> alpha(numBasis);
 
   size_t limit = (numBasis > iterationNum) ? 0 : (iterationNum - numBasis);
-  std::cout << "limit: " << limit << "\n";
   for (size_t i = iterationNum; i != limit; i--)
   {
-    std::cout << "iteration: " << i << "\n";
     int translatedPosition = (i + (numBasis - 1)) % numBasis;
     rho[iterationNum - i] = 1.0 / arma::dot(y.slice(translatedPosition),
                                             s.slice(translatedPosition));
-    std::cout << "relevant y: " << y.slice(translatedPosition);
-    std::cout << "relevant s: " << s.slice(translatedPosition);
     alpha[iterationNum - i] = rho[iterationNum - i] *
         arma::dot(s.slice(translatedPosition), searchDirection);
-    std::cout << "rho: " << rho[iterationNum - i] << "\n";
-    std::cout << "alpha: " << alpha[iterationNum - i] << "\n";
     searchDirection -= alpha[iterationNum - i] * y.slice(translatedPosition);
   }
 
-  std::cout << "scaling factor: " << scalingFactor << "\n";
   searchDirection *= scalingFactor;
 
   for (size_t i = limit; i < iterationNum; i++)
   {
-    std::cout << "iteration 2 " << i << ", iterationNum " << iterationNum <<
-"\n";
     int translatedPosition = i % numBasis;
     double beta = rho[iterationNum - i - 1] *
         arma::dot(y.slice(translatedPosition), searchDirection);
@@ -160,7 +149,6 @@ void L_BFGS::SearchDirection(const MatType& gradient,
 
   // Negate the search direction so that it is a descent direction.
   searchDirection *= -1;
-  std::cout << "after negation: " << searchDirection << "\n";
 }
 
 /**
@@ -256,10 +244,8 @@ bool L_BFGS::LineSearch(FunctionType& function,
 
   while (true)
   {
-    std::cout << "line search, step size " << stepSize << "\n";
     // Perform a step and evaluate the gradient and the function values at that
     // point.
-    std::cout << "lbfgs search direction: " << searchDirection << "\n";
     newIterateTmp = iterate;
     newIterateTmp += stepSize * searchDirection;
     functionValue = function.EvaluateWithGradient(newIterateTmp, gradient);
@@ -317,10 +303,7 @@ bool L_BFGS::LineSearch(FunctionType& function,
   }
 
   // Move to the new iterate.
-  std::cout << "search direction: " << searchDirection << "\nbest step size: "
-<< bestStepSize << "\n";
   iterate += bestStepSize * searchDirection;
-  std::cout << "new iterate: " << iterate << "\n";
   finalStepSize = bestStepSize;
   return true;
 }
@@ -410,8 +393,7 @@ L_BFGS::Optimize(FunctionType& function,
     //
     // But don't do this on the first iteration to ensure we always take at
     // least one descent step.
-    if ((itNum > 0 && (arma::norm(gradient, 2) < minGradientNorm)) ||
-        arma::norm(gradient, 2) == 0)
+    if (arma::norm(gradient, 2) < minGradientNorm)
     {
       Info << "L-BFGS gradient norm too small (terminating successfully)."
           << std::endl;

--- a/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
+++ b/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
@@ -114,8 +114,10 @@ void L_BFGS::SearchDirection(const MatType& gradient,
                              const CubeType& y,
                              MatType& searchDirection)
 {
+  std::cout << "SearchDirection(): \n";
   // Start from this point.
   searchDirection = gradient;
+  std::cout << " - searchDirection " << searchDirection;
 
   // See "A Recursive Formula to Compute H * g" in "Updating quasi-Newton
   // matrices with limited storage" (Nocedal, 1980).
@@ -126,20 +128,29 @@ void L_BFGS::SearchDirection(const MatType& gradient,
   arma::Col<CubeElemType> alpha(numBasis);
 
   size_t limit = (numBasis > iterationNum) ? 0 : (iterationNum - numBasis);
+  std::cout << "limit: " << limit << "\n";
   for (size_t i = iterationNum; i != limit; i--)
   {
+    std::cout << "iteration: " << i << "\n";
     int translatedPosition = (i + (numBasis - 1)) % numBasis;
     rho[iterationNum - i] = 1.0 / arma::dot(y.slice(translatedPosition),
                                             s.slice(translatedPosition));
+    std::cout << "relevant y: " << y.slice(translatedPosition);
+    std::cout << "relevant s: " << s.slice(translatedPosition);
     alpha[iterationNum - i] = rho[iterationNum - i] *
         arma::dot(s.slice(translatedPosition), searchDirection);
+    std::cout << "rho: " << rho[iterationNum - i] << "\n";
+    std::cout << "alpha: " << alpha[iterationNum - i] << "\n";
     searchDirection -= alpha[iterationNum - i] * y.slice(translatedPosition);
   }
 
+  std::cout << "scaling factor: " << scalingFactor << "\n";
   searchDirection *= scalingFactor;
 
   for (size_t i = limit; i < iterationNum; i++)
   {
+    std::cout << "iteration 2 " << i << ", iterationNum " << iterationNum <<
+"\n";
     int translatedPosition = i % numBasis;
     double beta = rho[iterationNum - i - 1] *
         arma::dot(y.slice(translatedPosition), searchDirection);
@@ -149,6 +160,7 @@ void L_BFGS::SearchDirection(const MatType& gradient,
 
   // Negate the search direction so that it is a descent direction.
   searchDirection *= -1;
+  std::cout << "after negation: " << searchDirection << "\n";
 }
 
 /**
@@ -244,8 +256,10 @@ bool L_BFGS::LineSearch(FunctionType& function,
 
   while (true)
   {
+    std::cout << "line search, step size " << stepSize << "\n";
     // Perform a step and evaluate the gradient and the function values at that
     // point.
+    std::cout << "lbfgs search direction: " << searchDirection << "\n";
     newIterateTmp = iterate;
     newIterateTmp += stepSize * searchDirection;
     functionValue = function.EvaluateWithGradient(newIterateTmp, gradient);
@@ -303,7 +317,10 @@ bool L_BFGS::LineSearch(FunctionType& function,
   }
 
   // Move to the new iterate.
+  std::cout << "search direction: " << searchDirection << "\nbest step size: "
+<< bestStepSize << "\n";
   iterate += bestStepSize * searchDirection;
+  std::cout << "new iterate: " << iterate << "\n";
   finalStepSize = bestStepSize;
   return true;
 }
@@ -385,13 +402,16 @@ L_BFGS::Optimize(FunctionType& function,
   for (size_t itNum = 0; (optimizeUntilConvergence || (itNum != maxIterations))
       && !terminate; ++itNum)
   {
+    Info << "iteration " << itNum << ", " << functionValue << "; " << iterate <<
+"\n";
     prevFunctionValue = functionValue;
 
     // Break when the norm of the gradient becomes too small.
     //
     // But don't do this on the first iteration to ensure we always take at
     // least one descent step.
-    if (itNum > 0 && (arma::norm(gradient, 2) < minGradientNorm))
+    if ((itNum > 0 && (arma::norm(gradient, 2) < minGradientNorm)) ||
+        arma::norm(gradient, 2) == 0)
     {
       Info << "L-BFGS gradient norm too small (terminating successfully)."
           << std::endl;

--- a/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
+++ b/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
@@ -385,8 +385,6 @@ L_BFGS::Optimize(FunctionType& function,
   for (size_t itNum = 0; (optimizeUntilConvergence || (itNum != maxIterations))
       && !terminate; ++itNum)
   {
-    Info << "iteration " << itNum << ", " << functionValue << "; " << iterate <<
-"\n";
     prevFunctionValue = functionValue;
 
     // Break when the norm of the gradient becomes too small.


### PR DESCRIPTION
This solves #199. 

Our documentation for constrained functions is actually incorrect.  The documentation implies that both "hard" and "soft" constraints are supported but this is not true.  In fact, the augmented Lagrangian optimizer (the only constrained optimizer we currently have) requires "soft" (differentiable) constraints.  Although I think it would be useful to provide support for optimizers that can take in arbitrary constraints, at the moment we don't have any, so I thought it was best to just simplify the documentation.

Also I fixed an issue where the L-BFGS optimizer will return NaNs when the starting point gives a gradient that is 0.  Essentially, for some reason, we previously did not allow termination on the first iteration due to the gradient norm being too small.  That's likely just a code artifact; I can't find any good reason to avoid that.