### PR TITLE
Incorporate release date with ensmallen version

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
 
+ * Add release date to version information. ([#226](https://github.com/mlpack/ensmallen/pull/226))
+
 ### ensmallen 2.14.2: "No Direction Home"
 ###### 2020-08-31
  * Fix implementation of fonesca fleming problem function f1 and f2 

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -44,7 +44,7 @@ struct version
 
     std::stringstream ss;
     ss << version::major << '.' << version::minor << '.' << version::patch
-       << " (" << nickname << ')\n' 
+       << " (" << nickname << ")\n" 
        << "Released on " << year << '-' << month << '-' << day;
 
     return ss.str();

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -59,5 +59,4 @@ struct version
   }
 };
 
-
 } // namespace ens

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -22,7 +22,7 @@
 // name will typically be a seemingly arbitrary set of words that does not
 // contain the capitalized string "RC".
 #define ENS_VERSION_NAME  "No Direction Home"
-// Incorporate the date the version was released
+// Incorporate the date the version was released.
 #define ENS_VERSION_YEAR  "2020"
 #define ENS_VERSION_MONTH "09"
 #define ENS_VERSION_DAY   "05"

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -41,19 +41,15 @@ struct version
 
     std::stringstream ss;
     ss << version::major << '.' << version::minor << '.' << version::patch
-       << " (" << nickname << ")";
+       << " (" << nickname << ')';
 
     return ss.str();
   }
     
   static inline std::string date()
   {
-    const char* year = ENS_VERSION_YEAR;
-    const char* month = ENS_VERSION_MONTH;
-    const char* day = ENS_VERSION_DAY;
-
     std::stringstream ss;
-    ss << year << '-' << month << '-' << day;
+    ss << ENS_VERSION_YEAR << '-' << ENS_VERSION_MONTH << '-' << ENS_VERSION_DAY;
 
     return ss.str();
   }

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -21,7 +21,11 @@
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not
 // contain the capitalized string "RC".
-#define ENS_VERSION_NAME "No Direction Home"
+#define ENS_VERSION_NAME  "No Direction Home"
+// Incorporate the date the version was released
+#define ENS_VERSION_YEAR  2020
+#define ENS_VERSION_MONTH 09
+#define ENS_VERSION_DAY   05
 
 namespace ens {
 
@@ -31,13 +35,18 @@ struct version
   static const unsigned int minor = ENS_VERSION_MINOR;
   static const unsigned int patch = ENS_VERSION_PATCH;
 
+  static const unsigned int release_year = ENS_VERSION_YEAR;
+  static const unsigned int release_month = ENS_VERSION_MONTH;
+  static const unsigned int release_day = ENS_VERSION_DAY;
+
   static inline std::string as_string()
   {
     const char* nickname = ENS_VERSION_NAME;
 
     std::stringstream ss;
     ss << version::major << '.' << version::minor << '.' << version::patch
-       << " (" << nickname << ')';
+       << ' (' << nickname << ')\n' <<
+       'Released on ' << release_year << '-' << release_month << '-' << release_day;
 
     return ss.str();
   }

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -35,18 +35,17 @@ struct version
   static const unsigned int minor = ENS_VERSION_MINOR;
   static const unsigned int patch = ENS_VERSION_PATCH;
 
-  static const std::string release_year = ENS_VERSION_YEAR;
-  static const std::string release_month = ENS_VERSION_MONTH;
-  static const std::string release_day = ENS_VERSION_DAY;
-
   static inline std::string as_string()
   {
     const char* nickname = ENS_VERSION_NAME;
+    const char* year = ENS_VERSION_YEAR;
+    const char* month = ENS_VERSION_MONTH;
+    const char* day = ENS_VERSION_DAY;
 
     std::stringstream ss;
     ss << version::major << '.' << version::minor << '.' << version::patch
        << " (" << nickname << ')\n' 
-       << "Released on " << release_year << '-' << release_month << '-' << release_day;
+       << "Released on " << year << '-' << month << '-' << day;
 
     return ss.str();
   }

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -23,9 +23,9 @@
 // contain the capitalized string "RC".
 #define ENS_VERSION_NAME  "No Direction Home"
 // Incorporate the date the version was released
-#define ENS_VERSION_YEAR  2020
-#define ENS_VERSION_MONTH 09
-#define ENS_VERSION_DAY   05
+#define ENS_VERSION_YEAR  "2020"
+#define ENS_VERSION_MONTH "09"
+#define ENS_VERSION_DAY   "05"
 
 namespace ens {
 
@@ -35,9 +35,9 @@ struct version
   static const unsigned int minor = ENS_VERSION_MINOR;
   static const unsigned int patch = ENS_VERSION_PATCH;
 
-  static const unsigned int release_year = ENS_VERSION_YEAR;
-  static const unsigned int release_month = ENS_VERSION_MONTH;
-  static const unsigned int release_day = ENS_VERSION_DAY;
+  static const std::string release_year = ENS_VERSION_YEAR;
+  static const std::string release_month = ENS_VERSION_MONTH;
+  static const std::string release_day = ENS_VERSION_DAY;
 
   static inline std::string as_string()
   {
@@ -45,8 +45,8 @@ struct version
 
     std::stringstream ss;
     ss << version::major << '.' << version::minor << '.' << version::patch
-       << ' (' << nickname << ')\n' <<
-       'Released on ' << release_year << '-' << release_month << '-' << release_day;
+       << " (" << nickname << ')\n' 
+       << "Released on " << release_year << '-' << release_month << '-' << release_day;
 
     return ss.str();
   }

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -38,17 +38,26 @@ struct version
   static inline std::string as_string()
   {
     const char* nickname = ENS_VERSION_NAME;
+
+    std::stringstream ss;
+    ss << version::major << '.' << version::minor << '.' << version::patch
+       << " (" << nickname << ")";
+
+    return ss.str();
+  }
+    
+  static inline std::string date()
+  {
     const char* year = ENS_VERSION_YEAR;
     const char* month = ENS_VERSION_MONTH;
     const char* day = ENS_VERSION_DAY;
 
     std::stringstream ss;
-    ss << version::major << '.' << version::minor << '.' << version::patch
-       << " (" << nickname << ")\n" 
-       << "Released on " << year << '-' << month << '-' << day;
+    ss << year << '-' << month << '-' << day;
 
     return ss.str();
   }
 };
+
 
 } // namespace ens

