### PR TITLE
Fix compilation issue when ENS_USE_OPENMP is specified.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Fix test compilation issue when `ENS_USE_OPENMP` is set
+   ([#255](https://github.com/mlpack/ensmallen/pull/255)).
 
 ### ensmallen 2.16.0: "Severely Dented Can Of Polyurethane"
 ###### 2021-02-11

--- a/tests/parallel_sgd_test.cpp
+++ b/tests/parallel_sgd_test.cpp
@@ -38,6 +38,7 @@ TEST_CASE("SimpleParallelSGDTest", "[ParallelSGDTest]")
 
   size_t threadsAvailable = omp_get_max_threads();
 
+  SparseTestFunction f;
   for (size_t i = threadsAvailable; i > 0; --i)
   {
     omp_set_num_threads(i);


### PR DESCRIPTION
I noticed this issue while testing. It seems to be a bug introduced by #249.  I guess the system I was testing on somehow did not set `ENS_USE_OPENMP`.