### PR TITLE
Fix test stability

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,14 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Expand README with example installation and add simple example program
+   showing usage of the L-BFGS optimizer
+   ([#248](https://github.com/mlpack/ensmallen/pull/248)).
 
- * expand README with example installation and add simple example program
-   showing usage of the L-BFGS optimizer ([#248](https://github.com/mlpack/ensmallen/pull/248)).
+ * Refactor tests to increase stability and reduce random errors
+   ([#249](https://github.com/mlpack/ensmallen/pull/249)).
 
 ### ensmallen 2.15.1: "Why Can't I Manage To Grow Any Plants?"
 ###### 2020-11-05
-
  * Fix include order to ensure traits is loaded before reports
    ([#239](https://github.com/mlpack/ensmallen/pull/239)).
 
@@ -16,7 +18,7 @@
    ([#228](https://github.com/mlpack/ensmallen/pull/228)).
 
  * Add release date to version information. ([#226](https://github.com/mlpack/ensmallen/pull/226))
- 
+
  * Fix typo in release script
    ([#236](https://github.com/mlpack/ensmallen/pull/236)).
 

--- a/include/ensmallen_bits/problems/ackley_function.hpp
+++ b/include/ensmallen_bits/problems/ackley_function.hpp
@@ -60,7 +60,6 @@ class AckleyFunction
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
-  //! This was previously -5.0, 5.0.
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("0.02; 0.02"); }
 

--- a/include/ensmallen_bits/problems/ackley_function.hpp
+++ b/include/ensmallen_bits/problems/ackley_function.hpp
@@ -60,8 +60,16 @@ class AckleyFunction
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
+  //! This was previously -5.0, 5.0.
   template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-5.0; 5.0"); }
+  MatType GetInitialPoint() const { return MatType("0.02; 0.02"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/beale_function.hpp
+++ b/include/ensmallen_bits/problems/beale_function.hpp
@@ -53,7 +53,6 @@ class BealeFunction
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
-  //! This was previously -4.5; 4.5.
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("2.8; 0.35"); }
 

--- a/include/ensmallen_bits/problems/beale_function.hpp
+++ b/include/ensmallen_bits/problems/beale_function.hpp
@@ -53,8 +53,16 @@ class BealeFunction
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
+  //! This was previously -4.5; 4.5.
   template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-4.5; 4.5"); }
+  MatType GetInitialPoint() const { return MatType("2.8; 0.35"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("3.0; 0.5"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/booth_function.hpp
+++ b/include/ensmallen_bits/problems/booth_function.hpp
@@ -56,6 +56,13 @@ class BoothFunction
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("-9; -9"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1.0; 3.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/bukin_function.hpp
+++ b/include/ensmallen_bits/problems/bukin_function.hpp
@@ -61,6 +61,13 @@ class BukinFunction
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("-10; -2.0"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("-10.0; 1.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/colville_function.hpp
+++ b/include/ensmallen_bits/problems/colville_function.hpp
@@ -57,6 +57,13 @@ class ColvilleFunction
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("-5; 3; 1; -9"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1; 1; 1; 1"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/drop_wave_function.hpp
+++ b/include/ensmallen_bits/problems/drop_wave_function.hpp
@@ -56,6 +56,13 @@ class DropWaveFunction
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("0.5; 0.5"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/easom_function.hpp
+++ b/include/ensmallen_bits/problems/easom_function.hpp
@@ -54,7 +54,14 @@ class EasomFunction
 
   //! Get the starting point.
   template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-90.0; 90.0"); }
+  MatType GetInitialPoint() const { return MatType("2.9; 2.9"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("3.14; 3.14"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return -1.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/eggholder_function.hpp
+++ b/include/ensmallen_bits/problems/eggholder_function.hpp
@@ -57,6 +57,13 @@ class EggholderFunction
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("-333; -333"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("512; 404.2319"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return -959.6407; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/generalized_rosenbrock_function.hpp
+++ b/include/ensmallen_bits/problems/generalized_rosenbrock_function.hpp
@@ -68,6 +68,16 @@ class GeneralizedRosenbrockFunction
     return arma::conv_to<MatType>::from(initialPoint);
   }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  const MatType GetFinalPoint() const
+  {
+    return arma::ones<MatType>(initialPoint.n_rows, initialPoint.n_cols);
+  }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/goldstein_price_function.hpp
+++ b/include/ensmallen_bits/problems/goldstein_price_function.hpp
@@ -62,7 +62,6 @@ class GoldsteinPriceFunction
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
-  //! This was previously -2; 2.
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("0.2; -0.5"); }
 

--- a/include/ensmallen_bits/problems/goldstein_price_function.hpp
+++ b/include/ensmallen_bits/problems/goldstein_price_function.hpp
@@ -62,8 +62,16 @@ class GoldsteinPriceFunction
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
+  //! This was previously -2; 2.
   template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-2; 2"); }
+  MatType GetInitialPoint() const { return MatType("0.2; -0.5"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; -1.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 3.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/gradient_descent_test_function.hpp
+++ b/include/ensmallen_bits/problems/gradient_descent_test_function.hpp
@@ -29,6 +29,13 @@ class GDTestFunction
   template<typename MatType>
   MatType GetInitialPoint() const { return MatType("1; 3; 2"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0; 0; 0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   //! Evaluate a function.
   template<typename MatType>
   typename MatType::elem_type Evaluate(const MatType& coordinates) const;

--- a/include/ensmallen_bits/problems/levy_function_n13.hpp
+++ b/include/ensmallen_bits/problems/levy_function_n13.hpp
@@ -49,8 +49,16 @@ class LevyFunctionN13
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
+  //! This was previously -10.0; 10.0.
   template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-10; 10"); }
+  MatType GetInitialPoint() const { return MatType("0.9; 1.1"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1.0; 1.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/levy_function_n13.hpp
+++ b/include/ensmallen_bits/problems/levy_function_n13.hpp
@@ -49,7 +49,6 @@ class LevyFunctionN13
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
-  //! This was previously -10.0; 10.0.
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("0.9; 1.1"); }
 

--- a/include/ensmallen_bits/problems/matyas_function.hpp
+++ b/include/ensmallen_bits/problems/matyas_function.hpp
@@ -56,6 +56,13 @@ class MatyasFunction
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("-3; 3"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/mc_cormick_function.hpp
+++ b/include/ensmallen_bits/problems/mc_cormick_function.hpp
@@ -56,6 +56,13 @@ class McCormickFunction
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("-2; 4"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("-0.54719; -1.54719"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return -1.9133; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/rastrigin_function.hpp
+++ b/include/ensmallen_bits/problems/rastrigin_function.hpp
@@ -44,13 +44,13 @@ class RastriginFunction
    *
    * @param n Number of dimensions for the function.
    */
-  RastriginFunction(const size_t n);
+  RastriginFunction(const size_t n = 2);
 
   /**
    * Shuffle the order of function visitation. This may be called by the
    * optimizer.
    */
- void Shuffle();
+  void Shuffle();
 
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return n; }
@@ -61,6 +61,16 @@ class RastriginFunction
   {
     return arma::conv_to<MatType>::from(initialPoint);
   }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    return arma::zeros<MatType>(initialPoint.n_rows, initialPoint.n_cols);
+  }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/rosenbrock_function.hpp
+++ b/include/ensmallen_bits/problems/rosenbrock_function.hpp
@@ -57,13 +57,14 @@ class RosenbrockFunction
 
   //! Get the starting point.
   template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const
-  {
-    MatType m(2, 1);
-    m[0] = -1.2;
-    m[1] = 1.0;
-    return m;
-  }
+  MatType GetInitialPoint() const { return MatType("-1.2; 1.0"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1.0; 1.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/rosenbrock_wood_function.hpp
+++ b/include/ensmallen_bits/problems/rosenbrock_wood_function.hpp
@@ -46,6 +46,16 @@ class RosenbrockWoodFunction
     return arma::conv_to<MatType>::from(initialPoint);
   }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    return arma::ones<MatType>(initialPoint.n_rows, initialPoint.n_cols);
+  }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/schaffer_function_n2.hpp
+++ b/include/ensmallen_bits/problems/schaffer_function_n2.hpp
@@ -57,6 +57,13 @@ class SchafferFunctionN2
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("-100; 100"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/schwefel_function.hpp
+++ b/include/ensmallen_bits/problems/schwefel_function.hpp
@@ -62,6 +62,18 @@ class SchwefelFunction
     return arma::conv_to<MatType>::from(initialPoint);
   }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    MatType result(initialPoint.n_rows, initialPoint.n_cols);
+    result.fill(420.9687);
+    return result;
+  }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/include/ensmallen_bits/problems/sgd_test_function.hpp
+++ b/include/ensmallen_bits/problems/sgd_test_function.hpp
@@ -41,6 +41,13 @@ class SGDTestFunction
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("6; -45.6; 6.2"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0; 0.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return -1.0; }
+
   //! Evaluate a function for a particular batch-size.
   template<typename MatType>
   typename MatType::elem_type Evaluate(const MatType& coordinates,

--- a/include/ensmallen_bits/problems/sparse_test_function.hpp
+++ b/include/ensmallen_bits/problems/sparse_test_function.hpp
@@ -36,6 +36,13 @@ class SparseTestFunction
   template<typename MatType>
   MatType GetInitialPoint() const { return MatType("0 0 0 0;"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("2.0 1.0 1.5 4.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 123.75; }
+
   //! Evaluate a function.
   template<typename MatType>
   typename MatType::elem_type Evaluate(const MatType& coordinates,

--- a/include/ensmallen_bits/problems/sphere_function.hpp
+++ b/include/ensmallen_bits/problems/sphere_function.hpp
@@ -45,7 +45,7 @@ class SphereFunction
    *
    * @param n Number of dimensions for the function.
    */
-  SphereFunction(const size_t n);
+  SphereFunction(const size_t n = 2);
 
   /**
    * Shuffle the order of function visitation. This may be called by the
@@ -62,6 +62,16 @@ class SphereFunction
   {
     return arma::conv_to<MatType>::from(initialPoint);
   }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    return arma::zeros<MatType>(initialPoint.n_rows, initialPoint.n_cols);
+  }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/styblinski_tang_function.hpp
+++ b/include/ensmallen_bits/problems/styblinski_tang_function.hpp
@@ -46,7 +46,7 @@ class StyblinskiTangFunction
    *
    * @param n Number of dimensions for the function.
    */
-  StyblinskiTangFunction(const size_t n);
+  StyblinskiTangFunction(const size_t n = 2);
 
   /**
    * Shuffle the order of function visitation. This may be called by the
@@ -63,6 +63,19 @@ class StyblinskiTangFunction
   {
     return arma::conv_to<MatType>::from(initialPoint);
   }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    MatType result(initialPoint.n_rows, initialPoint.n_cols);
+    for (size_t i = 0; i < result.n_elem; ++i)
+      result[i] = -2.903534;
+    return result;
+  }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return -39.16599 * n; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/three_hump_camel_function.hpp
+++ b/include/ensmallen_bits/problems/three_hump_camel_function.hpp
@@ -59,8 +59,16 @@ class ThreeHumpCamelFunction
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
+  //! This was previously -4.5; 4.5.
   template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-4.5; 4.5"); }
+  MatType GetInitialPoint() const { return MatType("1; 1"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/three_hump_camel_function.hpp
+++ b/include/ensmallen_bits/problems/three_hump_camel_function.hpp
@@ -59,7 +59,6 @@ class ThreeHumpCamelFunction
   size_t NumFunctions() const { return 1; }
 
   //! Get the starting point.
-  //! This was previously -4.5; 4.5.
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("1; 1"); }
 

--- a/include/ensmallen_bits/problems/wood_function.hpp
+++ b/include/ensmallen_bits/problems/wood_function.hpp
@@ -63,6 +63,13 @@ class WoodFunction
   template<typename MatType = arma::mat>
   MatType GetInitialPoint() const { return MatType("-3; -1; -3; -1"); }
 
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1; 1; 1; 1"); }
+
+  //! Get the final objective.
+  const double GetFinalObjective() const { return 0.0; }
+
   /**
    * Evaluate a function for a particular batch-size.
    *

--- a/tests/ada_bound_test.cpp
+++ b/tests/ada_bound_test.cpp
@@ -20,31 +20,19 @@ using namespace ens::test;
  */
 TEST_CASE("AdaBoundSphereFunctionTest", "[AdaBoundTest]")
 {
-  SphereFunction f(2);
   AdaBound optimizer(0.001, 2, 0.1, 1e-3, 0.9, 0.999, 1e-8, 500000,
       1e-3, false);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
  * Test the AdaBound optimizer on the Sphere function with arma::fmat.
  */
-TEST_CASE("AdaBoundphereFunctionTestFMat", "[AdaBoundTest]")
+TEST_CASE("AdaBoundSphereFunctionTestFMat", "[AdaBoundTest]")
 {
-  SphereFunction f(2);
   AdaBound optimizer(0.001, 2, 0.1, 1e-3, 0.9, 0.999, 1e-8, 500000,
       1e-3, false);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::fmat>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -52,15 +40,9 @@ TEST_CASE("AdaBoundphereFunctionTestFMat", "[AdaBoundTest]")
  */
 TEST_CASE("AMSBoundSphereFunctionTest", "[AdaBoundTest]")
 {
-  SphereFunction f(2);
   AMSBound optimizer(0.001, 2, 0.1, 1e-3, 0.9, 0.999, 1e-8, 500000,
       1e-3, false);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::mat>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -68,15 +50,9 @@ TEST_CASE("AMSBoundSphereFunctionTest", "[AdaBoundTest]")
  */
 TEST_CASE("AMSBoundphereFunctionTestFMat", "[AdaBoundTest]")
 {
-  SphereFunction f(2);
   AMSBound optimizer(0.001, 2, 0.1, 1e-3, 0.9, 0.999, 1e-8, 500000,
       1e-3, false);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::fmat>(optimizer, 0.5, 0.1);
 }
 
 #if ARMA_VERSION_MAJOR > 9 ||\
@@ -87,15 +63,9 @@ TEST_CASE("AMSBoundphereFunctionTestFMat", "[AdaBoundTest]")
  */
 TEST_CASE("AdaBoundSphereFunctionTestSpMat", "[AdaBoundTest]")
 {
-  SphereFunction f(2);
   AdaBound optimizer(0.001, 2, 0.1, 1e-3, 0.9, 0.999, 1e-8, 500000,
       1e-3, false);
-
-  arma::sp_mat coordinates = f.GetInitialPoint<arma::sp_mat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::sp_mat>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -120,15 +90,9 @@ TEST_CASE("AdaBoundSphereFunctionTestSpMatDenseGradient", "[AdaBoundTest]")
  */
 TEST_CASE("AMSBoundSphereFunctionTestSpMat", "[AdaBoundTest]")
 {
-  SphereFunction f(2);
   AMSBound optimizer(0.001, 2, 0.1, 1e-3, 0.9, 0.999, 1e-8, 500000,
       1e-3, false);
-
-  arma::sp_mat coordinates = f.GetInitialPoint<arma::sp_mat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::sp_mat>(optimizer, 0.5, 0.1);
 }
 
 /**

--- a/tests/ada_delta_test.cpp
+++ b/tests/ada_delta_test.cpp
@@ -19,70 +19,12 @@ using namespace ens;
 using namespace ens::test;
 
 /**
- * Tests the Adadelta optimizer using a simple test function.
- */
-TEST_CASE("SimpleAdaDeltaTestFunction", "[AdaDeltaTest]")
-{
-  SGDTestFunction f;
-  AdaDelta optimizer(1.0, 1, 0.05, 1e-6, 5000000, 1e-15, true, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.003));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.003));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.003));
-}
-
-/**
  * Run AdaDelta on logistic regression and make sure the results are acceptable.
  */
 TEST_CASE("AdaDeltaLogisticRegressionTest", "[AdaDeltaTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   AdaDelta adaDelta;
-  arma::mat coordinates = lr.GetInitialPoint();
-  adaDelta.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
-}
-
-/**
- * Tests the Adadelta optimizer using a simple test function with arma::fmat as
- * the type.
- */
-TEST_CASE("SimpleAdaDeltaTestFunctionFMat", "[AdaDeltaTest]")
-{
-  size_t trials = 3;
-  SGDTestFunction f;
-  arma::fmat coordinates;
-
-  for (size_t i = 0; i < trials; ++i)
-  {
-    coordinates = f.GetInitialPoint<arma::fmat>();
-
-    AdaDelta optimizer(2.0, 1, 0.05, 1e-6, 5000000, 1e-8, true, true);
-    optimizer.Optimize(f, coordinates);
-
-    if (arma::max(arma::vectorise(arma::abs(coordinates))) < 0.01f)
-      break;
-  }
-
-  REQUIRE(coordinates(0) == Approx(0.0f).margin(0.01));
-  REQUIRE(coordinates(1) == Approx(0.0f).margin(0.01));
-  REQUIRE(coordinates(2) == Approx(0.0f).margin(0.01));
+  LogisticRegressionFunctionTest(adaDelta, 0.003, 0.006, 1);
 }
 
 /**
@@ -91,22 +33,6 @@ TEST_CASE("SimpleAdaDeltaTestFunctionFMat", "[AdaDeltaTest]")
  */
 TEST_CASE("AdaDeltaLogisticRegressionTestFMat", "[AdaDeltaTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
   AdaDelta adaDelta;
-  arma::fmat coordinates = lr.GetInitialPoint();
-  adaDelta.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(adaDelta, 0.003, 0.006, 1);
 }

--- a/tests/ada_grad_test.cpp
+++ b/tests/ada_grad_test.cpp
@@ -18,69 +18,12 @@ using namespace ens;
 using namespace ens::test;
 
 /**
- * Tests the Adagrad optimizer using a simple test function.
- */
-TEST_CASE("SimpleAdaGradTestFunction", "[AdaGradTest]")
-{
-  SGDTestFunction f;
-  AdaGrad optimizer(0.99, 1, 1e-8, 5000000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.003));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.003));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.003));
-}
-
-/**
  * Run AdaGrad on logistic regression and make sure the results are acceptable.
  */
 TEST_CASE("AdaGradLogisticRegressionTest", "[AdaGradTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   AdaGrad adagrad(0.99, 32, 1e-8, 5000000, 1e-9, true);
-  arma::mat coordinates = lr.GetInitialPoint();
-  adagrad.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
-}
-
-/**
- * Tests the Adagrad optimizer using a simple test function with arma::fmat.
- */
-TEST_CASE("SimpleAdaGradTestFunctionFMat", "[AdaGradTest]")
-{
-  size_t trials = 3;
-  SGDTestFunction f;
-  arma::fmat coordinates;
-
-  for (size_t i = 0; i < trials; ++i)
-  {
-    coordinates = f.GetInitialPoint<arma::fmat>();
-
-    AdaGrad optimizer(0.99, 1, 1e-8, 5000000, 1e-9, true);
-    optimizer.Optimize(f, coordinates);
-
-    if (arma::max(arma::vectorise(arma::abs(coordinates))) < 0.01f)
-      break;
-  }
-
-  REQUIRE(coordinates(0) == Approx(0.0f).margin(0.01));
-  REQUIRE(coordinates(1) == Approx(0.0f).margin(0.01));
-  REQUIRE(coordinates(2) == Approx(0.0f).margin(0.01));
+  LogisticRegressionFunctionTest(adagrad, 0.003, 0.006);
 }
 
 /**
@@ -88,22 +31,6 @@ TEST_CASE("SimpleAdaGradTestFunctionFMat", "[AdaGradTest]")
  */
 TEST_CASE("AdaGradLogisticRegressionTestFMat", "[AdaGradTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
   AdaGrad adagrad(0.99, 32, 1e-8, 5000000, 1e-9, true);
-  arma::fmat coordinates = lr.GetInitialPoint();
-  adagrad.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest<arma::fmat>(adagrad, 0.003, 0.006);
 }

--- a/tests/adam_test.cpp
+++ b/tests/adam_test.cpp
@@ -25,14 +25,8 @@ using namespace ens::test;
  */
 TEST_CASE("AdamSphereFunctionTest", "[AdamTest]")
 {
-  SphereFunction f(2);
   Adam optimizer(0.5, 2, 0.7, 0.999, 1e-8, 500000, 1e-3, false);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction>(optimizer, 0.5, 0.2);
 }
 
 /**
@@ -40,14 +34,8 @@ TEST_CASE("AdamSphereFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamSphereFunctionTestFMat", "[AdamTest]")
 {
-  SphereFunction f(2);
   Adam optimizer(0.5, 2, 0.7, 0.999, 1e-8, 500000, 1e-3, false);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::fmat>(optimizer, 0.5, 0.2);
 }
 
 #if ARMA_VERSION_MAJOR > 9 ||\
@@ -58,14 +46,8 @@ TEST_CASE("AdamSphereFunctionTestFMat", "[AdamTest]")
  */
 TEST_CASE("AdamSphereFunctionTestSpMat", "[AdamTest]")
 {
-  SphereFunction f(2);
   Adam optimizer(0.5, 2, 0.7, 0.999, 1e-8, 500000, 1e-3, false);
-
-  arma::sp_mat coordinates = f.GetInitialPoint<arma::sp_mat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::sp_mat>(optimizer, 0.5, 0.2);
 }
 
 /**
@@ -91,14 +73,8 @@ TEST_CASE("AdamSphereFunctionTestSpMatDenseGradient", "[AdamTest]")
  */
 TEST_CASE("AdamStyblinskiTangFunctionTest", "[AdamTest]")
 {
-  StyblinskiTangFunction f(2);
   Adam optimizer(0.5, 2, 0.7, 0.999, 1e-8, 500000, 1e-3, false);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
+  FunctionTest<StyblinskiTangFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -106,15 +82,8 @@ TEST_CASE("AdamStyblinskiTangFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamMcCormickFunctionTest", "[AdamTest]")
 {
-  McCormickFunction f;
   Adam optimizer(0.5, 1, 0.7, 0.999, 1e-8, 500000, 1e-5, false);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  // 3% error tolerance.
-  REQUIRE(coordinates(0) == Approx(-0.547).epsilon(0.03));
-  REQUIRE(coordinates(1) == Approx(-1.547).epsilon(0.03));
+  FunctionTest<McCormickFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -122,17 +91,8 @@ TEST_CASE("AdamMcCormickFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamMatyasFunctionTest", "[AdamTest]")
 {
-  MatyasFunction f;
   Adam optimizer(0.5, 1, 0.7, 0.999, 1e-8, 500000, 1e-5, false);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  // 3% error tolerance.
-  REQUIRE((std::trunc(100.0 * coordinates(0)) / 100.0) ==
-      Approx(0.0).epsilon(0.003));
-  REQUIRE((std::trunc(100.0 * coordinates(1)) / 100.0) ==
-      Approx(0.0).epsilon(0.003));
+  FunctionTest<MatyasFunction>(optimizer, 0.1, 0.01);
 }
 
 /**
@@ -140,17 +100,8 @@ TEST_CASE("AdamMatyasFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamEasomFunctionTest", "[AdamTest]")
 {
-  EasomFunction f;
   Adam optimizer(0.2, 1, 0.7, 0.999, 1e-8, 500000, 1e-5, false);
-
-  arma::mat coordinates = arma::mat("2.9; 2.9");
-  optimizer.Optimize(f, coordinates);
-
-  // 5% error tolerance.
-  REQUIRE((std::trunc(100.0 * coordinates(0)) / 100.0) ==
-      Approx(3.14).epsilon(0.005));
-  REQUIRE((std::trunc(100.0 * coordinates(1)) / 100.0) ==
-      Approx(3.14).epsilon(0.005));
+  FunctionTest<EasomFunction>(optimizer, 1.5, 0.01);
 }
 
 /**
@@ -158,77 +109,18 @@ TEST_CASE("AdamEasomFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamBoothFunctionTest", "[AdamTest]")
 {
-  BoothFunction f;
   Adam optimizer(1e-1, 1, 0.7, 0.999, 1e-8, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(1.0).epsilon(0.002));
-  REQUIRE(coordinates(1) == Approx(3.0).epsilon(0.002));
+  FunctionTest<BoothFunction>(optimizer);
 }
 
-/**
- * Tests the Adam optimizer using a simple test function.
- */
-TEST_CASE("SimpleAdamTestFunction", "[AdamTest]")
-{
-  SGDTestFunction f;
-  Adam optimizer(1e-3, 1, 0.9, 0.999, 1e-8, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.3));
-}
-
-/**
- * Tests the AdaMax optimizer using a simple test function.
- */
-TEST_CASE("SimpleAdaMaxTestFunction", "[AdamTest]")
-{
-  SGDTestFunction f;
-  AdaMax optimizer(2e-3, 1, 0.9, 0.999, 1e-8, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.3));
-}
-
-/**
- * Tests the AMSGrad optimizer using a simple test function.
- */
-TEST_CASE("SimpleAMSGradTestFunction", "[AdamTest]")
-{
-  SGDTestFunction f;
-  AMSGrad optimizer(1e-3, 1, 0.9, 0.999, 1e-8, 500000, 1e-11, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.3));
-}
 
 /**
  * Test the AMSGrad optimizer on the Sphere function with arma::fmat.
  */
 TEST_CASE("AMSGradSphereFunctionTestFMat", "[AdamTest]")
 {
-  SphereFunction f(2);
   AMSGrad optimizer(1e-3, 1, 0.9, 0.999, 1e-8, 500000, 1e-11, true);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::fmat>(optimizer, 0.5, 0.1);
 }
 
 #if ARMA_VERSION_MAJOR > 9 || \
@@ -239,14 +131,8 @@ TEST_CASE("AMSGradSphereFunctionTestFMat", "[AdamTest]")
  */
 TEST_CASE("AMSGradSphereFunctionTestSpMat", "[AdamTest]")
 {
-  SphereFunction f(2);
   AMSGrad optimizer(1e-3, 1, 0.9, 0.999, 1e-8, 500000, 1e-11, true);
-
-  arma::sp_mat coordinates = f.GetInitialPoint<arma::sp_mat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::sp_mat>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -272,24 +158,8 @@ TEST_CASE("AMSGradSphereFunctionTestSpMatDenseGradient", "[AdamTest]")
  */
 TEST_CASE("AdamLogisticRegressionTest", "[AdamTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   Adam adam;
-  arma::mat coordinates = lr.GetInitialPoint();
-  adam.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(adam, 0.003, 0.006);
 }
 
 /**
@@ -297,24 +167,8 @@ TEST_CASE("AdamLogisticRegressionTest", "[AdamTest]")
  */
 TEST_CASE("AdaMaxLogisticRegressionTest", "[AdamTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   AdaMax adamax(1e-3, 1, 0.9, 0.999, 1e-8, 5000000, 1e-9, true);
-  arma::mat coordinates = lr.GetInitialPoint();
-  adamax.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(adamax, 0.003, 0.006);
 }
 
 /**
@@ -322,40 +176,8 @@ TEST_CASE("AdaMaxLogisticRegressionTest", "[AdamTest]")
  */
 TEST_CASE("AMSGradLogisticRegressionTest", "[AdamTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   AMSGrad amsgrad(1e-3, 1, 0.9, 0.999, 1e-8, 500000, 1e-11, true);
-  arma::mat coordinates = lr.GetInitialPoint();
-  amsgrad.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
-}
-
-/**
- * Tests the Nadam optimizer using a simple test function.
- */
-TEST_CASE("SimpleNadamTestFunction", "[AdamTest]")
-{
-  SGDTestFunction f;
-  Nadam optimizer(1e-3, 1, 0.9, 0.99, 1e-8, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.3));
+  LogisticRegressionFunctionTest(amsgrad, 0.003, 0.006);
 }
 
 /**
@@ -363,40 +185,8 @@ TEST_CASE("SimpleNadamTestFunction", "[AdamTest]")
  */
 TEST_CASE("NadamLogisticRegressionTest", "[AdamTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   Nadam nadam;
-  arma::mat coordinates = lr.GetInitialPoint();
-  nadam.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
-}
-
-/**
- * Tests the NadaMax optimizer using a simple test function.
- */
-TEST_CASE("SimpleNadaMaxTestFunction", "[AdamTest]")
-{
-  SGDTestFunction f;
-  NadaMax optimizer(1e-3, 1, 0.9, 0.99, 1e-8, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.3));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.3));
+  LogisticRegressionFunctionTest(nadam, 0.003, 0.006);
 }
 
 /**
@@ -404,101 +194,18 @@ TEST_CASE("SimpleNadaMaxTestFunction", "[AdamTest]")
  */
 TEST_CASE("NadaMaxLogisticRegressionTest", "[AdamTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   NadaMax nadamax(1e-3, 1, 0.9, 0.999, 1e-8, 5000000, 1e-9, true);
-  arma::mat coordinates = lr.GetInitialPoint();
-  nadamax.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(nadamax, 0.003, 0.006);
 }
 
 /**
- * Tests the OptimisticAdam optimizer using a simple test function.
- */
-TEST_CASE("SimpleOptimisticAdamTestFunction", "[AdamTest]")
-{
-  // Sometimes this test can fail randomly, so we allow it to run up to three
-  // times.
-  bool success = false;
-  for (size_t trial = 0; trial < 3; ++trial)
-  {
-    SGDTestFunction f;
-    OptimisticAdam optimizer(1e-2, 1, 0.9, 0.99, 1e-8);
-
-    arma::mat coordinates = f.GetInitialPoint();
-    optimizer.Optimize(f, coordinates);
-
-    success = (coordinates(0) == Approx(0.0).margin(0.3)) &&
-              (coordinates(1) == Approx(0.0).margin(0.3)) &&
-              (coordinates(2) == Approx(0.0).margin(0.3));
-    if (success)
-      break;
-  }
-
-  REQUIRE(success == true);
-}
-
-/**
- * Run OptimisticAdam on logistic regression and make sure the results are acceptable.
+ * Run OptimisticAdam on logistic regression and make sure the results are
+ * acceptable.
  */
 TEST_CASE("OptimisticAdamLogisticRegressionTest", "[AdamTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   OptimisticAdam optimisticAdam;
-  arma::mat coordinates = lr.GetInitialPoint();
-  optimisticAdam.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
-}
-
-/**
- * Tests the Padam optimizer using a simple test function.
- */
-TEST_CASE("SimplePadamTestFunction", "[AdamTest]")
-{
-  // Sometimes this test can fail randomly, so we allow it to run up to three
-  // times.
-  bool success = false;
-  for (size_t trial = 0; trial < 3; ++trial)
-  {
-    SGDTestFunction f;
-    Padam optimizer(1e-2, 1, 0.9, 0.99, 0.25, 1e-8);
-
-    arma::mat coordinates = f.GetInitialPoint();
-    optimizer.Optimize(f, coordinates);
-
-    success = (coordinates(0) == Approx(0.0).margin(0.3)) &&
-              (coordinates(1) == Approx(0.0).margin(0.3)) &&
-              (coordinates(2) == Approx(0.0).margin(0.3));
-    if (success)
-      break;
-  }
-
-  REQUIRE(success == true);
+  LogisticRegressionFunctionTest(optimisticAdam, 0.003, 0.006);
 }
 
 /**
@@ -506,41 +213,8 @@ TEST_CASE("SimplePadamTestFunction", "[AdamTest]")
  */
 TEST_CASE("PadamLogisticRegressionTest", "[AdamTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   Padam optimizer;
-  arma::mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
-}
-
-/**
- * Tests the QHadam optimizer using a simple test function.
- */
-TEST_CASE("SimpleQHAdamTestFunction", "[AdamTest]")
-{
-  SGDTestFunction f;
-  QHAdam optimizer(0.02, 32, 0.6, 0.9, 0.9, 0.999, 1e-8, 200000, 1e-7, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  bool success = (coordinates(0) == Approx(0.0).margin(0.3)) &&
-                 (coordinates(1) == Approx(0.0).margin(0.3)) &&
-                 (coordinates(2) == Approx(0.0).margin(0.3));
-  REQUIRE(success == true);
+  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006);
 }
 
 /**
@@ -548,24 +222,8 @@ TEST_CASE("SimpleQHAdamTestFunction", "[AdamTest]")
  */
 TEST_CASE("QHAdamLogisticRegressionTest", "[AdamTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   QHAdam optimizer;
-  arma::mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006);
 }
 
 /**
@@ -574,24 +232,8 @@ TEST_CASE("QHAdamLogisticRegressionTest", "[AdamTest]")
  */
 TEST_CASE("QHAdamLogisticRegressionFMatTest", "[AdamTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
   QHAdam optimizer;
-  arma::fmat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const float acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.03)); // 3% error tolerance.
-
-  const float testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.06)); // 6% error tolerance.
+  LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.03, 0.06);
 }
 
 #if ARMA_VERSION_MAJOR > 9 ||\
@@ -603,24 +245,8 @@ TEST_CASE("QHAdamLogisticRegressionFMatTest", "[AdamTest]")
  */
 TEST_CASE("QHAdamLogisticRegressionSpMatTest", "[AdamTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
   QHAdam optimizer;
-  arma::sp_mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.003, 0.006);
 }
 
 #endif
@@ -632,14 +258,8 @@ TEST_CASE("QHAdamLogisticRegressionSpMatTest", "[AdamTest]")
  */
 TEST_CASE("AdamAckleyFunctionTest", "[AdamTest]")
 {
-  AckleyFunction f;
   Adam optimizer(0.001, 2, 0.7, 0.999, 1e-8, 500000, 1e-7, false);
-
-  arma::mat coordinates = arma::mat("0.02; 0.02");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.001));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.001));
+  FunctionTest<AckleyFunction>(optimizer);
 }
 
 /**
@@ -649,14 +269,8 @@ TEST_CASE("AdamAckleyFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamBealeFunctionTest", "[AdamTest]")
 {
-  BealeFunction f;
   Adam optimizer(0.001, 2, 0.7, 0.999, 1e-8, 500000, 1e-7, false);
-
-  arma::mat coordinates = arma::mat("2.8; 0.35");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(3.0).margin(0.01));
-  REQUIRE(coordinates(1) == Approx(0.5).margin(0.01));
+  FunctionTest<BealeFunction>(optimizer, 0.1, 0.01);
 }
 
 /**
@@ -666,14 +280,8 @@ TEST_CASE("AdamBealeFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamGoldsteinPriceFunctionTest", "[AdamTest]")
 {
-  GoldsteinPriceFunction f;
   Adam optimizer(0.0001, 2, 0.7, 0.999, 1e-8, 500000, 1e-9, false);
-
-  arma::mat coordinates = arma::mat("0.2; -0.5");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0).margin(0.01));
-  REQUIRE(coordinates(1) == Approx(-1).margin(0.01));
+  FunctionTest<GoldsteinPriceFunction>(optimizer, 0.1, 0.01);
 }
 
 /**
@@ -683,14 +291,8 @@ TEST_CASE("AdamGoldsteinPriceFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamLevyFunctionTest", "[AdamTest]")
 {
-  LevyFunctionN13 f;
   Adam optimizer(0.001, 2, 0.7, 0.999, 1e-8, 500000, 1e-9, false);
-
-  arma::mat coordinates = arma::mat("0.9; 1.1");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(1).margin(0.01));
-  REQUIRE(coordinates(1) == Approx(1).margin(0.01));
+  FunctionTest<LevyFunctionN13>(optimizer, 0.1, 0.01);
 }
 
 /**
@@ -717,14 +319,8 @@ TEST_CASE("AdamHimmelblauFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamThreeHumpCamelFunctionTest", "[AdamTest]")
 {
-  ThreeHumpCamelFunction f;
   Adam optimizer(0.001, 2, 0.7, 0.999, 1e-8, 500000, 1e-9, false);
-
-  arma::mat coordinates = arma::mat("1; 1");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.01));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.01));
+  FunctionTest<ThreeHumpCamelFunction>(optimizer, 0.1, 0.01);
 }
 
 /**
@@ -734,12 +330,6 @@ TEST_CASE("AdamThreeHumpCamelFunctionTest", "[AdamTest]")
  */
 TEST_CASE("AdamSchafferFunctionN2Test", "[AdamTest]")
 {
-  SchafferFunctionN2 f;
   Adam optimizer(0.001, 2, 0.7, 0.999, 1e-8, 500000, 1e-9, false);
-
-  arma::mat coordinates = arma::mat("1; 1");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.01));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.01));
+  FunctionTest<SchafferFunctionN2>(optimizer, 0.1, 0.01);
 }

--- a/tests/bigbatch_sgd_test.cpp
+++ b/tests/bigbatch_sgd_test.cpp
@@ -22,28 +22,11 @@ using namespace ens::test;
  */
 TEST_CASE("BBSBBLogisticRegressionTest", "[BigBatchSGDTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
-  for (size_t batchSize = 40; batchSize < 50; batchSize += 5)
+  // Run big-batch SGD with a couple of batch sizes.
+  for (size_t batchSize = 350; batchSize < 360; batchSize += 5)
   {
-    BBS_Armijo bbsgd(batchSize, 0.005, 0.1, 10000, 1e-6, true, true);
-
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-    arma::mat coordinates = lr.GetInitialPoint();
-    bbsgd.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    BBS_BB bbsgd(batchSize, 0.001, 0.1, 10000, 1e-8, true, true);
+    LogisticRegressionFunctionTest(bbsgd, 0.003, 0.006, 3);
   }
 }
 
@@ -53,28 +36,11 @@ TEST_CASE("BBSBBLogisticRegressionTest", "[BigBatchSGDTest]")
  */
 TEST_CASE("BBSArmijoLogisticRegressionTest", "[BigBatchSGDTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run big-batch SGD with a couple of batch sizes.
   for (size_t batchSize = 40; batchSize < 50; batchSize += 1)
   {
     BBS_Armijo bbsgd(batchSize, 0.005, 0.1, 10000, 1e-6, true, true);
-
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-    arma::mat coordinates = lr.GetInitialPoint();
-    bbsgd.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest(bbsgd, 0.003, 0.006, 3);
   }
 }
 
@@ -84,28 +50,11 @@ TEST_CASE("BBSArmijoLogisticRegressionTest", "[BigBatchSGDTest]")
  */
 TEST_CASE("BBSBBLogisticRegressionFMatTest", "[BigBatchSGDTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run big-batch SGD with a couple of batch sizes.
   for (size_t batchSize = 350; batchSize < 360; batchSize += 5)
   {
     BBS_BB bbsgd(batchSize, 0.001, 0.1, 10000, 1e-8, true, true);
-
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-    arma::fmat coordinates = lr.GetInitialPoint();
-    bbsgd.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(bbsgd, 0.003, 0.006, 3);
   }
 }
 
@@ -115,28 +64,11 @@ TEST_CASE("BBSBBLogisticRegressionFMatTest", "[BigBatchSGDTest]")
  */
 TEST_CASE("BBSArmijoLogisticRegressionFMatTest", "[BigBatchSGDTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run big-batch SGD with a couple of batch sizes.
   for (size_t batchSize = 40; batchSize < 50; batchSize += 1)
   {
     BBS_Armijo bbsgd(batchSize, 0.01, 0.1, 10000, 1e-6, true, true);
-
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-    arma::fmat coordinates = lr.GetInitialPoint();
-    bbsgd.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(bbsgd, 0.003, 0.006, 5);
   }
 }
 
@@ -149,28 +81,11 @@ TEST_CASE("BBSArmijoLogisticRegressionFMatTest", "[BigBatchSGDTest]")
  */
 TEST_CASE("BBSBBLogisticRegressionSpMatTest", "[BigBatchSGDTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run big-batch SGD with a couple of batch sizes.
   for (size_t batchSize = 350; batchSize < 360; batchSize += 5)
   {
     BBS_BB bbsgd(batchSize, 0.005, 0.5, 10000, 1e-8, true, true);
-
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    bbsgd.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(bbsgd, 0.003, 0.006, 3);
   }
 }
 
@@ -180,28 +95,11 @@ TEST_CASE("BBSBBLogisticRegressionSpMatTest", "[BigBatchSGDTest]")
  */
 TEST_CASE("BBSArmijoLogisticRegressionSpMatTest", "[BigBatchSGDTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run big-batch SGD with a couple of batch sizes.
   for (size_t batchSize = 40; batchSize < 50; batchSize += 1)
   {
     BBS_Armijo bbsgd(batchSize, 0.01, 0.001, 10000, 1e-6, true, true);
-
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    bbsgd.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(bbsgd, 0.003, 0.006, 3);
   }
 }
 

--- a/tests/cmaes_test.cpp
+++ b/tests/cmaes_test.cpp
@@ -18,54 +18,13 @@ using namespace ens;
 using namespace ens::test;
 
 /**
- * Tests the CMA-ES optimizer using a simple test function.
- */
-TEST_CASE("SimpleTestFunction", "[CMAESTest]")
-{
-  SGDTestFunction f;
-  CMAES<> optimizer(0, -1, 1, 32, 200, -1);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.003));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.003));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.003));
-}
-
-/**
  * Run CMA-ES with the full selection policy on logistic regression and
  * make sure the results are acceptable.
  */
 TEST_CASE("CMAESLogisticRegressionTest", "[CMAESTest]")
 {
-  const size_t trials = 3;
-  bool success = false;
-  for (size_t trial = 0; trial < trials; ++trial)
-  {
-    arma::mat data, testData, shuffledData;
-    arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-    LogisticRegressionTestData(data, testData, shuffledData,
-        responses, testResponses, shuffledResponses);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    CMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
-    arma::mat coordinates = lr.GetInitialPoint();
-    cmaes.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    if (acc >= 99.7 && testAcc >= 99.4)
-    {
-      success = true;
-      break;
-    }
-  }
-
-  REQUIRE(success == true);
+  CMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
+  LogisticRegressionFunctionTest(cmaes, 0.003, 0.006, 5);
 }
 
 /**
@@ -74,33 +33,8 @@ TEST_CASE("CMAESLogisticRegressionTest", "[CMAESTest]")
  */
 TEST_CASE("ApproxCMAESLogisticRegressionTest", "[CMAESTest]")
 {
-  const size_t trials = 3;
-  bool success = false;
-  for (size_t trial = 0; trial < trials; ++trial)
-  {
-    arma::mat data, testData, shuffledData;
-    arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-    LogisticRegressionTestData(data, testData, shuffledData,
-        responses, testResponses, shuffledResponses);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    ApproxCMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
-    arma::mat coordinates = lr.GetInitialPoint();
-    cmaes.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    if (acc >= 99.7 && testAcc >= 99.4)
-    {
-      success = true;
-      break;
-    }
-  }
-
-  REQUIRE(success == true);
+  ApproxCMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
+  LogisticRegressionFunctionTest(cmaes, 0.003, 0.006, 5);
 }
 
 /**
@@ -109,33 +43,8 @@ TEST_CASE("ApproxCMAESLogisticRegressionTest", "[CMAESTest]")
  */
 TEST_CASE("CMAESLogisticRegressionFMatTest", "[CMAESTest]")
 {
-  const size_t trials = 3;
-  bool success = false;
-  for (size_t trial = 0; trial < trials; ++trial)
-  {
-    arma::fmat data, testData, shuffledData;
-    arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-    LogisticRegressionTestData(data, testData, shuffledData,
-        responses, testResponses, shuffledResponses);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    CMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
-    arma::fmat coordinates = lr.GetInitialPoint();
-    cmaes.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    if (acc >= 99.0 && testAcc >= 98.0)
-    {
-      success = true;
-      break;
-    }
-  }
-
-  REQUIRE(success == true);
+  CMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
+  LogisticRegressionFunctionTest<arma::fmat>(cmaes, 0.01, 0.02, 5);
 }
 
 /**
@@ -144,31 +53,6 @@ TEST_CASE("CMAESLogisticRegressionFMatTest", "[CMAESTest]")
  */
 TEST_CASE("ApproxCMAESLogisticRegressionFMatTest", "[CMAESTest]")
 {
-  const size_t trials = 3;
-  bool success = false;
-  for (size_t trial = 0; trial < trials; ++trial)
-  {
-    arma::fmat data, testData, shuffledData;
-    arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-    LogisticRegressionTestData(data, testData, shuffledData,
-        responses, testResponses, shuffledResponses);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    ApproxCMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
-    arma::fmat coordinates = lr.GetInitialPoint();
-    cmaes.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    if (acc >= 99.0 && testAcc >= 98.0)
-    {
-      success = true;
-      break;
-    }
-  }
-
-  REQUIRE(success == true);
+  ApproxCMAES<> cmaes(0, -1, 1, 32, 200, 1e-3);
+  LogisticRegressionFunctionTest<arma::fmat>(cmaes, 0.01, 0.02, 5);
 }

--- a/tests/cne_test.cpp
+++ b/tests/cne_test.cpp
@@ -24,24 +24,8 @@ using namespace std;
  */
 TEST_CASE("CNELogisticRegressionTest", "[CNETest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   CNE opt(300, 150, 0.2, 0.2, 0.2, -1);
-  arma::mat coordinates = lr.GetInitialPoint();
-  opt.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(opt, 0.003, 0.006);
 }
 
 /**
@@ -50,24 +34,8 @@ TEST_CASE("CNELogisticRegressionTest", "[CNETest]")
  */
 TEST_CASE("CNELogisticRegressionFMatTest", "[CNETest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
   CNE opt(300, 150, 0.2, 0.2, 0.2, -1);
-  arma::fmat coordinates = lr.GetInitialPoint();
-  opt.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest<arma::fmat>(opt, 0.003, 0.006);
 }
 
 /**
@@ -90,14 +58,8 @@ TEST_CASE("CNECrossInTrayFunctionTest", "[CNETest]")
  */
 TEST_CASE("CNEAckleyFunctionTest", "[CNETest]")
 {
-  AckleyFunction f;
   CNE optimizer(450, 1500, 0.3, 0.3, 0.3, -1);
-
-  arma::mat coordinates = arma::mat("3; 3");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0).margin(0.1));
+  FunctionTest<AckleyFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -105,14 +67,8 @@ TEST_CASE("CNEAckleyFunctionTest", "[CNETest]")
  */
 TEST_CASE("CNEBealeFunctionTest", "[CNETest]")
 {
-  BealeFunction f;
   CNE optimizer(450, 1500, 0.3, 0.3, 0.3, -1);
-
-  arma::mat coordinates = arma::mat("3; 3");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(3).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.5).margin(0.1));
+  FunctionTest<BealeFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -120,14 +76,8 @@ TEST_CASE("CNEBealeFunctionTest", "[CNETest]")
  */
 TEST_CASE("CNEGoldsteinPriceFunctionTest", "[CNETest]")
 {
-  GoldsteinPriceFunction f;
   CNE optimizer(450, 1500, 0.3, 0.3, 0.1, -1);
-
-  arma::mat coordinates = arma::mat("0.5; -0.5");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(-1).margin(0.1));
+  FunctionTest<GoldsteinPriceFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -135,14 +85,8 @@ TEST_CASE("CNEGoldsteinPriceFunctionTest", "[CNETest]")
  */
 TEST_CASE("CNELevyFunctionN13Test", "[CNETest]")
 {
-  LevyFunctionN13 f;
   CNE optimizer(450, 1500, 0.3, 0.3, 0.02, -1);
-
-  arma::mat coordinates = arma::mat("1.5; 0.5");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(1).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(1).margin(0.1));
+  FunctionTest<LevyFunctionN13>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -165,14 +109,8 @@ TEST_CASE("CNEHimmelblauFunctionTest", "[CNETest]")
  */
 TEST_CASE("CNEThreeHumpCamelFunctionTest", "[CNETest]")
 {
-  ThreeHumpCamelFunction f;
   CNE optimizer(450, 1500, 0.3, 0.3, 0.3, -1);
-
-  arma::mat coordinates = arma::mat("1; 1");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0).margin(0.1));
+  FunctionTest<ThreeHumpCamelFunction>(optimizer, 0.5, 0.1);
 }
 
 // TODO: The CNE optimizer with the given parameter occasionally fails to find a
@@ -186,11 +124,23 @@ TEST_CASE("CNESchafferFunctionN4Test", "[CNETest]")
   SchafferFunctionN4 f;
   CNE optimizer(500, 1600, 0.3, 0.3, 0.3, -1);
 
-  arma::mat coordinates = arma::mat("0.5; 2");
-  optimizer.Optimize(f, coordinates);
+  // We allow a few trials.
+  for (size_t trial = 0; trial < 5; ++trial)
+  {
+    arma::mat coordinates = arma::mat("0.5; 2");
+    optimizer.Optimize(f, coordinates);
 
-  REQUIRE(coordinates(0) == Approx(0).margin(0.1));
-  REQUIRE(abs(coordinates(1)) == Approx(1.25313).margin(0.1));
+    if (trial != 4)
+    {
+      if (coordinates(0) != Approx(0).margin(0.1))
+        continue;
+      if (abs(coordinates(1)) != Approx(1.25313).margin(0.1))
+        continue;
+    }
+
+    REQUIRE(coordinates(0) == Approx(0).margin(0.1));
+    REQUIRE(abs(coordinates(1)) == Approx(1.25313).margin(0.1));
+  }
 }
 
 /**
@@ -198,12 +148,7 @@ TEST_CASE("CNESchafferFunctionN4Test", "[CNETest]")
  */
 TEST_CASE("CNESchafferFunctionN2Test", "[CNETest]")
 {
-  SchafferFunctionN2 f;
+  // We allow a few trials in case convergence is not achieved.
   CNE optimizer(500, 1600, 0.3, 0.3, 0.3, -1);
-
-  arma::mat coordinates = arma::mat("0.5; -0.5");
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0).margin(0.1));
+  FunctionTest<SchafferFunctionN2>(optimizer, 0.5, 0.1, 7);
 }

