### PR TITLE
Fix SimpleSGDTestFunction arma::fmat test failures

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Make a few tests more robust.
 
 ### ensmallen 2.14.2: "No Direction Home"
 ###### 2020-08-31

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
- * Make a few tests more robust.
+ * Make a few tests more robust
+   ([#228](https://github.com/mlpack/ensmallen/pull/228)).
 
 ### ensmallen 2.14.2: "No Direction Home"
 ###### 2020-08-31

--- a/tests/ada_delta_test.cpp
+++ b/tests/ada_delta_test.cpp
@@ -65,11 +65,20 @@ TEST_CASE("AdaDeltaLogisticRegressionTest", "[AdaDeltaTest]")
  */
 TEST_CASE("SimpleAdaDeltaTestFunctionFMat", "[AdaDeltaTest]")
 {
+  size_t trials = 3;
   SGDTestFunction f;
-  AdaDelta optimizer(1.0, 1, 0.05, 1e-6, 5000000, 1e-15, true, true);
+  arma::fmat coordinates;
 
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
+  for (size_t i = 0; i < trials; ++i)
+  {
+    coordinates = f.GetInitialPoint<arma::fmat>();
+
+    AdaDelta optimizer(2.0, 1, 0.05, 1e-6, 5000000, 1e-8, true, true);
+    optimizer.Optimize(f, coordinates);
+
+    if (arma::max(arma::vectorise(arma::abs(coordinates))) < 0.01f)
+      break;
+  }
 
   REQUIRE(coordinates(0) == Approx(0.0f).margin(0.01));
   REQUIRE(coordinates(1) == Approx(0.0f).margin(0.01));

--- a/tests/ada_grad_test.cpp
+++ b/tests/ada_grad_test.cpp
@@ -63,11 +63,20 @@ TEST_CASE("AdaGradLogisticRegressionTest", "[AdaGradTest]")
  */
 TEST_CASE("SimpleAdaGradTestFunctionFMat", "[AdaGradTest]")
 {
+  size_t trials = 3;
   SGDTestFunction f;
-  AdaGrad optimizer(0.99, 1, 1e-8, 5000000, 1e-9, true);
+  arma::fmat coordinates;
 
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
+  for (size_t i = 0; i < trials; ++i)
+  {
+    coordinates = f.GetInitialPoint<arma::fmat>();
+
+    AdaGrad optimizer(0.99, 1, 1e-8, 5000000, 1e-9, true);
+    optimizer.Optimize(f, coordinates);
+
+    if (arma::max(arma::vectorise(arma::abs(coordinates))) < 0.01f)
+      break;
+  }
 
   REQUIRE(coordinates(0) == Approx(0.0f).margin(0.01));
   REQUIRE(coordinates(1) == Approx(0.0f).margin(0.01));


### PR DESCRIPTION
This PR adapts the strategies used for the two tests (AdaDelta and AdaGrad) that use `SimpleSGDTestFunction` with an `arma::fmat`.  Basically I increased the step size and this seemed to help, but not enough, so I then made the test run a maximum of three times to make sure it converges at least once.  With these changes, now locally I saw no failures of either test with >1000 runs.

This should fix #182 and #225. :+1: