### PR TITLE
Release version 2.13.0: "Automatically Automated Automation"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ $ cd ensmallen
 
 # - or -
 
-$ wget http://ensmallen.org/files/ensmallen-2.12.1.tar.gz
-$ tar -xvzpf ensmallen-2.12.1.tar.gz
+$ wget http://ensmallen.org/files/ensmallen-2.13.0.tar.gz
+$ tar -xvzpf ensmallen-2.13.0.tar.gz
 $ cd ensmallen-latest
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### ensmallen ?.??.?: "???"
+###### ????-??-??
+
 ### ensmallen 2.13.0: "Automatically Automated Automation"
 ###### 2020-07-15
  * Fix CMake package export

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,10 +2,10 @@
 ###### ????-??-??
  * Fix CMake package export
     ([#198](https://github.com/mlpack/ensmallen/pull/198)).
-    
-  * Allow early stop callback to accept a lambda function
-    ([#165](https://github.com/mlpack/ensmallen/pull/165)).
-    
+
+ * Allow early stop callback to accept a lambda function
+   ([#165](https://github.com/mlpack/ensmallen/pull/165)).
+
 ### ensmallen 2.12.1: "Stir Crazy"
 ###### 2020-04-20
  * Fix total number of epochs and time estimation for ProgressBar callback

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-### ensmallen ?.??.?: "???"
-###### ????-??-??
+### ensmallen 2.13.0: "Automatically Automated Automation"
+###### 2020-07-15
  * Fix CMake package export
     ([#198](https://github.com/mlpack/ensmallen/pull/198)).
 

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -15,13 +15,13 @@
 #define ENS_VERSION_MAJOR 2
 // The minor version is two digits so regular numerical comparisons of versions
 // work right.  The first minor version of a release is always 10.
-#define ENS_VERSION_MINOR 12
-#define ENS_VERSION_PATCH 1
+#define ENS_VERSION_MINOR 13
+#define ENS_VERSION_PATCH 0
 // If this is a release candidate, it will be reflected in the version name
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not
 // contain the capitalized string "RC".
-#define ENS_VERSION_NAME "Stir Crazy"
+#define ENS_VERSION_NAME "Automatically Automated Automation"
 
 namespace ens {
 

--- a/scripts/ensmallen-release.sh
+++ b/scripts/ensmallen-release.sh
@@ -131,7 +131,12 @@ git add CONTRIBUTING.md;
 git add HISTORY.md;
 git commit -m "Update and release version $MAJOR.$MINOR.$PATCH.";
 
-changelog_str=`cat HISTORY.md | awk '/^### /{f=0} /^### ensmallen '$MAJOR'.'$MINOR'.'$PATCH'/{f=1} f{print}' | grep -v '^#'`;
+changelog_str=`cat HISTORY.md |\
+    awk '/^### /{f=0} /^### ensmallen 2.13.0: "Automatically Automated Automation"/{f=1} f{print}' |\
+    grep -v '^#' |\
+    tr '\n' '!' |\
+    sed -e 's/!  [ ]*/ /g' |\
+    tr '!' '\n'`;
 echo "Changelog string:"
 echo "$changelog_str"
 

--- a/scripts/ensmallen-release.sh
+++ b/scripts/ensmallen-release.sh
@@ -148,10 +148,12 @@ git push --set-upstream $github_user release-$MAJOR.$MINOR.$PATCH;
 hub pull-request \
     -b mlpack:master \
     -h $github_user:release-$MAJOR.$MINOR.$PATCH \
-    -m "Release version $MAJOR.$MINOR.$PATCH" \
+    -m "Release version $MAJOR.$MINOR.$PATCH: \"$version_name\"" \
     -m "This automatically-generated pull request adds the commits necessary to make the $MAJOR.$MINOR.$PATCH release." \
     -m "Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it." \
     -m "Or, well, hopefully that will happen someday." \
+    -m "### Changelog" \
+    -m `cat HISTORY.md | awk '/^### /{f=0} /^### ensmallen '$MAJOR'.'$MINOR'.'$PATCH'/{f=1} f{print}' | grep -v '^#'`
     -l "t: release"
 
 echo "";

--- a/scripts/ensmallen-release.sh
+++ b/scripts/ensmallen-release.sh
@@ -131,6 +131,10 @@ git add CONTRIBUTING.md;
 git add HISTORY.md;
 git commit -m "Update and release version $MAJOR.$MINOR.$PATCH.";
 
+changelog_str=`cat HISTORY.md | awk '/^### /{f=0} /^### ensmallen '$MAJOR'.'$MINOR'.'$PATCH'/{f=1} f{print}' | grep -v '^#'`;
+echo "Changelog string:"
+echo "$changelog_str"
+
 # Add one more commit to create the new HISTORY block.
 echo "### ensmallen ?.??.?: \"???\"" > HISTORY.md.new;
 echo "###### ????-??-??" >> HISTORY.md.new;
@@ -153,7 +157,7 @@ hub pull-request \
     -m "Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it." \
     -m "Or, well, hopefully that will happen someday." \
     -m "### Changelog" \
-    -m `cat HISTORY.md | awk '/^### /{f=0} /^### ensmallen '$MAJOR'.'$MINOR'.'$PATCH'/{f=1} f{print}' | grep -v '^#'`
+    -m "$changelog_str" \
     -l "t: release"
 
 echo "";


### PR DESCRIPTION
This automatically-generated pull request adds the commits necessary to make the 2.13.0 release.

Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it.

Or, well, hopefully that will happen someday.

### Changelog

 * Fix CMake package export ([#198](https://github.com/mlpack/ensmallen/pull/198)).

 * Allow early stop callback to accept a lambda function ([#165](https://github.com/mlpack/ensmallen/pull/165)).