--- a/tests/de_test.cpp
+++ b/tests/de_test.cpp
@@ -20,24 +20,8 @@ using namespace ens::test;
  */
 TEST_CASE("DELogisticRegressionTest", "[DETest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   DE opt(200, 1000, 0.6, 0.8, 1e-5);
-  arma::mat coordinates = lr.GetInitialPoint();
-  opt.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(opt, 0.01, 0.02, 3);
 }
 
 /**
@@ -46,22 +30,6 @@ TEST_CASE("DELogisticRegressionTest", "[DETest]")
  */
 TEST_CASE("DELogisticRegressionFMatTest", "[DETest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData, responses,
-      testResponses, shuffledResponses);
-  LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
   DE opt(200, 1000, 0.6, 0.8, 1e-5);
-  arma::fmat coordinates = lr.GetInitialPoint();
-  opt.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const float acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.03)); // 3% error tolerance.
-
-  const float testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.06)); // 6% error tolerance.
+  LogisticRegressionFunctionTest<arma::fmat>(opt, 0.03, 0.06, 3);
 }

--- a/tests/eve_test.cpp
+++ b/tests/eve_test.cpp
@@ -18,44 +18,12 @@ using namespace ens;
 using namespace ens::test;
 
 /**
- * Test the Eve optimizer on the simple SGD function.
- */
-TEST_CASE("EveSGDFunction","[EveTest]")
-{
-  SGDTestFunction f;
-  Eve optimizer(1e-3, 1, 0.9, 0.999, 0.999, 1e-8, 10, 400000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.1));
-}
-
-/**
  * Run Eve on logistic regression and make sure the results are acceptable.
  */
 TEST_CASE("EveLogisticRegressionTest","[EveTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   Eve optimizer(1e-3, 1, 0.9, 0.999, 0.999, 1e-8, 10000, 500000, 1e-9, true);
-  arma::mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006);
 }
 
 /**
@@ -63,14 +31,8 @@ TEST_CASE("EveLogisticRegressionTest","[EveTest]")
  */
 TEST_CASE("EveSphereFunctionTest","[EveTest]")
 {
-  SphereFunction f(2);
   Eve optimizer(1e-3, 2, 0.9, 0.999, 0.999, 1e-8, 10000, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -78,14 +40,8 @@ TEST_CASE("EveSphereFunctionTest","[EveTest]")
  */
 TEST_CASE("EveStyblinskiTangFunctionTest","[EveTest]")
 {
-  StyblinskiTangFunction f(2);
   Eve optimizer(1e-3, 2, 0.9, 0.999, 0.999, 1e-8, 10000, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01));
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01));
+  FunctionTest<StyblinskiTangFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -94,14 +50,8 @@ TEST_CASE("EveStyblinskiTangFunctionTest","[EveTest]")
  */
 TEST_CASE("EveStyblinskiTangFunctionFMatTest","[EveTest]")
 {
-  StyblinskiTangFunction f(2);
   Eve optimizer(1e-3, 2, 0.9, 0.999, 0.999, 1e-8, 10000, 500000, 1e-9, true);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01));
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01));
+  FunctionTest<StyblinskiTangFunction, arma::fmat>(optimizer, 0.5, 0.1);
 }
 
 #if ARMA_VERSION_MAJOR > 9 ||\
