### PR TITLE
Fix implementation of fonesca fleming problem function f1 and f2     type usage and negative signs.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Fix implementation of fonesca fleming problem function f1 and f2 
+   type usage and negative signs. ([#223](https://github.com/mlpack/ensmallen/pull/223))
 
 ### ensmallen 2.14.1: "No Direction Home"
 ###### 2020-08-19

--- a/include/ensmallen_bits/problems/fonseca_fleming_function.hpp
+++ b/include/ensmallen_bits/problems/fonseca_fleming_function.hpp
@@ -22,8 +22,8 @@ namespace test {
  * The Fonseca Fleming function N.1 is defined by
  *
  * \f[
- * f_1(x) = 1 - \exp(\sum_1^3{(x_i - \frac{1}{\sqrt3})^2})
- * f_2(x) = 1 - \exp(\sum_1^3{(x_i + \frac{1}{\sqrt3})^2})
+ * f_{1}\left(\boldsymbol{x}\right) = 1 - \exp \left[-\sum_{i=1}^{3} \left(x_{i} - \frac{1}{\sqrt{n}} \right)^{2} \right] \\
+ * f_{2}\left(\boldsymbol{x}\right) = 1 - \exp \left[-\sum_{i=1}^{3} \left(x_{i} + \frac{1}{\sqrt{n}} \right)^{2} \right] \\
  * \f]
  *
  * The optimal solutions to this multi-objective function lie in the
@@ -71,9 +71,11 @@ class FonsecaFlemingFunction
   {
     typename MatType::elem_type Evaluate(const MatType& coords)
     {
-        return 1.0f - exp(-pow(coords[0] - 1.0f / sqrt(3), 2) -
-            - pow(coords[1] - 1.0f / sqrt(3), 2)
-            - pow(coords[2] - 1.0f / sqrt(3), 2));
+        return 1.0 - exp(
+             -pow(static_cast<double>(coords[0]) - 1.0 / sqrt(3.0), 2.0)
+             -pow(static_cast<double>(coords[1]) - 1.0 / sqrt(3.0), 2.0)
+             -pow(static_cast<double>(coords[2]) - 1.0 / sqrt(3.0), 2.0)
+        );
     }
   } objectiveA;
 
@@ -81,9 +83,11 @@ class FonsecaFlemingFunction
   {
     typename MatType::elem_type Evaluate(const MatType& coords)
     {
-        return 1.0f - exp(-pow(coords[0] + 1.0f / sqrt(3), 2) -
-            - pow(coords[1] + 1.0f / sqrt(3), 2)
-            - pow(coords[2] + 1.0f / sqrt(3), 2));
+        return 1.0 - exp(
+            -pow(static_cast<double>(coords[0]) + 1.0 / sqrt(3.0), 2.0)
+            -pow(static_cast<double>(coords[1]) + 1.0 / sqrt(3.0), 2.0)
+            -pow(static_cast<double>(coords[2]) + 1.0 / sqrt(3.0), 2.0)
+        );
     }
   } objectiveB;
 


### PR DESCRIPTION
Fixes the type issues that came up during a CRAN check submission on Solaris. 

> In file included from ../inst/include/ensmallen_bits/problems/problems.hpp:20:0,
>                  from ../inst/include/ensmallen.hpp:77,
>                  from ../inst/include/RcppEnsmallen.h:25,
>                  from RcppExports.cpp:4:
> ../inst/include/ensmallen_bits/problems/fonseca_fleming_function.hpp: In member function ‘typename MatType::elem_type ens::test::FonsecaFlemingFunction<MatType>::ObjectiveA::Evaluate(const MatType&)’:
> ../inst/include/ensmallen_bits/problems/fonseca_fleming_function.hpp:74:57: error: call of overloaded ‘sqrt(int)’ is ambiguous
>          return 1.0f - exp(-pow(coords[0] - 1.0f / sqrt(3), 2) -
> 

https://www.r-project.org/nosvn/R.check/r-patched-solaris-x86/RcppEnsmallen-00install.html

Also, removes an extra negative sign between x1 and x2 addition. 