### PR TITLE
Use normal distribution for CNE initial population generation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
  * Fix test compilation issue when `ENS_USE_OPENMP` is set
    ([#255](https://github.com/mlpack/ensmallen/pull/255)).
 
+ * Fix CNE initial population generation to use normal distribution
+   ([#258](https://github.com/mlpack/ensmallen/pull/258)).
+
 ### ensmallen 2.16.0: "Severely Dented Can Of Polyurethane"
 ###### 2021-02-11
  * Expand README with example installation and add simple example program

--- a/include/ensmallen_bits/cne/cne_impl.hpp
+++ b/include/ensmallen_bits/cne/cne_impl.hpp
@@ -93,7 +93,7 @@ typename MatType::elem_type CNE::Optimize(ArbitraryFunctionType& function,
   std::vector<BaseMatType> population;
   for (size_t i = 0 ; i < populationSize; ++i)
   {
-    population.push_back(arma::randu<BaseMatType>(iterate.n_rows,
+    population.push_back(arma::randn<BaseMatType>(iterate.n_rows,
         iterate.n_cols) + iterate);
   }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -22,9 +22,9 @@ int main(int argc, char** argv)
    * each run.  This is good for ensuring that a test's tolerance is sufficient
    * across many different runs.
    */
-  size_t seed = std::time(NULL);
-  srand((unsigned int) seed);
-  arma::arma_rng::set_seed(seed);
+  //size_t seed = std::time(NULL);
+  //srand((unsigned int) seed);
+  //arma::arma_rng::set_seed(seed);
 
   std::cout << "ensmallen version: " << ens::version::as_string() << std::endl;
 


### PR DESCRIPTION
This fixes #247.  I chose against multiplying the normal distribution by `mutationSize` because the documentation only says that it uses a `normal distribution` (e.g. variance 1).  I'm totally open to other strategies here; I don't have any particular opinion on what is best.

I also undid an accidental change from another PR, and commented out the random seed for each test run.