@@ -113,14 +63,8 @@ TEST_CASE("EveStyblinskiTangFunctionFMatTest","[EveTest]")
  */
 TEST_CASE("EveStyblinskiTangFunctionSpMatTest","[EveTest]")
 {
-  StyblinskiTangFunction f(2);
   Eve optimizer(1e-3, 2, 0.9, 0.999, 0.999, 1e-8, 10000, 500000, 1e-9, true);
-
-  arma::sp_mat coordinates = f.GetInitialPoint<arma::sp_mat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01));
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01));
+  FunctionTest<StyblinskiTangFunction, arma::sp_mat>(optimizer, 0.5, 0.1);
 }
 
 #endif

--- a/tests/ftml_test.cpp
+++ b/tests/ftml_test.cpp
@@ -18,44 +18,12 @@ using namespace ens;
 using namespace ens::test;
 
 /**
- * Test the FTML optimizer on the simple SGD function.
- */
-TEST_CASE("FTMLSGDFunction", "[FTMLTest]")
-{
-  SGDTestFunction f;
-  FTML optimizer(0.005, 1, 0.9, 0.999, 1e-8, 1000000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.1));
-}
-
-/**
  * Run FTML on logistic regression and make sure the results are acceptable.
  */
 TEST_CASE("FTMLLogisticRegressionTest", "[FTMLTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   FTML optimizer(0.001, 1, 0.9, 0.999, 1e-8, 100000, 1e-5, true);
-  arma::mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006);
 }
 
 /**
@@ -63,13 +31,8 @@ TEST_CASE("FTMLLogisticRegressionTest", "[FTMLTest]")
  */
 TEST_CASE("FTMLSphereFunctionTest", "[FTMLTest]")
 {
-  SphereFunction f(2);
   FTML optimizer(0.001, 2, 0.9, 0.999, 1e-8, 500000, 1e-9, true);
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -77,14 +40,8 @@ TEST_CASE("FTMLSphereFunctionTest", "[FTMLTest]")
  */
 TEST_CASE("FTMLStyblinskiTangFunctionTest", "[FTMLTest]")
 {
-  StyblinskiTangFunction f(2);
   FTML optimizer(0.001, 2, 0.9, 0.999, 1e-8, 100000, 1e-5, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01));
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01));
+  FunctionTest<StyblinskiTangFunction>(optimizer, 0.5, 0.1);
 }
 
 /**
@@ -93,14 +50,8 @@ TEST_CASE("FTMLStyblinskiTangFunctionTest", "[FTMLTest]")
  */
 TEST_CASE("FTMLStyblinskiTangFunctionFMatTest", "[FTMLTest]")
 {
-  StyblinskiTangFunction f(2);
   FTML optimizer(0.001, 2, 0.9, 0.999, 1e-8, 100000, 1e-5, true);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01));
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01));
+  FunctionTest<StyblinskiTangFunction, arma::fmat>(optimizer, 0.5, 0.1);
 }
 
 // A test with sp_mat is not done, because FTML uses some parts internally that

--- a/tests/gradient_descent_test.cpp
+++ b/tests/gradient_descent_test.cpp
@@ -12,50 +12,25 @@
 
 #include <ensmallen.hpp>
 #include "catch.hpp"
+#include "test_function_tools.hpp"
 
 using namespace ens;
 using namespace ens::test;
 
 TEST_CASE("SimpleGDTestFunction", "[GradientDescentTest]")
 {
-  GDTestFunction f;
   GradientDescent s(0.01, 5000000, 1e-9);
-
-  arma::mat coordinates = f.GetInitialPoint<arma::mat>();
-  double result = s.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(0.0).margin(1e-4));
-  REQUIRE(coordinates(0) == Approx(0.0).margin(1e-2));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(1e-2));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(1e-2));
+  FunctionTest<GDTestFunction>(s, 0.1, 0.01);
 }
 
 TEST_CASE("GDRosenbrockTest", "[GradientDescentTest]")
 {
-  // Create the Rosenbrock function.
-  RosenbrockFunction f;
-
   GradientDescent s(0.001, 0, 1e-15);
-
-  arma::mat coordinates = f.GetInitialPoint<arma::mat>();
-  double result = s.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(0.0).margin(1e-10));
-  for (size_t j = 0; j < 2; ++j)
-    REQUIRE(coordinates(j) == Approx(1.0).epsilon(1e-5));
+  FunctionTest<RosenbrockFunction>(s, 0.01, 0.001);
 }
 
 TEST_CASE("GDRosenbrockFMatTest", "[GradientDescentTest]")
 {
-  // Create the Rosenbrock function.
-  RosenbrockFunction f;
-
   GradientDescent s(0.001, 0, 1e-15);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  float result = s.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(0.0).margin(1e-5));
-  for (size_t j = 0; j < 2; ++j)
-    REQUIRE(coordinates(j) == Approx(1.0).epsilon(1e-3));
+  FunctionTest<RosenbrockFunction, arma::fmat>(s, 0.1, 0.01);
 }

--- a/tests/iqn_test.cpp
+++ b/tests/iqn_test.cpp
@@ -22,29 +22,11 @@ using namespace ens::test;
  */
 TEST_CASE("IQNLogisticRegressionTest", "[IQNTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-  // Now run SGDR with snapshot ensembles on a couple of batch sizes.
+  // Run on a couple of batch sizes.
   for (size_t batchSize = 1; batchSize < 9; batchSize += 4)
   {
     IQN iqn(0.01, batchSize, 5000, 0.01);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::mat coordinates = lr.GetInitialPoint();
-    iqn.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.013)); // 1.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.016)); // 1.6% error tolerance.
+    LogisticRegressionFunctionTest(iqn, 0.013, 0.016);
   }
 }
 
@@ -54,28 +36,10 @@ TEST_CASE("IQNLogisticRegressionTest", "[IQNTest]")
  */
 TEST_CASE("IQNLogisticRegressionFMatTest", "[IQNTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-  // Now run SGDR with snapshot ensembles on a couple of batch sizes.
+  // Run on a couple of batch sizes.
   for (size_t batchSize = 1; batchSize < 9; batchSize += 4)
   {
     IQN iqn(0.001, batchSize, 5000, 0.01);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::fmat coordinates = lr.GetInitialPoint();
-    iqn.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.013)); // 1.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.016)); // 1.6% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(iqn, 0.013, 0.016);
   }
 }

--- a/tests/katyusha_test.cpp
+++ b/tests/katyusha_test.cpp
@@ -21,28 +21,11 @@ using namespace ens::test;
  */
 TEST_CASE("KatyushaLogisticRegressionTest", "[KatyushaTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 45; batchSize += 5)
   {
     Katyusha optimizer(1.0, 10.0, batchSize, 100, 0, 1e-10, true);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest(optimizer, 0.015, 0.015);
   }
 }
 
@@ -52,28 +35,11 @@ TEST_CASE("KatyushaLogisticRegressionTest", "[KatyushaTest]")
  */
 TEST_CASE("KatyushaProximalLogisticRegressionTest", "[KatyushaTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 45; batchSize += 5)
   {
     KatyushaProximal optimizer(1.0, 10.0, batchSize, 100, 0, 1e-10, true);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest(optimizer, 0.015, 0.015);
   }
 }
 
@@ -83,28 +49,11 @@ TEST_CASE("KatyushaProximalLogisticRegressionTest", "[KatyushaTest]")
  */
 TEST_CASE("KatyushaLogisticRegressionFMatTest", "[KatyushaTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 45; batchSize += 5)
   {
     Katyusha optimizer(1.0, 10.0, batchSize, 100, 0, 1e-10, true);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::fmat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.015, 0.015);
   }
 }
 
@@ -114,28 +63,11 @@ TEST_CASE("KatyushaLogisticRegressionFMatTest", "[KatyushaTest]")
  */
 TEST_CASE("KatyushaProximalLogisticRegressionFMatTest", "[KatyushaTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 45; batchSize += 5)
   {
     KatyushaProximal optimizer(1.0, 10.0, batchSize, 100, 0, 1e-10, true);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::fmat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.015, 0.015);
   }
 }
 
@@ -148,28 +80,11 @@ TEST_CASE("KatyushaProximalLogisticRegressionFMatTest", "[KatyushaTest]")
  */
 TEST_CASE("KatyushaLogisticRegressionSpMatTest", "[KatyushaTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 45; batchSize += 5)
   {
     Katyusha optimizer(1.0, 10.0, batchSize, 100, 0, 1e-10, true);
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.015, 0.015);
   }
 }
 
@@ -179,28 +94,11 @@ TEST_CASE("KatyushaLogisticRegressionSpMatTest", "[KatyushaTest]")
  */
 TEST_CASE("KatyushaProximalLogisticRegressionSpMatTest", "[KatyushaTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run big-batch SGD with a couple of batch sizes.
+  // Run with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 45; batchSize += 5)
   {
     KatyushaProximal optimizer(1.0, 10.0, batchSize, 100, 0, 1e-10, true);
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.015, 0.015);
   }
 }
 

--- a/tests/lbfgs_test.cpp
+++ b/tests/lbfgs_test.cpp
@@ -12,6 +12,7 @@
 
 #include <ensmallen.hpp>
 #include "catch.hpp"
+#include "test_function_tools.hpp"
 
 using namespace ens;
 using namespace ens::test;
@@ -21,18 +22,9 @@ using namespace ens::test;
  */
 TEST_CASE("RosenbrockFunctionTest", "[LBFGSTest]")
 {
-  RosenbrockFunction f;
   L_BFGS lbfgs;
   lbfgs.MaxIterations() = 10000;
-
-  arma::mat coords = f.GetInitialPoint();
-  lbfgs.Optimize(f, coords);
-
-  double finalValue = f.Evaluate(coords);
-
-  REQUIRE(finalValue == Approx(0.0).margin(1e-5));
-  REQUIRE(coords(0) == Approx(1.0).epsilon(1e-7));
-  REQUIRE(coords(1) == Approx(1.0).epsilon(1e-7));
+  FunctionTest<RosenbrockFunction>(lbfgs, 0.01, 0.001);
 }
 
 /**
@@ -40,18 +32,9 @@ TEST_CASE("RosenbrockFunctionTest", "[LBFGSTest]")
  */
 TEST_CASE("RosenbrockFunctionFloatTest", "[LBFGSTest]")
 {
-  RosenbrockFunction f;
   L_BFGS lbfgs;
   lbfgs.MaxIterations() = 10000;
-
-  arma::fmat coords = f.GetInitialPoint<arma::fvec>();
-  lbfgs.Optimize(f, coords);
-
-  float finalValue = f.Evaluate(coords);
-
-  REQUIRE(finalValue == Approx(0.0f).margin(1e-3));
-  REQUIRE(coords(0) == Approx(1.0f).epsilon(1e-4));
-  REQUIRE(coords(1) == Approx(1.0f).epsilon(1e-4));
+  FunctionTest<RosenbrockFunction, arma::fmat>(lbfgs, 0.1, 0.01);
 }
 
 /**
@@ -79,18 +62,9 @@ TEST_CASE("RosenbrockFunctionSpGradTest", "[LBFGSTest]")
  */
 TEST_CASE("RosenbrockFunctionSpMatTest", "[LBFGSTest]")
 {
-  RosenbrockFunction f;
   L_BFGS lbfgs;
   lbfgs.MaxIterations() = 10000;
-
-  arma::sp_mat coords = f.GetInitialPoint<arma::sp_vec>();
-  lbfgs.Optimize(f, coords);
-
-  double finalValue = f.Evaluate(coords);
-
-  REQUIRE(finalValue == Approx(0.0).margin(1e-5));
-  REQUIRE(coords(0) == Approx(1.0).epsilon(1e-7));
-  REQUIRE(coords(1) == Approx(1.0).epsilon(1e-7));
+  FunctionTest<RosenbrockFunction, arma::sp_mat>(lbfgs, 0.01, 0.001);
 }
 
 /**
@@ -98,15 +72,9 @@ TEST_CASE("RosenbrockFunctionSpMatTest", "[LBFGSTest]")
  */
 TEST_CASE("ColvilleFunctionTest", "[LBFGSTest]")
 {
-  ColvilleFunction f;
   L_BFGS lbfgs;
   lbfgs.MaxIterations() = 10000;
-
-  arma::vec coords = f.GetInitialPoint();
-  lbfgs.Optimize(f, coords);
-
-  REQUIRE(coords(0) == Approx(1.0).epsilon(1e-7));
-  REQUIRE(coords(1) == Approx(1.0).epsilon(1e-7));
+  FunctionTest<ColvilleFunction>(lbfgs, 0.01, 0.001);
 }
 
 /**
@@ -114,20 +82,9 @@ TEST_CASE("ColvilleFunctionTest", "[LBFGSTest]")
  */
 TEST_CASE("WoodFunctionTest", "[LBFGSTest]")
 {
-  WoodFunction f;
   L_BFGS lbfgs;
   lbfgs.MaxIterations() = 10000;
-
-  arma::vec coords = f.GetInitialPoint();
-  lbfgs.Optimize(f, coords);
-
-  double finalValue = f.Evaluate(coords);
-
-  REQUIRE(finalValue == Approx(0.0).margin(1e-5));
-  REQUIRE(coords(0) == Approx(1.0).epsilon(1e-7));
-  REQUIRE(coords(1) == Approx(1.0).epsilon(1e-7));
-  REQUIRE(coords(2) == Approx(1.0).epsilon(1e-7));
-  REQUIRE(coords(3) == Approx(1.0).epsilon(1e-7));
+  FunctionTest<WoodFunction>(lbfgs, 0.01, 0.001);
 }
 
 /**
@@ -164,19 +121,7 @@ TEST_CASE("GeneralizedRosenbrockFunctionTest", "[LBFGSTest]")
  */
 TEST_CASE("RosenbrockWoodFunctionTest", "[LBFGSTest]")
 {
-  RosenbrockWoodFunction f;
   L_BFGS lbfgs;
   lbfgs.MaxIterations() = 10000;
-
-  arma::mat coords = f.GetInitialPoint();
-  lbfgs.Optimize(f, coords);
-
-  double finalValue = f.Evaluate(coords);
-
-  REQUIRE(finalValue == Approx(0.0).margin(1e-5));
-  for (int row = 0; row < 4; row++)
-  {
-    REQUIRE((coords(row, 0)) == Approx(1.0).epsilon(1e-7));
-    REQUIRE((coords(row, 1)) == Approx(1.0).epsilon(1e-7));
-  }
+  FunctionTest<RosenbrockWoodFunction>(lbfgs, 0.01, 0.001);
 }