--- a/scripts/ensmallen-release.sh
+++ b/scripts/ensmallen-release.sh
@@ -125,11 +125,11 @@ sed -i "s/### ensmallen ?.??.?: \"???\"/### $new_line/" HISTORY.md;
 sed -i "s/###### ????-??-??/###### $year-$month-$day/" HISTORY.md;
 
 # Update date in ens_version.hpp
-sed -i 's/ENS_VERSION_YEAR[ ]*[0-9]*$/ENS_VERSION_YEAR '$year'/' \
+sed -i 's/ENS_VERSION_YEAR[ ]*\".*\"$/ENS_VERSION_YEAR \"'"$year"'\"/' \
     include/ensmallen_bits/ens_version.hpp;
-sed -i 's/ENS_VERSION_MONTH[ ]*[0-9]*$/ENS_VERSION_MONTH '$month'/' \
+sed -i 's/ENS_VERSION_MONTH[ ]*\".*\"$/ENS_VERSION_MONTH \"'"$month"'\"/' \
     include/ensmallen_bits/ens_version.hpp;
-sed -i 's/ENS_VERSION_DAY[ ]*[0-9]*$/ENS_VERSION_DAY '$day'/' \
+sed -i 's/ENS_VERSION_DAY[ ]*\".*\"$/ENS_VERSION_DAY \"'"$day"'\"/' \
     include/ensmallen_bits/ens_version.hpp;
 
 # Now, we'll do all this on a new release branch.

--- a/scripts/ensmallen-release.sh
+++ b/scripts/ensmallen-release.sh
@@ -124,6 +124,14 @@ new_line="ensmallen $MAJOR.$MINOR.$PATCH: \"$version_name\"";
 sed -i "s/### ensmallen ?.??.?: \"???\"/### $new_line/" HISTORY.md;
 sed -i "s/###### ????-??-??/###### $year-$month-$day/" HISTORY.md;
 
+# Update date in ens_version.hpp
+sed -i 's/ENS_VERSION_YEAR[ ]*[0-9]*$/ENS_VERSION_YEAR '$year'/' \
+    include/ensmallen_bits/ens_version.hpp;
+sed -i 's/ENS_VERSION_MONTH[ ]*[0-9]*$/ENS_VERSION_MONTH '$month'/' \
+    include/ensmallen_bits/ens_version.hpp;
+sed -i 's/ENS_VERSION_DAY[ ]*[0-9]*$/ENS_VERSION_DAY '$day'/' \
+    include/ensmallen_bits/ens_version.hpp;
+
 # Now, we'll do all this on a new release branch.
 git checkout -b release-$MAJOR.$MINOR.$PATCH;
 


### PR DESCRIPTION
From #222, we discussed adding date information to the header file for when ensmallen was released/updated. This PR includes the version update within `ens_version.hpp` and updates the release script to automatically set these fields. 