### PR TITLE
add short example program; expand README with example installation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 ###### ????-??-??
 
  * expand README with example installation and add simple example program
-   showing usage of the L-BFGS optimizer
+   showing usage of the L-BFGS optimizer ([#248](https://github.com/mlpack/ensmallen/pull/248)).
 
 ### ensmallen 2.15.1: "Why Can't I Manage To Grow Any Plants?"
 ###### 2020-11-05

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
 
+ * expand README with example installation and add simple example program
+   showing usage of the L-BFGS optimizer
+
 ### ensmallen 2.15.1: "Why Can't I Manage To Grow Any Plants?"
 ###### 2020-11-05
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ If CMake is not already available on your system, it can be obtained from https:
 If you are using an older system such as RHEL 7 or CentOS 7,
 an updated version of CMake is also available via the EPEL repository via the `cmake3` package.
 
+Example installation:
+
+```
+mkdir build
+cd build
+cmake ..
+sudo make install
+```
+
+
+### Example Usage
+
+See `example.cpp` for example usage of the L-BFGS optimizer.
+
 
 ### License
 
@@ -36,14 +50,15 @@ Unless stated otherwise, the source code for **ensmallen** is licensed under the
 "LICENSE.txt" file.  You may also obtain a copy of the License at
 http://opensource.org/licenses/BSD-3-Clause .
 
+
 ### Citation
 
 Please cite the following paper if you use ensmallen in your research and/or
 software. Citations are useful for the continued development and maintenance of
 the library.
 
-* S. Bhardwaj, R. Curtin, M. Edel, Y. Mentekidis, C. Sanderson.
-  [ensmallen: a flexible C++ library for efficient function optimization](http://www.ensmallen.org/files/ensmallen_2018.pdf).
+* S. Bhardwaj, R. Curtin, M. Edel, Y. Mentekidis, C. Sanderson.  
+  [ensmallen: a flexible C++ library for efficient function optimization](http://www.ensmallen.org/files/ensmallen_2018.pdf).  
   Workshop on Systems for ML and Open Source Software at NIPS 2018.
 
 ```

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo make install
 
 ### Example Usage
 
-See `example.cpp` for example usage of the L-BFGS optimizer.
+See [`example.cpp`](example.cpp) for example usage of the L-BFGS optimizer in a linear regression setting.
 
 
 ### License

--- a/example.cpp
+++ b/example.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
   
   LinearRegressionFunction lrf(X, y);
   
-  // create an Limited-memory BFGS optimizer object with default parameters
+  // create a Limited-memory BFGS optimizer object with default parameters
   ens::L_BFGS opt;
   opt.MaxIterations() = 10;
   

--- a/example.cpp
+++ b/example.cpp
@@ -58,7 +58,8 @@ int main(int argc, char** argv)
   ens::L_BFGS opt;
   opt.MaxIterations() = 10;
   
-  arma::vec theta(n_dims, arma::fill::randu);   // initial point (uniform random)
+  // initial point (uniform random)
+  arma::vec theta(n_dims, arma::fill::randu);
   
   opt.Optimize(lrf, theta);
   

--- a/example.cpp
+++ b/example.cpp
@@ -54,6 +54,7 @@ int main(int argc, char** argv)
   
   LinearRegressionFunction lrf(X, y);
   
+  // create an Limited-memory BFGS optimizer object with default parameters
   ens::L_BFGS opt;
   opt.MaxIterations() = 10;
   

--- a/example.cpp
+++ b/example.cpp
@@ -1,7 +1,7 @@
 // Example implementation of an objective function class for linear regression
 // and usage of the L-BFGS optimizer.
 // 
-// Compilatation:
+// Compilation:
 // g++ example.cpp -o example -O3 -larmadillo
 
 

--- a/example.cpp
+++ b/example.cpp
@@ -33,10 +33,10 @@ class LinearRegressionFunction
 int main(int argc, char** argv)
 {
   if (argc < 3)
-    {
+  {
     std::cout << "usage: " << argv[0] << " n_dims n_points" << std::endl;
     return -1;
-    }
+  }
   
   int n_dims   = atoi(argv[1]);
   int n_points = atoi(argv[2]);

--- a/example.cpp
+++ b/example.cpp
@@ -1,0 +1,68 @@
+// Example implementation of an objective function class for linear regression
+// and usage of the L-BFGS optimizer.
+// 
+// Compilatation:
+// g++ example.cpp -o example -O3 -larmadillo
+
+
+#include <iostream>
+#include <armadillo>
+#include <ensmallen.hpp>
+
+
+class LinearRegressionFunction
+{
+  public:
+  
+  LinearRegressionFunction(arma::mat& X, arma::vec& y) : X(X), y(y) { }
+  
+  double EvaluateWithGradient(const arma::mat& theta, arma::mat& gradient)
+  {
+    const arma::vec tmp = X.t() * theta - y;
+    gradient = 2 * X * tmp;
+    return arma::dot(tmp,tmp);
+  }
+  
+  private:
+  
+  const arma::mat& X;
+  const arma::vec& y;
+};
+
+
+int main(int argc, char** argv)
+{
+  if (argc < 3)
+    {
+    std::cout << "usage: " << argv[0] << " n_dims n_points" << std::endl;
+    return -1;
+    }
+  
+  int n_dims   = atoi(argv[1]);
+  int n_points = atoi(argv[2]);
+  
+  // generate noisy dataset with a slight linear pattern
+  arma::mat X(n_dims, n_points, arma::fill::randu);
+  arma::vec y(        n_points, arma::fill::randu);
+  
+  for (size_t i = 0; i < n_points; ++i)
+  {
+    double a = arma::randu();
+    X(1, i) += a;
+    y(i)    += a;
+  }
+  
+  LinearRegressionFunction lrf(X, y);
+  
+  ens::L_BFGS opt;
+  opt.MaxIterations() = 10;
+  
+  arma::vec theta(n_dims, arma::fill::randu);   // initial point (uniform random)
+  
+  opt.Optimize(lrf, theta);
+  
+  // theta now contains the optimized parameters
+  theta.print("theta:");
+  
+  return 0;
+}


### PR DESCRIPTION
This is to partially address the concerns raised by JMLR reviewer 1.
Specifically, the short example program has been added to satisfy the following comment:

> The documentation of ensmallen is detailed but I missed some simple examples in the README file. There are examples in the documentation, but I believe having a few compileable-then-runnable examples in the repository would be a great improvement. 