--- a/tests/lookahead_test.cpp
+++ b/tests/lookahead_test.cpp
@@ -20,38 +20,13 @@ using namespace ens::test;
  */
 TEST_CASE("LookaheadAdamSphereFunctionTest", "[LookaheadTest]")
 {
-  SphereFunction f(2);
-
   Lookahead<> optimizer(0.5, 5, 100000, 1e-5, NoDecay(), false, true);
   optimizer.BaseOptimizer().StepSize() = 0.1;
   optimizer.BaseOptimizer().BatchSize() = 2;
   optimizer.BaseOptimizer().Beta1() = 0.7;
   optimizer.BaseOptimizer().Tolerance() = 1e-15;
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
-}
-
-/**
- * Test the Lookahead - Adam optimizer on the SGDTest function.
- */
-TEST_CASE("LookaheadAdamSimpleSGDTestFunction", "[LookaheadTest]")
-{
-  SGDTestFunction f;
-
-  Adam adam(0.001, 1, 0.9, 0.999, 1e-8, 5, 1e-19, false, true);
-  Lookahead<Adam> optimizer(adam, 0.5, 5, 100000, 1e-15, NoDecay(),
-      false, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(1e-3));
+  // We allow a few trials.
+  FunctionTest<SphereFunction>(optimizer, 0.5, 0.2, 3);
 }
 
 /**
@@ -59,17 +34,10 @@ TEST_CASE("LookaheadAdamSimpleSGDTestFunction", "[LookaheadTest]")
  */
 TEST_CASE("LookaheadAdaGradSphereFunction", "[LookaheadTest]")
 {
-  SphereFunction f(2);
-
   AdaGrad adagrad(0.99, 1, 1e-8, 5, 1e-15, true);
   Lookahead<AdaGrad> optimizer(adagrad, 0.5, 5, 5000000, 1e-15, NoDecay(),
       false, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction>(optimizer, 0.5, 0.2, 3);
 }
 
 /**
@@ -78,44 +46,19 @@ TEST_CASE("LookaheadAdaGradSphereFunction", "[LookaheadTest]")
  */
 TEST_CASE("LookaheadAdamLogisticRegressionTest","[LookaheadTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   Adam adam(0.001, 32, 0.9, 0.999, 1e-8, 5, 1e-19);
   Lookahead<Adam> optimizer(adam, 0.5, 20, 100000, 1e-15, NoDecay(),
       false, true);
-
-  arma::mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006);
 }
 
 /**
- * Test the Lookahead - Adam optimizer on the SGDTest function (float).
+ * Test the Lookahead - Adam optimizer on the Sphere function (float).
  */
-TEST_CASE("LookaheadAdamSimpleSGDTestFunctionFloat", "[LookaheadTest]")
+TEST_CASE("LookaheadAdamSimpleSphereFunctionFloat", "[LookaheadTest]")
 {
-  SGDTestFunction f;
-
   Adam adam(0.001, 1, 0.9, 0.999, 1e-8, 5, 1e-19, false, true);
   Lookahead<Adam> optimizer(adam, 0.5, 5, 100000, 1e-15, NoDecay(),
       false, true);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(1e-3));
+  FunctionTest<SphereFunction, arma::fmat>(optimizer, 0.5, 0.2, 3);
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -22,9 +22,9 @@ int main(int argc, char** argv)
    * each run.  This is good for ensuring that a test's tolerance is sufficient
    * across many different runs.
    */
-  //size_t seed = std::time(NULL);
-  //srand((unsigned int) seed);
-  //arma::arma_rng::set_seed(seed);
+  size_t seed = std::time(NULL);
+  srand((unsigned int) seed);
+  arma::arma_rng::set_seed(seed);
 
   std::cout << "ensmallen version: " << ens::version::as_string() << std::endl;
 

--- a/tests/nesterov_momentum_sgd_test.cpp
+++ b/tests/nesterov_momentum_sgd_test.cpp
@@ -29,7 +29,7 @@ TEST_CASE("NesterovMomentumSGDSpeedUpTestFunction", "[NesterovMomentumSGDTest]")
   arma::mat coordinates = f.GetInitialPoint();
   double result = s.Optimize(f, coordinates);
 
-  REQUIRE(result == Approx(-1.0).epsilon(0.0025));
+  REQUIRE(result == Approx(-1.0).margin(0.01));
   REQUIRE(coordinates(0) == Approx(0.0).margin(3e-3));
   REQUIRE(coordinates(1) == Approx(0.0).margin(1e-6));
   REQUIRE(coordinates(2) == Approx(0.0).margin(1e-6));
@@ -54,7 +54,7 @@ TEST_CASE("NesterovMomentumSGDGeneralizedRosenbrockTest", "[NesterovMomentumSGDT
 
     REQUIRE(result == Approx(0.0).margin(1e-4));
     for (size_t j = 0; j < i; ++j)
-      REQUIRE(coordinates(j) == Approx(1.0).epsilon(1e-5));
+      REQUIRE(coordinates(j) == Approx(1.0).epsilon(0.003));
   }
 }
 
@@ -76,15 +76,15 @@ TEST_CASE("NesterovMomentumSGDGeneralizedRosenbrockFMatTest",
     size_t trial = 0;
     float result = std::numeric_limits<float>::max();
     arma::fmat coordinates;
-    while (trial++ < 5 && result > 0.1)
+    while (trial++ < 8 && result > 0.1)
     {
       coordinates = f.GetInitialPoint<arma::fmat>();
       result = s.Optimize(f, coordinates);
     }
 
-    REQUIRE(result == Approx(0.0).margin(1e-2));
+    REQUIRE(result == Approx(0.0).margin(0.02));
     for (size_t j = 0; j < i; ++j)
-      REQUIRE(coordinates(j) == Approx(1.0).epsilon(1e-2));
+      REQUIRE(coordinates(j) == Approx(1.0).margin(0.05));
   }
 }
 
@@ -108,6 +108,6 @@ TEST_CASE("NesterovMomentumSGDGeneralizedRosenbrockSpMatTest",
 
     REQUIRE(result == Approx(0.0).margin(1e-4));
     for (size_t j = 0; j < i; ++j)
-      REQUIRE(coordinates(j) == Approx(1.0).epsilon(1e-5));
+      REQUIRE(coordinates(j) == Approx(1.0).epsilon(0.003));
   }
 }

--- a/tests/nsga2_test.cpp
+++ b/tests/nsga2_test.cpp
@@ -44,25 +44,37 @@ TEST_CASE("NSGA2SchafferN1Test", "[NSGA2Test]")
   typedef decltype(SCH.objectiveA) ObjectiveTypeA;
   typedef decltype(SCH.objectiveB) ObjectiveTypeB;
 
-  arma::mat coords = SCH.GetInitialPoint();
-  std::tuple<ObjectiveTypeA, ObjectiveTypeB> objectives = SCH.GetObjectives();
-
-  opt.Optimize(objectives, coords);
-  std::vector<arma::mat> bestFront = opt.Front();
-
-  bool allInRange = true;
-
-  for (arma::mat solution: bestFront)
+  // We allow a few trials in case of poor convergence.
+  bool success = false;
+  for (size_t trial = 0; trial < 3; ++trial)
   {
-    double val = arma::as_scalar(solution);
+    arma::mat coords = SCH.GetInitialPoint();
+    std::tuple<ObjectiveTypeA, ObjectiveTypeB> objectives = SCH.GetObjectives();
 
-    if (val < 0.0 || val > 2.0)
+    opt.Optimize(objectives, coords);
+    std::vector<arma::mat> bestFront = opt.Front();
+
+    bool allInRange = true;
+
+    for (arma::mat solution: bestFront)
     {
-      allInRange = false;
+      double val = arma::as_scalar(solution);
+
+      if (val < 0.0 || val > 2.0)
+      {
+        allInRange = false;
+        break;
+      }
+    }
+
+    if (allInRange)
+    {
+      success = true;
       break;
     }
   }
-  REQUIRE(allInRange);
+
+  REQUIRE(success == true);
 }
 
 /**
@@ -70,6 +82,7 @@ TEST_CASE("NSGA2SchafferN1Test", "[NSGA2Test]")
  */
 TEST_CASE("NSGA2SchafferN1TestVectorBounds", "[NSGA2Test]")
 {
+  // This test can be a little flaky, so we try it a few times.
   SchafferFunctionN1<arma::mat> SCH;
   const arma::vec lowerBound = {-1000};
   const arma::vec upperBound = {1000};
@@ -79,25 +92,36 @@ TEST_CASE("NSGA2SchafferN1TestVectorBounds", "[NSGA2Test]")
   typedef decltype(SCH.objectiveA) ObjectiveTypeA;
   typedef decltype(SCH.objectiveB) ObjectiveTypeB;
 
-  arma::mat coords = SCH.GetInitialPoint();
-  std::tuple<ObjectiveTypeA, ObjectiveTypeB> objectives = SCH.GetObjectives();
-
-  opt.Optimize(objectives, coords);
-  std::vector<arma::mat> bestFront = opt.Front();
-
-  bool allInRange = true;
-
-  for (arma::mat solution: bestFront)
+  bool success = false;
+  for (size_t trial = 0; trial < 3; ++trial)
   {
-    double val = arma::as_scalar(solution);
+    arma::mat coords = SCH.GetInitialPoint();
+    std::tuple<ObjectiveTypeA, ObjectiveTypeB> objectives = SCH.GetObjectives();
 
-    if (val < 0.0 || val > 2.0)
+    opt.Optimize(objectives, coords);
+    std::vector<arma::mat> bestFront = opt.Front();
+
+    bool allInRange = true;
+
+    for (arma::mat solution: bestFront)
     {
-      allInRange = false;
+      double val = arma::as_scalar(solution);
+
+      if (val < 0.0 || val > 2.0)
+      {
+        allInRange = false;
+        break;
+      }
+    }
+
+    if (allInRange)
+    {
+      success = true;
       break;
     }
   }
-  REQUIRE(allInRange);
+
+  REQUIRE(success == true);
 }
 
 /**

--- a/tests/parallel_sgd_test.cpp
+++ b/tests/parallel_sgd_test.cpp
@@ -30,8 +30,6 @@ using namespace ens::test;
  */
 TEST_CASE("SimpleParallelSGDTest", "[ParallelSGDTest]")
 {
-  SparseTestFunction f;
-
   ConstantStep decayPolicy(0.4);
 
   // The batch size for this test should be chosen according to the threads
@@ -47,19 +45,7 @@ TEST_CASE("SimpleParallelSGDTest", "[ParallelSGDTest]")
     size_t batchSize = std::ceil((float) f.NumFunctions() / i);
 
     ParallelSGD<ConstantStep> s(10000, batchSize, 1e-5, true, decayPolicy);
-
-    arma::mat coordinates = f.GetInitialPoint<arma::mat>();
-    double result = s.Optimize(f, coordinates);
-
-    // The final value of the objective function should be close to the optimal
-    // value, that is the sum of values at the vertices of the parabolas.
-    REQUIRE(result == Approx(123.75).epsilon(0.0001));
-
-    // The co-ordinates should be the vertices of the parabolas.
-    REQUIRE(coordinates(0) == Approx(2.0).epsilon(0.0002));
-    REQUIRE(coordinates(1) == Approx(1.0).epsilon(0.0002));
-    REQUIRE(coordinates(2) == Approx(1.5).epsilon(0.0002));
-    REQUIRE(coordinates(3) == Approx(4.0).epsilon(0.0002));
+    FunctionTest<SparseTestFunction>(s, 0.01, 0.001);
   }
 }
 

--- a/tests/pso_test.cpp
+++ b/tests/pso_test.cpp
@@ -66,14 +66,28 @@ TEST_CASE("LBestPSORosenbrockTest","[PSOTest]")
   lowerBound.fill(50);
   upperBound.fill(60);
 
