### PR TITLE
Fix quotation bug in release script.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,8 @@
 ###### ????-??-??
  * Fix release script (remove hardcoded information, trim leading whitespaces
    introduced by `wc -l` in MacOS)
-    ([#216](https://github.com/mlpack/ensmallen/pull/216)).
+    ([#216](https://github.com/mlpack/ensmallen/pull/216),
+     [#220](https://github.com/mlpack/ensmallen/pull/220)).
 
  * Adjust tolerance for AugLagrangian convergence based on element type
    ([#217](https://github.com/mlpack/ensmallen/pull/217)).

--- a/scripts/ensmallen-release.sh
+++ b/scripts/ensmallen-release.sh
@@ -133,7 +133,7 @@ git add HISTORY.md;
 git commit -m "Update and release version $MAJOR.$MINOR.$PATCH.";
 
 changelog_str=`cat HISTORY.md |\
-    awk '/^### /{f=0} /^### ensmallen '"$MAJOR"'.'"$MINOR"'.'"$PATCH"': '"$version_name"'/{f=1} f{print}' |\
+    awk '/^### /{f=0} /^### ensmallen '"$MAJOR"'.'"$MINOR"'.'"$PATCH"': "'"$version_name"'"/{f=1} f{print}' |\
     grep -v '^#' |\
     tr '\n' '!' |\
     sed -e 's/!  [ ]*/ /g' |\


### PR DESCRIPTION
This is a simple change to correctly extract the changelog in the release script.  Previously, it would search for, e.g.,

```
### ensmallen 2.14.1: No Direction Home
```

but it needs to search for

```
### ensmallen 2.14.1: "No Direction Home"
```

You can see an example of the existing script failing in #218 and then the modified script succeeding in #219.