### PR TITLE
Fix Report callback when no steps were taken.

### DIFF
--- a/include/ensmallen_bits/callbacks/report.hpp
+++ b/include/ensmallen_bits/callbacks/report.hpp
@@ -178,7 +178,7 @@ class Report
     if (tookStep)
       output << objectives.size() << std::endl;
     else
-      output << "0 (No steps taken!  Did optimization fail?)" << std::endl;
+      output << "0 (No steps taken! Did the optimization fail?)" << std::endl;
 
     if (epochCalls > 0)
     {

--- a/include/ensmallen_bits/callbacks/report.hpp
+++ b/include/ensmallen_bits/callbacks/report.hpp
@@ -149,6 +149,15 @@ class Report
     output << coordinates.n_cols << std::endl;
     output << std::endl;
 
+    // If we did not take any steps, at least fill what the initial objective
+    // was.
+    const bool tookStep = (objectives.size() > 0);
+    if (objectives.size() == 0)
+    {
+      objectives.push_back(function.Evaluate(coordinates));
+      timings.push_back(optimizationTimer.toc());
+    }
+
     output << "Loss:" << std::endl;
     PrettyPrintElement("Initial", 30);
     output << objectives[0] << std::endl;
@@ -166,7 +175,10 @@ class Report
       output << optimizerStream.str();
 
     PrettyPrintElement("Iterations:", 30);
-    output << objectives.size() << std::endl;
+    if (tookStep)
+      output << objectives.size() << std::endl;
+    else
+      output << "0 (No steps taken!  Did optimization fail?)" << std::endl;
 
     if (epochCalls > 0)
     {
@@ -183,7 +195,7 @@ class Report
       output << stepsizes.back() << std::endl;
     }
 
-    if (hasGradient)
+    if (hasGradient && gradientsNorm.size() > 0)
     {
       PrettyPrintElement("Coordinates max. norm:", 30);
       output << *std::max_element(std::begin(gradientsNorm),

--- a/include/ensmallen_bits/callbacks/report.hpp
+++ b/include/ensmallen_bits/callbacks/report.hpp
@@ -152,10 +152,21 @@ class Report
     // If we did not take any steps, at least fill what the initial objective
     // was.
     const bool tookStep = (objectives.size() > 0);
-    if (objectives.size() == 0)
+    if (objectives.size() == 0 && evaluateCalls > 0)
     {
-      objectives.push_back(function.Evaluate(coordinates));
+      objectives.push_back(objective);
       timings.push_back(optimizationTimer.toc());
+    }
+    else if (evaluateCalls == 0)
+    {
+      // It's not entirely clear how to compute the objective (since the
+      // function could implement many different ways of evaluating the
+      // objective), so issue an error and return.
+      output << "Objective never computed.  Did the optimization fail?"
+          << std::endl;
+      PrettyPrintElement("Time (in seconds):", 30);
+      output << optimizationTimer.toc() << std::endl;
+      return;
     }
 
     output << "Loss:" << std::endl;


### PR DESCRIPTION
This fixes #246.

Basically, the `Report` callback was failing (segfaulting) when an optimizer took no steps at all.  These changes try to handle that a bit more gracefully, and print a warning for the user, since they may need to investigate why the optimizer took no steps.