-  LBestPSO s(250, lowerBound, upperBound, 3000, 600, 1e-30, 2.05, 2.05);
-  arma::vec coordinates = f.GetInitialPoint();
+  // We allow a few trials.
+  for (size_t trial = 0; trial < 3; ++trial)
+  {
+    LBestPSO s(250, lowerBound, upperBound, 3000, 600, 1e-30, 2.05, 2.05);
+    arma::vec coordinates = f.GetInitialPoint();
 
-  const double result = s.Optimize(f, coordinates);
+    const double result = s.Optimize(f, coordinates);
 
-  REQUIRE(result == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(0) == Approx(1.0).epsilon(1e-2));
-  REQUIRE(coordinates(1) == Approx(1.0).epsilon(1e-2));
+    if (trial != 2)
+    {
+      if (result != Approx(0.0).margin(0.03))
+        continue;
+      if (coordinates(0) != Approx(1.0).margin(0.02))
+        continue;
+      if (coordinates(1) != Approx(1.0).margin(0.02))
+        continue;
+    }
+
+    REQUIRE(result == Approx(0.0).margin(0.03));
+    REQUIRE(coordinates(0) == Approx(1.0).margin(0.02));
+    REQUIRE(coordinates(1) == Approx(1.0).margin(0.02));
+  }
 }
 
 /**
@@ -89,14 +103,28 @@ TEST_CASE("LBestPSORosenbrockFMatTest","[PSOTest]")
   lowerBound.fill(50);
   upperBound.fill(60);
 
-  LBestPSO s(250, lowerBound, upperBound, 5000, 600, 1e-30, 2.05, 2.05);
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
+  // We allow a few trials.
+  for (size_t trial = 0; trial < 5; ++trial)
+  {
+    LBestPSO s(250, lowerBound, upperBound, 5000, 600, 1e-30, 2.05, 2.05);
+    arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
 
-  const double result = s.Optimize(f, coordinates);
+    const double result = s.Optimize(f, coordinates);
 
-  REQUIRE(result == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(0) == Approx(1.0).epsilon(1e-2));
-  REQUIRE(coordinates(1) == Approx(1.0).epsilon(1e-2));
+    if (trial != 4)
+    {
+      if (result != Approx(0.0).margin(0.03))
+        continue;
+      if (coordinates(0) != Approx(1.0).margin(0.03))
+        continue;
+      if (coordinates(1) != Approx(1.0).margin(0.03))
+        continue;
+    }
+
+    REQUIRE(result == Approx(0.0).margin(0.03));
+    REQUIRE(coordinates(0) == Approx(1.0).margin(0.03));
+    REQUIRE(coordinates(1) == Approx(1.0).margin(0.03));
+  }
 }
 
 /**
@@ -111,14 +139,28 @@ TEST_CASE("LBestPSORosenbrockDoubleTest","[PSOTest]")
   double lowerBound = 50;
   double upperBound = 60;
 
-  LBestPSO s(250, lowerBound, upperBound, 5000, 400, 1e-30, 2.05, 2.05);
-  arma::vec coordinates = f.GetInitialPoint();
+  // We allow a few trials.
+  for (size_t trial = 0; trial < 3; ++trial)
+  {
+    LBestPSO s(250, lowerBound, upperBound, 5000, 400, 1e-30, 2.05, 2.05);
+    arma::vec coordinates = f.GetInitialPoint();
 
-  const double result = s.Optimize(f, coordinates);
+    const double result = s.Optimize(f, coordinates);
 
-  REQUIRE(result == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(0) == Approx(1.0).epsilon(1e-3));
-  REQUIRE(coordinates(1) == Approx(1.0).epsilon(1e-3));
+    if (trial != 2)
+    {
+      if (result != Approx(0.0).margin(1e-3))
+        continue;
+      if (coordinates(0) != Approx(1.0).epsilon(1e-2))
+        continue;
+      if (coordinates(1) != Approx(1.0).epsilon(1e-2))
+        continue;
+    }
+
+    REQUIRE(result == Approx(0.0).margin(0.005));
+    REQUIRE(coordinates(0) == Approx(1.0).margin(0.005));
+    REQUIRE(coordinates(1) == Approx(1.0).margin(0.005));
+  }
 }
 
 /**
@@ -134,13 +176,29 @@ TEST_CASE("LBestPSOCrossInTrayFunctionTest", "[PSOTest]")
   lowerBound.fill(-1);
   upperBound.fill(1);
 
-  LBestPSO s(500, lowerBound, upperBound, 6000, 400, 1e-30, 2.05, 2.05);
-  arma::mat coordinates = arma::mat("10; 10");
-  const double result = s.Optimize(f, coordinates);
+  // We allow many trials---sometimes this can have trouble converging.
+  for (size_t trial = 0; trial < 15; ++trial)
+  {
+    LBestPSO s(500, lowerBound, upperBound, 6000, 400, 1e-30, 2.05, 2.05);
+    arma::mat coordinates = arma::mat("10; 10");
+    const double result = s.Optimize(f, coordinates);
 
-  REQUIRE(result == Approx(-2.06261).margin(0.01));
-  REQUIRE(abs(coordinates(0)) == Approx(1.34941).margin(0.01));
-  REQUIRE(abs(coordinates(1)) == Approx(1.34941).margin(0.01));
+    if (trial != 14)
+    {
+      if (std::isinf(result) || std::isnan(result))
+        continue;
+      if (result != Approx(-2.06261).margin(0.01))
+        continue;
+      if (abs(coordinates(0)) != Approx(1.34941).margin(0.01))
+        continue;
+      if (abs(coordinates(1)) != Approx(1.34941).margin(0.01))
+        continue;
+    }
+
+    REQUIRE(result == Approx(-2.06261).margin(0.01));
+    REQUIRE(abs(coordinates(0)) == Approx(1.34941).margin(0.01));
+    REQUIRE(abs(coordinates(1)) == Approx(1.34941).margin(0.01));
+  }
 }
 
 /**
@@ -201,13 +259,25 @@ TEST_CASE("LBestPSOGoldsteinPriceFunctionTest", "[PSOTest]")
   lowerBound.fill(1.6);
   upperBound.fill(2);
 
-  LBestPSO s(64, lowerBound, upperBound);
+  // Allow a few trials in case of failure.
+  for (size_t trial = 0; trial < 10; ++trial)
+  {
+    LBestPSO s(64, lowerBound, upperBound);
 
-  arma::mat coordinates = arma::mat("1; 0");
-  s.Optimize(f, coordinates);
+    arma::mat coordinates = arma::mat("1; 0");
+    s.Optimize(f, coordinates);
 
-  REQUIRE(coordinates(0) == Approx(0).margin(0.01));
-  REQUIRE(coordinates(1) == Approx(-1).margin(0.01));
+    if (trial != 9)
+    {
+      if (coordinates(0) != Approx(0).margin(0.01))
+        continue;
+      if (coordinates(1) != Approx(-1).margin(0.01))
+        continue;
+    }
+
+    REQUIRE(coordinates(0) == Approx(0).margin(0.01));
+    REQUIRE(coordinates(1) == Approx(-1).margin(0.01));
+  }
 }
 
 /**

--- a/tests/quasi_hyperbolic_momentum_sgd_test.cpp
+++ b/tests/quasi_hyperbolic_momentum_sgd_test.cpp
@@ -9,6 +9,7 @@
  */
 #include <ensmallen.hpp>
 #include "catch.hpp"
+#include "test_function_tools.hpp"
 
 using namespace ens;
 using namespace ens::test;
@@ -16,56 +17,32 @@ using namespace ens::test;
 /**
  * Tests the Quasi Hyperbolic Momentum SGD update policy.
  */
-TEST_CASE("QHSGDTestFunction", "[QHMomentumSGDTest]")
+TEST_CASE("QHSphereFunction", "[QHMomentumSGDTest]")
 {
-  SGDTestFunction f;
   QHUpdate update(0.4, 0.9);
   QHSGD s(0.0025, 1, 500000, 1e-10, true, update, NoDecay(), true, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  double result = s.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(-1.0).epsilon(0.0025));
-  REQUIRE(coordinates(0) == Approx(0.0).margin(3e-3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(1e-6));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(1e-6));
+  FunctionTest<SphereFunction>(s, 0.03, 0.003);
 }
 
 /**
  * Tests the Quasi Hyperbolic Momentum SGD update policy using arma::fmat.
  */
-TEST_CASE("QHSGDFMatTestFunction", "[QHMomentumSGDTest]")
+TEST_CASE("QHSphereFunctionFMat", "[QHMomentumSGDTest]")
 {
-  SGDTestFunction f;
   QHUpdate update(0.9, 0.9);
   QHSGD s(0.002, 1, 2500000, 1e-9, true, update);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  float result = s.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(-1.0).epsilon(0.025));
-  REQUIRE(coordinates(0) == Approx(0.0).margin(3e-2));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(1e-4));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(1e-4));
+  FunctionTest<SphereFunction, arma::fmat>(s, 0.3, 0.03);
 }
 
 /**
  * Tests the Quasi Hyperbolic Momentum SGD update policy using arma::sp_mat.
  */
-TEST_CASE("QHSGDSpMatTestFunction", "[QHMomentumSGDTest]")
+TEST_CASE("QHSpMatTestSphereFunction", "[QHMomentumSGDTest]")
 {
-  SGDTestFunction f;
   QHUpdate update(0.9, 0.9);
   QHSGD s(0.002, 1, 2500000, 1e-15, true, update);
   s.ExactObjective() = true;
-
-  arma::sp_mat coordinates = f.GetInitialPoint<arma::sp_mat>();
-  double result = s.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(-1.0).epsilon(0.0025));
-  REQUIRE(coordinates(0) == Approx(0.0).margin(3e-3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(1e-6));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(1e-6));
+  FunctionTest<SphereFunction, arma::sp_mat>(s, 0.03, 0.003);
 }
 
 /**

--- a/tests/rmsprop_test.cpp
+++ b/tests/rmsprop_test.cpp
@@ -16,42 +16,13 @@
 using namespace ens;
 using namespace ens::test;
 
-TEST_CASE("RMSPropSGDFunction", "[rmsprop]")
-{
-  SGDTestFunction f;
-  RMSProp optimizer(1e-3, 1, 0.99, 1e-8, 5000000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(std::abs(coordinates(0)) <= 0.1);
-  REQUIRE(std::abs(coordinates(1)) <= 0.1);
-  REQUIRE(std::abs(coordinates(2)) <= 0.1);
-}
-
 /**
  * Run RMSProp on logistic regression and make sure the results are acceptable.
  */
 TEST_CASE("RMSPropLogisticRegressionTest", "[rmsprop]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   RMSProp optimizer;
-  arma::mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006);
 }
 
 /**
@@ -60,24 +31,8 @@ TEST_CASE("RMSPropLogisticRegressionTest", "[rmsprop]")
  */
 TEST_CASE("RMSPropLogisticRegressionFMatTest", "[rmsprop]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
   RMSProp optimizer;
-  arma::fmat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.003, 0.006);
 }
 
 #if ARMA_VERSION_MAJOR > 9 ||\
@@ -89,24 +44,8 @@ TEST_CASE("RMSPropLogisticRegressionFMatTest", "[rmsprop]")
  */
 TEST_CASE("RMSPropLogisticRegressionSpMatTest", "[rmsprop]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
   RMSProp optimizer;
-  arma::sp_mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.003, 0.006);
 }
 
 #endif

--- a/tests/sa_test.cpp
+++ b/tests/sa_test.cpp
@@ -12,6 +12,7 @@
 
 #include <ensmallen.hpp>
 #include "catch.hpp"
+#include "test_function_tools.hpp"
 
 using namespace ens;
 using namespace ens::test;
@@ -47,33 +48,19 @@ TEST_CASE("SAGeneralizedRosenbrockTest","[SATest]")
 // The Rosenbrock function is a simple function to optimize.
 TEST_CASE("SARosenbrockTest", "[SATest]")
 {
-  RosenbrockFunction f;
   ExponentialSchedule schedule;
   // The convergence is very sensitive to the choices of maxMove and initMove.
   SA<> sa(schedule, 1000000, 1000., 1000, 100, 1e-11, 3, 1.5, 0.3, 0.3);
-  arma::mat coordinates = f.GetInitialPoint();
-
-  const double result = sa.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(0.0).margin(1e-5));
-  REQUIRE(coordinates(0) == Approx(1.0).epsilon(1e-4));
-  REQUIRE(coordinates(1) == Approx(1.0).epsilon(1e-4));
+  FunctionTest<RosenbrockFunction>(sa, 0.01, 0.001);
 }
 
 // The Rosenbrock function is a simple function to optimize.  Use arma::fmat.
 TEST_CASE("SARosenbrockFMatTest", "[SATest]")
 {
-  RosenbrockFunction f;
   ExponentialSchedule schedule;
   // The convergence is very sensitive to the choices of maxMove and initMove.
   SA<> sa(schedule, 1000000, 1000., 1000, 100, 1e-11, 3, 1.5, 0.3, 0.3);
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-
-  const float result = sa.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(0) == Approx(1.0).epsilon(1e-2));
-  REQUIRE(coordinates(1) == Approx(1.0).epsilon(1e-2));
+  FunctionTest<RosenbrockFunction, arma::fmat>(sa, 0.1, 0.01);
 }
 
 /**
@@ -85,27 +72,9 @@ TEST_CASE("RastrigrinFunctionTest", "[SATest]")
   // Simulated annealing isn't guaranteed to converge (except in very specific
   // situations).  If this works 1 of 4 times, I'm fine with that.  All I want
   // to know is that this implementation will escape from local minima.
-  size_t successes = 0;
-
-  for (size_t trial = 0; trial < 4; ++trial)
-  {
-    RastriginFunction f(2);
-    ExponentialSchedule schedule;
-    // The convergence is very sensitive to the choices of maxMove and initMove.
-    // SA<> sa(schedule, 2000000, 100, 50, 1000, 1e-12, 2, 2.0, 0.5, 0.1);
-    SA<> sa(schedule, 2000000, 100, 50, 1000, 1e-12, 2, 2.0, 0.5, 0.1);
-    arma::mat coordinates = f.GetInitialPoint();
-
-    const double result = sa.Optimize(f, coordinates);
-
-    if ((std::abs(result) < 1e-3) &&
-        (std::abs(coordinates(0)) < 1e-3) &&
-        (std::abs(coordinates(1)) < 1e-3))
-    {
-      ++successes;
-      break; // No need to continue.
-    }
-  }
-
-  REQUIRE(successes >= 1);
+  ExponentialSchedule schedule;
+  // The convergence is very sensitive to the choices of maxMove and initMove.
+  // SA<> sa(schedule, 2000000, 100, 50, 1000, 1e-12, 2, 2.0, 0.5, 0.1);
+  SA<> sa(schedule, 2000000, 100, 50, 1000, 1e-12, 2, 2.0, 0.5, 0.1);
+  FunctionTest<RastriginFunction>(sa, 0.01, 0.001, 4);
 }

--- a/tests/sarah_test.cpp
+++ b/tests/sarah_test.cpp
@@ -22,28 +22,11 @@ using namespace ens::test;
  */
 TEST_CASE("SARAHLogisticRegressionTest","[SARAHTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SARAH with a couple of batch sizes.
+  // Run SARAH with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 45; batchSize += 5)
   {
     SARAH optimizer(0.01, batchSize, 250, 0, 1e-5, true);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest(optimizer, 0.015, 0.015);
   }
 }
 
@@ -53,28 +36,11 @@ TEST_CASE("SARAHLogisticRegressionTest","[SARAHTest]")
  */
 TEST_CASE("SARAHPlusLogisticRegressionTest","[SARAHTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SARAH_Plus with a couple of batch sizes.
+  // Run SARAH_Plus with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 45; batchSize += 5)
   {
     SARAH_Plus optimizer(0.01, batchSize, 250, 0, 1e-5, true);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest(optimizer, 0.015, 0.015);
   }
 }
 
@@ -84,28 +50,11 @@ TEST_CASE("SARAHPlusLogisticRegressionTest","[SARAHTest]")
  */
 TEST_CASE("SARAHLogisticRegressionFMatTest","[SARAHTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SARAH with a couple of batch sizes.
+  // Run SARAH with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 45; batchSize += 5)
   {
     SARAH optimizer(0.01, batchSize, 250, 0, 1e-5, true);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::fmat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.015, 0.015);
   }
 }
 
@@ -115,28 +64,11 @@ TEST_CASE("SARAHLogisticRegressionFMatTest","[SARAHTest]")
  */
 TEST_CASE("SARAHPlusLogisticRegressionFMatTest","[SARAHTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SARAH_Plus with a couple of batch sizes.
+  // Run SARAH_Plus with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 45; batchSize += 5)
   {
     SARAH_Plus optimizer(0.01, batchSize, 250, 0, 1e-5, true);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::fmat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.015, 0.015);
   }
 }
 
@@ -149,28 +81,11 @@ TEST_CASE("SARAHPlusLogisticRegressionFMatTest","[SARAHTest]")
  */
 TEST_CASE("SARAHLogisticRegressionSpMatTest","[SARAHTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SARAH with a couple of batch sizes.
+  // Run SARAH with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 45; batchSize += 5)
   {
     SARAH optimizer(0.01, batchSize, 250, 0, 1e-5, true);
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.015, 0.015);
   }
 }
 
@@ -180,28 +95,11 @@ TEST_CASE("SARAHLogisticRegressionSpMatTest","[SARAHTest]")
  */
 TEST_CASE("SARAHPlusLogisticRegressionSpMatTest","[SARAHTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SARAH_Plus with a couple of batch sizes.
+  // Run SARAH_Plus with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 45; batchSize += 5)
   {
     SARAH_Plus optimizer(0.01, batchSize, 250, 0, 1e-5, true);
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.015, 0.015);
   }
 }
 

