### PR TITLE
Release version 2.14.1: "No Direction Home"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ $ cd ensmallen
 
 # - or -
 
-$ wget http://ensmallen.org/files/ensmallen-2.14.0.tar.gz
-$ tar -xvzpf ensmallen-2.14.0.tar.gz
+$ wget http://ensmallen.org/files/ensmallen-2.14.1.tar.gz
+$ tar -xvzpf ensmallen-2.14.1.tar.gz
 $ cd ensmallen-latest
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### ensmallen ?.??.?: "???"
+###### ????-??-??
+
 ### ensmallen 2.14.1: "No Direction Home"
 ###### 2020-08-18
  * Fix release script (remove hardcoded information, trim leading whitespaces

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-### ensmallen ?.??.?: "???"
-###### ????-??-??
+### ensmallen 2.14.1: "No Direction Home"
+###### 2020-08-18
  * Fix release script (remove hardcoded information, trim leading whitespaces
    introduced by `wc -l` in MacOS)
     ([#216](https://github.com/mlpack/ensmallen/pull/216)).

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -16,7 +16,7 @@
 // The minor version is two digits so regular numerical comparisons of versions
 // work right.  The first minor version of a release is always 10.
 #define ENS_VERSION_MINOR 14
-#define ENS_VERSION_PATCH 0
+#define ENS_VERSION_PATCH 1
 // If this is a release candidate, it will be reflected in the version name
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not

--- a/scripts/ensmallen-release.sh
+++ b/scripts/ensmallen-release.sh
@@ -133,7 +133,7 @@ git add HISTORY.md;
 git commit -m "Update and release version $MAJOR.$MINOR.$PATCH.";
 
 changelog_str=`cat HISTORY.md |\
-    awk '/^### /{f=0} /^### ensmallen '"$MAJOR"'.'"$MINOR"'.'"$PATCH"': '"$version_name"'/{f=1} f{print}' |\
+    awk '/^### /{f=0} /^### ensmallen '"$MAJOR"'.'"$MINOR"'.'"$PATCH"': "'"$version_name"'"/{f=1} f{print}' |\
     grep -v '^#' |\
     tr '\n' '!' |\
     sed -e 's/!  [ ]*/ /g' |\


### PR DESCRIPTION
This automatically-generated pull request adds the commits necessary to make the 2.14.1 release.

Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it.

Or, well, hopefully that will happen someday.

When you merge this PR, be sure to merge it using a *rebase*.

### Changelog

 * Fix release script (remove hardcoded information, trim leading whitespaces introduced by `wc -l` in MacOS) ([#216](https://github.com/mlpack/ensmallen/pull/216)).

 * Adjust tolerance for AugLagrangian convergence based on element type ([#217](https://github.com/mlpack/ensmallen/pull/217)).