### PR TITLE
Fix include order of traits which reports depends upon

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
 
+ * Fix include order to ensure traits is loaded before reports
+   ([#239](https://github.com/mlpack/ensmallen/pull/239)).
+
 ### ensmallen 2.15.0: "Why Can't I Manage To Grow Any Plants?"
 ###### 2020-11-01
  * Make a few tests more robust

--- a/include/ensmallen.hpp
+++ b/include/ensmallen.hpp
@@ -66,7 +66,7 @@
 #include "ensmallen_bits/utility/any.hpp"
 #include "ensmallen_bits/utility/arma_traits.hpp"
 
-// contains traits, must be placed before report callback
+// Contains traits, must be placed before report callback.
 #include "ensmallen_bits/function.hpp" // TODO: should move to function/
 
 // Callbacks.

--- a/include/ensmallen.hpp
+++ b/include/ensmallen.hpp
@@ -66,6 +66,9 @@
 #include "ensmallen_bits/utility/any.hpp"
 #include "ensmallen_bits/utility/arma_traits.hpp"
 
+// contains traits, must be placed before report callback
+#include "ensmallen_bits/function.hpp" // TODO: should move to function/
+
 // Callbacks.
 #include "ensmallen_bits/callbacks/callbacks.hpp"
 #include "ensmallen_bits/callbacks/early_stop_at_min_loss.hpp"
@@ -89,8 +92,6 @@
 #include "ensmallen_bits/de/de.hpp"
 #include "ensmallen_bits/eve/eve.hpp"
 #include "ensmallen_bits/ftml/ftml.hpp"
-
-#include "ensmallen_bits/function.hpp" // TODO: should move to function/
 
 #include "ensmallen_bits/fw/frank_wolfe.hpp"
 #include "ensmallen_bits/gradient_descent/gradient_descent.hpp"


### PR DESCRIPTION
While preparing the new CRAN release, my local compile on macOS 10.15.7 yielded an error when compiling of:

```bash
error: no template named 'HasStepSizeSignature' in namespace 'ens::traits';
 did you mean 'HasBatchSizeSignature'?
```

I've verified that the definition is present in `traits`. 

Oddly enough, the new version is passing cleanly with CI checks: coatless/rcppensmallen#39 

I think the error is being triggered because of an include-order issue. Specifically, `ensmallen/include/ensmallen.hpp` needs to have `#include "ensmallen_bits/function.hpp"` placed before `#include "ensmallen_bits/callbacks/report.hpp"`

<details>
<summary>
Full stack trace
</summary>

```bash
clang++ -mmacosx-version-min=10.13 -std=gnu++11 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG  -I'/Library/Frameworks/R.framework/Versions/4.0/Resources/library/Rcpp/include' -I'/Library/Frameworks/R.framework/Versions/4.0/Resources/library/RcppArmadillo/include' -I/usr/local/include  -I../inst/include  -fPIC  -Wall -g -O2  -c RcppExports.cpp -o RcppExports.o
In file included from RcppExports.cpp:4:
In file included from ./../inst/include/RcppEnsmallen.h:25:
In file included from ../inst/include/ensmallen.hpp:74:
../inst/include/ensmallen_bits/callbacks/report.hpp:528:35: error: no template named 'HasStepSizeSignature' in namespace 'ens::traits'; did you mean 'HasBatchSizeSignature'?
  typename std::enable_if<traits::HasStepSizeSignature<OptimizerType>::value,
                          ~~~~~~~~^~~~~~~~~~~~~~~~~~~~
                                  HasBatchSizeSignature
/usr/local/include/ensmallen_bits/function/traits.hpp:381:8: note: 'HasBatchSizeSignature' declared here
struct HasBatchSizeSignature
       ^
In file included from RcppExports.cpp:4:
In file included from ./../inst/include/RcppEnsmallen.h:25:
In file included from ../inst/include/ensmallen.hpp:74:
../inst/include/ensmallen_bits/callbacks/report.hpp:536:36: error: no template named 'HasStepSizeSignature' in namespace 'ens::traits'; did you mean 'HasBatchSizeSignature'?
  typename std::enable_if<!traits::HasStepSizeSignature<OptimizerType>::value,
                           ~~~~~~~~^~~~~~~~~~~~~~~~~~~~
                                   HasBatchSizeSignature
/usr/local/include/ensmallen_bits/function/traits.hpp:381:8: note: 'HasBatchSizeSignature' declared here
struct HasBatchSizeSignature
```

</details>