--- a/tests/scd_test.cpp
+++ b/tests/scd_test.cpp
@@ -46,22 +46,8 @@ TEST_CASE("DisjointFeatureTest", "[SCDTest]")
 {
   // The test function for parallel SGD should work with SCD, as the gradients
   // of the individual functions are projections into the ith dimension.
-  SparseTestFunction f;
   SCD<> s(0.4);
-
-  arma::mat iterate = f.GetInitialPoint<arma::mat>();
-
-  double result = s.Optimize(f, iterate);
-
-  // The final value of the objective function should be close to the optimal
-  // value, that is the sum of values at the vertices of the parabolas.
-  REQUIRE(result == Approx(123.75).epsilon(0.0001));
-
-  // The co-ordinates should be the vertices of the parabolas.
-  REQUIRE(iterate(0) == Approx(2.0).epsilon(0.0002));
-  REQUIRE(iterate(1) == Approx(1.0).epsilon(0.0002));
-  REQUIRE(iterate(2) == Approx(1.5).epsilon(0.0002));
-  REQUIRE(iterate(3) == Approx(4.0).epsilon(0.0002));
+  FunctionTest<SparseTestFunction>(s, 0.01, 0.001);
 }
 
 /**
@@ -73,22 +59,8 @@ TEST_CASE("DisjointFeatureFMatTest", "[SCDTest]")
 {
   // The test function for parallel SGD should work with SCD, as the gradients
   // of the individual functions are projections into the ith dimension.
-  SparseTestFunction f;
   SCD<> s(0.4);
-
-  arma::fmat iterate = f.GetInitialPoint<arma::fmat>();
-
-  float result = s.Optimize(f, iterate);
-
-  // The final value of the objective function should be close to the optimal
-  // value, that is the sum of values at the vertices of the parabolas.
-  REQUIRE(result == Approx(123.75).epsilon(0.01));
-
-  // The co-ordinates should be the vertices of the parabolas.
-  REQUIRE(iterate(0) == Approx(2.0).epsilon(0.02));
-  REQUIRE(iterate(1) == Approx(1.0).epsilon(0.02));
-  REQUIRE(iterate(2) == Approx(1.5).epsilon(0.02));
-  REQUIRE(iterate(3) == Approx(4.0).epsilon(0.02));
+  FunctionTest<SparseTestFunction, arma::fmat>(s, 0.2, 0.02);
 }
 
 /**
@@ -100,22 +72,8 @@ TEST_CASE("DisjointFeatureSpMatTest", "[SCDTest]")
 {
   // The test function for parallel SGD should work with SCD, as the gradients
   // of the individual functions are projections into the ith dimension.
-  SparseTestFunction f;
   SCD<> s(0.4);
-
-  arma::sp_mat iterate = f.GetInitialPoint<arma::sp_mat>();
-
-  double result = s.Optimize(f, iterate);
-
-  // The final value of the objective function should be close to the optimal
-  // value, that is the sum of values at the vertices of the parabolas.
-  REQUIRE(result == Approx(123.75).epsilon(0.0001));
-
-  // The co-ordinates should be the vertices of the parabolas.
-  REQUIRE(iterate(0) == Approx(2.0).epsilon(0.0002));
-  REQUIRE(iterate(1) == Approx(1.0).epsilon(0.0002));
-  REQUIRE(iterate(2) == Approx(1.5).epsilon(0.0002));
-  REQUIRE(iterate(3) == Approx(4.0).epsilon(0.0002));
+  FunctionTest<SparseTestFunction, arma::sp_mat>(s, 0.01, 0.001);
 }
 
 /**

--- a/tests/sgd_test.cpp
+++ b/tests/sgd_test.cpp
@@ -12,27 +12,12 @@
 
 #include <ensmallen.hpp>
 #include "catch.hpp"
+#include "test_function_tools.hpp"
 
 using namespace std;
 using namespace arma;
 using namespace ens;
 using namespace ens::test;
-
-TEST_CASE("SimpleSGDTestFunction", "[SGDTest]")
-{
-  SGDTestFunction f;
-  VanillaUpdate vanillaUpdate;
-  StandardSGD s(0.0003, 1, 5000000, 1e-9, true, vanillaUpdate, NoDecay(), true,
-      true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  double result = s.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(-1.0).epsilon(0.0005));
-  REQUIRE(coordinates(0) == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(1e-7));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(1e-7));
-}
 
 TEST_CASE("GeneralizedRosenbrockTest", "[SGDTest]")
 {
@@ -55,21 +40,6 @@ TEST_CASE("GeneralizedRosenbrockTest", "[SGDTest]")
   }
 }
 
-TEST_CASE("SimpleSGDTestFunctionFloat", "[SGDTest]")
-{
-  SGDTestFunction f;
-  StandardSGD s(0.0003, 1, 5000000, 1e-9, true);
-  s.ExactObjective() = true;
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  float result = s.Optimize(f, coordinates);
-
-  REQUIRE(result == Approx(-1.0).epsilon(0.0005));
-  REQUIRE(coordinates(0) == Approx(0.0).margin(1e-3));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(1e-5));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(1e-5));
-}
-
 TEST_CASE("GeneralizedRosenbrockTestFloat", "[SGDTest]")
 {
   // Loop over several variants.
@@ -78,13 +48,28 @@ TEST_CASE("GeneralizedRosenbrockTestFloat", "[SGDTest]")
     // Create the generalized Rosenbrock function.
     GeneralizedRosenbrockFunction f(i);
 
-    StandardSGD s(0.001, 1, 0, 1e-15, true);
+    // Allow a few trials.
+    for (size_t trial = 0; trial < 5; ++trial)
+    {
+      StandardSGD s(0.001, 1, 0, 1e-15, true);
 
-    arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-    float result = s.Optimize(f, coordinates);
+      arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
+      float result = s.Optimize(f, coordinates);
 
-    REQUIRE(result == Approx(0.0).margin(1e-5));
-    for (size_t j = 0; j < i; ++j)
-      REQUIRE(coordinates(j) == Approx(1.0).epsilon(1e-3));
+      if (trial != 4)
+      {
+        if (result != Approx(0.0).margin(1e-5))
+          continue;
+        for (size_t j = 0; j < i; ++j)
+        {
+          if (coordinates(j) != Approx(1.0).epsilon(1e-3))
+            continue;
+        }
+      }
+
+      REQUIRE(result == Approx(0.0).margin(1e-5));
+      for (size_t j = 0; j < i; ++j)
+        REQUIRE(coordinates(j) == Approx(1.0).epsilon(1e-3));
+    }
   }
 }

--- a/tests/sgdr_test.cpp
+++ b/tests/sgdr_test.cpp
@@ -59,28 +59,11 @@ TEST_CASE("SGDRCyclicalResetTest","[SGDRTest]")
  */
 TEST_CASE("SGDRLogisticRegressionTest","[SGDRTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SGDR with a couple of batch sizes.
+  // Run SGDR with a couple of batch sizes.
   for (size_t batchSize = 5; batchSize < 50; batchSize += 5)
   {
     SGDR<> sgdr(50, 2.0, batchSize, 0.01, 10000, 1e-3);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::mat coordinates = lr.GetInitialPoint();
-    sgdr.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest(sgdr, 0.003, 0.006);
   }
 }
 
@@ -90,28 +73,11 @@ TEST_CASE("SGDRLogisticRegressionTest","[SGDRTest]")
  */
 TEST_CASE("SGDRLogisticRegressionFMatTest","[SGDRTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SGDR with a couple of batch sizes.
+  // Run SGDR with a couple of batch sizes.
   for (size_t batchSize = 5; batchSize < 50; batchSize += 5)
   {
     SGDR<> sgdr(50, 2.0, batchSize, 0.01, 10000, 1e-3);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::fmat coordinates = lr.GetInitialPoint();
-    sgdr.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(sgdr, 0.015, 0.03, 3);
   }
 }
 
@@ -124,28 +90,11 @@ TEST_CASE("SGDRLogisticRegressionFMatTest","[SGDRTest]")
  */
 TEST_CASE("SGDRLogisticRegressionSpMatTest","[SGDRTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SGDR with a couple of batch sizes.
+  // Run SGDR with a couple of batch sizes.
   for (size_t batchSize = 5; batchSize < 50; batchSize += 5)
   {
     SGDR<> sgdr(50, 2.0, batchSize, 0.01, 10000, 1e-3);
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    sgdr.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(sgdr, 0.003, 0.006);
   }
 }
 

--- a/tests/smorms3_test.cpp
+++ b/tests/smorms3_test.cpp
@@ -18,45 +18,12 @@ using namespace ens;
 using namespace ens::test;
 
 /**
- * Tests the SMORMS3 optimizer using a simple test function.
- */
-TEST_CASE("SimpleSMORMS3TestFunction","[SMORMS3Test]")
-{
-  SGDTestFunction f;
-  SMORMS3 s(0.001, 1, 1e-16, 5000000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  s.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(2) == Approx(0.0).margin(0.1));
-}
-
-/**
  * Run SMORMS3 on logistic regression and make sure the results are acceptable.
  */
 TEST_CASE("SMORMS3LogisticRegressionTest","[SMORMS3Test]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
   SMORMS3 smorms3;
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-  arma::mat coordinates = lr.GetInitialPoint();
-  smorms3.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(smorms3, 0.003, 0.006);
 }
 
 /**
@@ -65,23 +32,6 @@ TEST_CASE("SMORMS3LogisticRegressionTest","[SMORMS3Test]")
  */
 TEST_CASE("SMORMS3LogisticRegressionFMatTest","[SMORMS3Test]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
   SMORMS3 smorms3;
-  LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-  arma::fmat coordinates = lr.GetInitialPoint();
-  smorms3.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest<arma::fmat>(smorms3, 0.003, 0.006);
 }

--- a/tests/snapshot_ensembles.cpp
+++ b/tests/snapshot_ensembles.cpp
@@ -63,28 +63,11 @@ TEST_CASE("SnapshotEnsemblesResetTest","[SnapshotEnsemblesTest]")
  */
 TEST_CASE("SnapshotEnsemblesLogisticRegressionTest","[SnapshotEnsemblesTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SGDR with snapshot ensembles on a couple of batch sizes.
+  // Run SGDR with snapshot ensembles on a couple of batch sizes.
   for (size_t batchSize = 5; batchSize < 50; batchSize += 5)
   {
     SnapshotSGDR<> sgdr(50, 2.0, batchSize, 0.01, 10000, 1e-3);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::mat coordinates = lr.GetInitialPoint();
-    sgdr.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest(sgdr, 0.003, 0.006);
   }
 }
 
@@ -94,28 +77,11 @@ TEST_CASE("SnapshotEnsemblesLogisticRegressionTest","[SnapshotEnsemblesTest]")
  */
 TEST_CASE("SnapshotEnsemblesLogisticRegressionFMatTest","[SnapshotEnsemblesTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SGDR with snapshot ensembles on a couple of batch sizes.
+  // Run SGDR with snapshot ensembles on a couple of batch sizes.
   for (size_t batchSize = 5; batchSize < 50; batchSize += 5)
   {
     SnapshotSGDR<> sgdr(50, 2.0, batchSize, 0.01, 10000, 1e-3);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::fmat coordinates = lr.GetInitialPoint();
-    sgdr.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(sgdr, 0.03, 0.06, 3);
   }
 }
 
@@ -129,28 +95,11 @@ TEST_CASE("SnapshotEnsemblesLogisticRegressionFMatTest","[SnapshotEnsemblesTest]
 TEST_CASE("SnapshotEnsemblesLogisticRegressionSpMatTest",
           "[SnapshotEnsemblesTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SGDR with snapshot ensembles on a couple of batch sizes.
+  // Run SGDR with snapshot ensembles on a couple of batch sizes.
   for (size_t batchSize = 5; batchSize < 50; batchSize += 5)
   {
     SnapshotSGDR<> sgdr(50, 2.0, batchSize, 0.01, 10000, 1e-3);
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    sgdr.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(sgdr, 0.003, 0.006);
   }
 }
 

--- a/tests/spalera_sgd_test.cpp
+++ b/tests/spalera_sgd_test.cpp
@@ -22,40 +22,11 @@ using namespace ens::test;
  */
 TEST_CASE("LogisticRegressionTest","[SPALeRASGDTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run mini-batch SGD with a couple of batch sizes.
+  // Run SPALeRA SGD with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 50; batchSize += 5)
   {
-    bool success = false;
-
-    // It's possible that convergence can randomly fail.  So allow up to three
-    // trials.
-    for (size_t trial = 0; trial < 3; ++trial)
-    {
-      SPALeRASGD<> optimizer(0.05 / batchSize, batchSize, 10000, 1e-4);
-      LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-      arma::mat coordinates = lr.GetInitialPoint();
-      optimizer.Optimize(lr, coordinates);
-
-      // Ensure that the error is close to zero.
-      const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-      const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-          coordinates);
-
-      if (acc >= 98.5 && testAcc >= 97.6)
-      {
-        success = true;
-        break;
-      }
-    }
-
-    REQUIRE(success == true); // At least one trial must succeed.
+    SPALeRASGD<> optimizer(0.05 / batchSize, batchSize, 10000, 1e-4);
+    LogisticRegressionFunctionTest(optimizer, 0.015, 0.024, 3);
   }
 }
 
@@ -65,39 +36,10 @@ TEST_CASE("LogisticRegressionTest","[SPALeRASGDTest]")
  */
 TEST_CASE("LogisticRegressionFMatTest","[SPALeRASGDTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run mini-batch SGD with a couple of batch sizes.
+  // Run SPALeRA SGD with a couple of batch sizes.
   for (size_t batchSize = 30; batchSize < 50; batchSize += 5)
   {
-    bool success = false;
-
-    // It's possible that convergence can randomly fail.  So allow up to three
-    // trials.
-    for (size_t trial = 0; trial < 3; ++trial)
-    {
-      SPALeRASGD<> optimizer(0.05 / batchSize, batchSize, 10000, 1e-4);
-      LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-      arma::fmat coordinates = lr.GetInitialPoint();
-      optimizer.Optimize(lr, coordinates);
-
-      // Ensure that the error is close to zero.
-      const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-      const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-          coordinates);
-
-      if (acc >= 98.5 && testAcc >= 97.6)
-      {
-        success = true;
-        break;
-      }
-    }
-
-    REQUIRE(success == true); // At least one trial must succeed.
+    SPALeRASGD<> optimizer(0.05 / batchSize, batchSize, 10000, 1e-4);
+    LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.015, 0.024, 3);
   }
 }

--- a/tests/spsa_test.cpp
+++ b/tests/spsa_test.cpp
@@ -24,14 +24,8 @@ using namespace ens::test;
  */
 TEST_CASE("SPSASphereFunctionTest", "[SPSATest]")
 {
-  SphereFunction f(2);
   SPSA optimizer(0.1, 0.102, 0.16, 0.3, 100000, 0);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction>(optimizer, 1.0, 0.1);
 }
 
 /**
@@ -39,14 +33,8 @@ TEST_CASE("SPSASphereFunctionTest", "[SPSATest]")
  */
 TEST_CASE("SPSASphereFunctionFMatTest", "[SPSATest]")
 {
-  SphereFunction f(2);
   SPSA optimizer(0.1, 0.102, 0.16, 0.3, 100000, 0);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0f).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0f).margin(0.1));
+  FunctionTest<SphereFunction, arma::fmat>(optimizer, 1.0, 0.1);
 }
 
 /**
@@ -54,14 +42,8 @@ TEST_CASE("SPSASphereFunctionFMatTest", "[SPSATest]")
  */
 TEST_CASE("SPSASphereFunctionSpMatTest", "[SPSATest]")
 {
-  SphereFunction f(2);
   SPSA optimizer(0.1, 0.102, 0.16, 0.3, 100000, 0);
-
-  arma::sp_mat coordinates = f.GetInitialPoint<arma::sp_mat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction, arma::sp_mat>(optimizer, 1.0, 0.1);
 }
 
 /**
@@ -69,17 +51,8 @@ TEST_CASE("SPSASphereFunctionSpMatTest", "[SPSATest]")
  */
 TEST_CASE("SPSAMatyasFunctionTest", "[SPSATest]")
 {
-  MatyasFunction f;
   SPSA optimizer(0.1, 0.102, 0.16, 0.3, 100000, 0);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  // 3% error tolerance.
-  REQUIRE((std::trunc(100.0 * coordinates(0)) / 100.0) ==
-      Approx(0.0).epsilon(0.003));
-  REQUIRE((std::trunc(100.0 * coordinates(1)) / 100.0) ==
-      Approx(0.0).epsilon(0.003));
+  FunctionTest<MatyasFunction>(optimizer, 0.1, 0.01);
 }
 
 /**
@@ -87,31 +60,8 @@ TEST_CASE("SPSAMatyasFunctionTest", "[SPSATest]")
  */
 TEST_CASE("SPSALogisticRegressionTest", "[SPSATest]")
 {
-  arma::mat data, testData, shuffledData;
-  bool success = false;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  for (size_t trial = 0; trial < 6; ++trial)
-  {
-    LogisticRegressionTestData(data, testData, shuffledData,
-        responses, testResponses, shuffledResponses);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    SPSA optimizer(0.5, 0.102, 0.002, 0.3, 5000, 1e-8);
-    arma::mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    if (acc == Approx(100.0).epsilon(0.003) &&
-        testAcc == Approx(100.0).epsilon(0.006))
-      success = true;
-
-    if (success)
-      break;
-  }
-
-  REQUIRE(success == true);
+  // We allow 10 trials, because SPSA is definitely not guaranteed to
+  // converge.
+  SPSA optimizer(0.5, 0.102, 0.002, 0.3, 5000, 1e-8);
+  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006, 10);
 }

--- a/tests/svrg_test.cpp
+++ b/tests/svrg_test.cpp
@@ -21,30 +21,11 @@ using namespace ens::test;
  */
 TEST_CASE("SVRGLogisticRegressionTest", "[SVRGTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SVRG with a couple of batch sizes.
+  // Run SVRG with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 50; batchSize += 5)
   {
     SVRG optimizer(0.005, batchSize, 300, 0, 1e-5, true);
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-    // REQUIRE(acc == Approx(100.0).scale(0.015)); // 1.5% error tolerance.
-    // TODO: not sure whether .epsilon() or .scale() is more appropriate
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest(optimizer, 0.015, 0.015);
   }
 }
 
@@ -53,29 +34,12 @@ TEST_CASE("SVRGLogisticRegressionTest", "[SVRGTest]")
  */
 TEST_CASE("SVRGBBLogisticRegressionTest", "[SVRGTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SVRG with a couple of batch sizes.
+  // Run SVRG with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 50; batchSize += 5)
   {
     SVRG_BB optimizer(0.005, batchSize, 300, 0, 1e-5, true, SVRGUpdate(),
         BarzilaiBorweinDecay(0.1));
-    LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest(optimizer, 0.015, 0.015);
   }
 }
 
@@ -85,30 +49,11 @@ TEST_CASE("SVRGBBLogisticRegressionTest", "[SVRGTest]")
  */
 TEST_CASE("SVRGLogisticRegressionFMatTest", "[SVRGTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SVRG with a couple of batch sizes.
+  // Run SVRG with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 50; batchSize += 5)
   {
     SVRG optimizer(0.005, batchSize, 300, 0, 1e-5, true);
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::fmat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-    // REQUIRE(acc == Approx(100.0).scale(0.015)); // 1.5% error tolerance.
-    // TODO: not sure whether .epsilon() or .scale() is more appropriate
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.015, 0.015);
   }
 }
 
@@ -118,29 +63,12 @@ TEST_CASE("SVRGLogisticRegressionFMatTest", "[SVRGTest]")
  */
 TEST_CASE("SVRGBBLogisticRegressionFMatTest", "[SVRGTest]")
 {
-  arma::fmat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SVRG_BB with a couple of batch sizes.
+  // Run SVRG_BB with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 50; batchSize += 5)
   {
     SVRG_BB optimizer(0.005, batchSize, 300, 0, 1e-5, true,
         SVRGUpdate(), BarzilaiBorweinDecay(0.1));
-    LogisticRegression<arma::fmat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::fmat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.015, 0.015);
   }
 }
 
@@ -153,30 +81,11 @@ TEST_CASE("SVRGBBLogisticRegressionFMatTest", "[SVRGTest]")
  */
 TEST_CASE("SVRGLogisticRegressionSpMatTest", "[SVRGTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SVRG with a couple of batch sizes.
+  // Run SVRG with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 50; batchSize += 5)
   {
     SVRG optimizer(0.005, batchSize, 300, 0, 1e-5, true);
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-    // REQUIRE(acc == Approx(100.0).scale(0.015)); // 1.5% error tolerance.
-    // TODO: not sure whether .epsilon() or .scale() is more appropriate
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.015, 0.015);
   }
 }
 
@@ -186,29 +95,12 @@ TEST_CASE("SVRGLogisticRegressionSpMatTest", "[SVRGTest]")
  */
 TEST_CASE("SVRGBBLogisticRegressionSpMatTest", "[SVRGTest]")
 {
-  arma::sp_mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-
-  // Now run SVRG with a couple of batch sizes.
+  // Run SVRG with a couple of batch sizes.
   for (size_t batchSize = 35; batchSize < 50; batchSize += 5)
   {
     SVRG_BB optimizer(0.005, batchSize, 300, 0, 1e-5, true,
         SVRGUpdate(), BarzilaiBorweinDecay(0.1));
-    LogisticRegression<arma::sp_mat> lr(shuffledData, shuffledResponses, 0.5);
-
-    arma::sp_mat coordinates = lr.GetInitialPoint();
-    optimizer.Optimize(lr, coordinates);
-
-    // Ensure that the error is close to zero.
-    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-    REQUIRE(acc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
-
-    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-        coordinates);
-    REQUIRE(testAcc == Approx(100.0).epsilon(0.015)); // 1.5% error tolerance.
+    LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.015, 0.015);
   }
 }
 

--- a/tests/swats_test.cpp
+++ b/tests/swats_test.cpp
@@ -22,24 +22,9 @@ using namespace ens::test;
  */
 TEST_CASE("SWATSLogisticRegressionTestFunction", "[SWATSTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
-  SWATS optimizer(0.01, 10, 0.9, 0.999, 1e-6, 600000, 1e-9, true);
-  arma::mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  SWATS optimizer(1e-3, 10, 0.9, 0.999, 1e-6, 600000, 1e-9, true);
+  // We allow a few trials in case of poor convergence.
+  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006, 5);
 }
 
 /**
@@ -47,14 +32,8 @@ TEST_CASE("SWATSLogisticRegressionTestFunction", "[SWATSTest]")
  */
 TEST_CASE("SWATSSphereFunctionTest", "[SWATSTest]")
 {
-  SphereFunction f(2);
   SWATS optimizer(1e-3, 2, 0.9, 0.999, 1e-6, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction>(optimizer, 1.0, 0.1);
 }
 
 /**
@@ -62,14 +41,8 @@ TEST_CASE("SWATSSphereFunctionTest", "[SWATSTest]")
  */
 TEST_CASE("SWATSStyblinskiTangFunctionTest", "[SWATSTest]")
 {
-  StyblinskiTangFunction f(2);
   SWATS optimizer(1e-3, 2, 0.9, 0.999, 1e-6, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01));
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01));
+  FunctionTest<StyblinskiTangFunction>(optimizer, 0.3, 0.03);
 }
 
 /**
@@ -77,14 +50,8 @@ TEST_CASE("SWATSStyblinskiTangFunctionTest", "[SWATSTest]")
  */
 TEST_CASE("SWATSStyblinskiTangFunctionFMatTest", "[SWATSTest]")
 {
-  StyblinskiTangFunction f(2);
   SWATS optimizer(1e-3, 2, 0.9, 0.999, 1e-6, 500000, 1e-9, true);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.1));
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.1));
+  FunctionTest<StyblinskiTangFunction, arma::fmat>(optimizer, 3.0, 0.3);
 }
 
 #if ARMA_VERSION_MAJOR > 9 ||\
@@ -95,14 +62,8 @@ TEST_CASE("SWATSStyblinskiTangFunctionFMatTest", "[SWATSTest]")
  */
 TEST_CASE("SWATSStyblinskiTangFunctionSpMatTest", "[SWATSTest]")
 {
-  StyblinskiTangFunction f(2);
   SWATS optimizer(1e-3, 2, 0.9, 0.999, 1e-6, 500000, 1e-9, true);
-
-  arma::sp_mat coordinates = f.GetInitialPoint<arma::sp_mat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01));
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01));
+  FunctionTest<StyblinskiTangFunction, arma::sp_mat>(optimizer, 0.3, 0.03);
 }
 
 #endif

--- a/tests/test_function_tools.hpp
+++ b/tests/test_function_tools.hpp
@@ -97,4 +97,125 @@ inline void CheckMatrices(const MatType& a,
   }
 }
 
+template<typename FunctionType, typename OptimizerType, typename PointType>
+bool TestOptimizer(FunctionType& f,
+                   OptimizerType& optimizer,
+                   PointType& point,
+                   const PointType& expectedResult,
+                   const double coordinateMargin,
+                   const double expectedObjective,
+                   const double objectiveMargin,
+                   const bool mustSucceed = true)
+{
+  const double objective = optimizer.Optimize(f, point);
+
+  if (mustSucceed)
+  {
+    REQUIRE(objective == Approx(expectedObjective).margin(objectiveMargin));
+    for (size_t i = 0; i < point.n_elem; ++i)
+    {
+      REQUIRE(point[i] == Approx(expectedResult[i]).margin(coordinateMargin));
+    }
+  }
+  else
+  {
+    if (objective != Approx(expectedObjective).margin(objectiveMargin))
+      return false;
+
+    for (size_t i = 0; i < point.n_elem; ++i)
+    {
+      if (point[i] != Approx(expectedResult[i]).margin(coordinateMargin))
+        return false;
+    }
+  }
+
+  return true;
+}
+
+// This runs a test multiple times, but does not do any special behavior between
+// runs.
+template<typename FunctionType, typename OptimizerType, typename PointType>
+void MultipleTrialOptimizerTest(FunctionType& f,
+                                OptimizerType& optimizer,
+                                PointType& initialPoint,
+                                const PointType& expectedResult,
+                                const double coordinateMargin,
+                                const double expectedObjective,
+                                const double objectiveMargin,
+                                const size_t trials = 1)
+{
+  for (size_t t = 0; t < trials; ++t)
+  {
+    PointType coordinates(initialPoint);
+
+    // Only force success on the last trial.
+    bool result = TestOptimizer(f, optimizer, coordinates, expectedResult,
+        coordinateMargin, expectedObjective, objectiveMargin,
+        (t == (trials - 1)));
+    if (result && t != (trials - 1))
+    {
+      // Just make sure at least something was tested for reporting purposes.
+      REQUIRE(result == true);
+      return;
+    }
+  }
+}
+
+template<typename FunctionType,
+         typename MatType = arma::mat,
+         typename OptimizerType = ens::StandardSGD>
+void FunctionTest(OptimizerType& optimizer,
+                  const double objectiveMargin = 0.01,
+                  const double coordinateMargin = 0.001,
+                  const size_t trials = 1)
+{
+  FunctionType f;
+  MatType initialPoint = f.template GetInitialPoint<MatType>();
+  MatType expectedResult = f.template GetFinalPoint<MatType>();
+
+  MultipleTrialOptimizerTest(f, optimizer, initialPoint, expectedResult,
+      coordinateMargin, f.GetFinalObjective(), objectiveMargin, trials);
+}
+
+template<typename MatType = arma::mat, typename OptimizerType>
+void LogisticRegressionFunctionTest(OptimizerType& optimizer,
+                                    const double trainAccuracyTolerance,
+                                    const double testAccuracyTolerance,
+                                    const size_t trials = 1)
+{
+  // We have to generate new data for each trial, so we can't use
+  // MultipleTrialOptimizerTest().
+  MatType data, testData, shuffledData;
+  arma::Row<size_t> responses, testResponses, shuffledResponses;
+
+  for (size_t i = 0; i < trials; ++i)
+  {
+    LogisticRegressionTestData(data, testData, shuffledData,
+        responses, testResponses, shuffledResponses);
+    ens::test::LogisticRegression<MatType> lr(shuffledData, shuffledResponses,
+        0.5);
+
+    MatType coordinates = lr.GetInitialPoint();
+
+    optimizer.Optimize(lr, coordinates);
+
+    const double acc = lr.ComputeAccuracy(data, responses, coordinates);
+    const double testAcc = lr.ComputeAccuracy(testData, testResponses,
+        coordinates);
+
+    // Provide a shortcut to try again if we're not on the last trial.
+    if (i != (trials - 1))
+    {
+      if (acc != Approx(100.0).epsilon(trainAccuracyTolerance))
+        continue;
+      if (testAcc != Approx(100.0).epsilon(testAccuracyTolerance))
+        continue;
+    }
+
+    REQUIRE(acc == Approx(100.0).epsilon(trainAccuracyTolerance));
+    REQUIRE(testAcc == Approx(100.0).epsilon(testAccuracyTolerance));
+    break;
+  }
+}
+
 #endif

--- a/tests/wn_grad_test.cpp
+++ b/tests/wn_grad_test.cpp
@@ -22,24 +22,8 @@ using namespace ens::test;
  */
 TEST_CASE("WNGradLogisticRegressionTest","[WNGradTest]")
 {
-  arma::mat data, testData, shuffledData;
-  arma::Row<size_t> responses, testResponses, shuffledResponses;
-
-  LogisticRegressionTestData(data, testData, shuffledData,
-      responses, testResponses, shuffledResponses);
-  LogisticRegression<> lr(shuffledData, shuffledResponses, 0.5);
-
   WNGrad optimizer(0.56, 1, 500000, 1e-9, true);
-  arma::mat coordinates = lr.GetInitialPoint();
-  optimizer.Optimize(lr, coordinates);
-
-  // Ensure that the error is close to zero.
-  const double acc = lr.ComputeAccuracy(data, responses, coordinates);
-  REQUIRE(acc == Approx(100.0).epsilon(0.003)); // 0.3% error tolerance.
-
-  const double testAcc = lr.ComputeAccuracy(testData, testResponses,
-      coordinates);
-  REQUIRE(testAcc == Approx(100.0).epsilon(0.006)); // 0.6% error tolerance.
+  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006);
 }
 
 /**
@@ -47,14 +31,8 @@ TEST_CASE("WNGradLogisticRegressionTest","[WNGradTest]")
  */
 TEST_CASE("WNGradSphereFunctionTest","[WNGradTest]")
 {
-  SphereFunction f(2);
   WNGrad optimizer(0.56, 2, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
+  FunctionTest<SphereFunction>(optimizer, 1.0, 0.1);
 }
 
 /**
@@ -62,14 +40,8 @@ TEST_CASE("WNGradSphereFunctionTest","[WNGradTest]")
  */
 TEST_CASE("WNGradStyblinskiTangFunctionTest","[WNGradTest]")
 {
-  StyblinskiTangFunction f(2);
   WNGrad optimizer(0.56, 2, 500000, 1e-9, true);
-
-  arma::mat coordinates = f.GetInitialPoint();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
+  FunctionTest<StyblinskiTangFunction>(optimizer, 0.3, 0.03);
 }
 
 /**
@@ -77,14 +49,8 @@ TEST_CASE("WNGradStyblinskiTangFunctionTest","[WNGradTest]")
  */
 TEST_CASE("WNGradStyblinskiTangFunctionFMatTest", "[WNGradTest]")
 {
-  StyblinskiTangFunction f(2);
   WNGrad optimizer(0.56, 2, 500000, 1e-9, true);
-
-  arma::fmat coordinates = f.GetInitialPoint<arma::fmat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
+  FunctionTest<StyblinskiTangFunction, arma::fmat>(optimizer, 3.0, 0.3);
 }
 
 /**
@@ -92,12 +58,6 @@ TEST_CASE("WNGradStyblinskiTangFunctionFMatTest", "[WNGradTest]")
  */
 TEST_CASE("WNGradStyblinskiTangFunctionSpMatTest", "[WNGradTest]")
 {
-  StyblinskiTangFunction f(2);
   WNGrad optimizer(0.56, 2, 500000, 1e-9, true);
-
-  arma::sp_mat coordinates = f.GetInitialPoint<arma::sp_mat>();
-  optimizer.Optimize(f, coordinates);
-
-  REQUIRE(coordinates(0) == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
-  REQUIRE(coordinates(1) == Approx(-2.9).epsilon(0.01)); // 1% error tolerance.
+  FunctionTest<StyblinskiTangFunction, arma::sp_mat>(optimizer, 0.3, 0.03);
 }


### PR DESCRIPTION
Occasionally, ensmallen tests fail randomly, because often the tests we run are non-deterministic.  This can cause a bad user experience (and can confuse reviewers of journal articles for ensmallen too :)) so I spent some time refactoring ensmallen's test suite so that I was able to run it 1000 times with no failures at all.

A number of major changes were done during this process:

1.  I added a `GetFinalPoint()` method to most of the functions in `ensmallen_bits/problems/`.  I didn't do this for functions with multiple global minima.  Maybe we could do that another time.  I also added `GetFinalObjective()`.

2. Some methods in `ensmallen_bits/problems/` used different initial points in the tests than `GetInitialPoint()` returned.  So I updated the implementation of `GetInitialPoint()` to use what was used in the tests.

3. I added a function called `FunctionTest()` to `test_function_tools.hpp`, that expects an input optimizer and the type of a function, then uses `GetInitialPoint()` and `GetFinalPoint()` to run the optimization and check convergence.  It also supports a number of trials---so for instances where the test often fails, you can set trials to, e.g., 3 and it will run the test up to 3 times.

4. I made a standalone `LogisticRegressionFunctionTest()` utility in `test_function_tools.hpp`, since `FunctionTest()` doesn't work quite right for our logistic regression tests (as we are checking the accuracy, not the objective).  This also supports multiple trials.

5. Wherever possible, I refactored all of the tests to use `FunctionTest()` and `LogisticRegressionFunctionTest()`, and set the number of trials to what I observed was necessary for no failures in 1000 runs.

6. I removed tests for `SGDTestFunction` as much as possible.  The reason for this is that `SGDTestFunction` is actually really not a good test function for SGD.  In order to optimize it correctly, an optimizer must consider each of the three different objective functions it contains, but, when a batch size of 1 is used, the gradient of each individual function is extremely different!  This means that lots of oscillations will be introduced for most SGD-like optimizers, and as a result these tests were very prone to failure.  I found the logistic regression test to be more suitable in these instances.  However, there are a couple tests that still use `SGDTestFunction` that seem to work okay.

Hopefully after this we will see very few reports of test failures! :)  I suppose, I should think about how to set up an automatic job that will run the tests 1000 times each month or something like that.