### PR TITLE
Remove unused `const` to fix compilation warnings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,9 @@
  * Fix CNE initial population generation to use normal distribution
    ([#258](https://github.com/mlpack/ensmallen/pull/258)).
 
+ * Fix compilation warnings
+   ([#259](https://github.com/mlpack/ensmallen/pull/259)).
+
 ### ensmallen 2.16.0: "Severely Dented Can Of Polyurethane"
 ###### 2021-02-11
  * Expand README with example installation and add simple example program

--- a/include/ensmallen_bits/problems/ackley_function.hpp
+++ b/include/ensmallen_bits/problems/ackley_function.hpp
@@ -68,7 +68,7 @@ class AckleyFunction
   MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/beale_function.hpp
+++ b/include/ensmallen_bits/problems/beale_function.hpp
@@ -61,7 +61,7 @@ class BealeFunction
   MatType GetFinalPoint() const { return MatType("3.0; 0.5"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/booth_function.hpp
+++ b/include/ensmallen_bits/problems/booth_function.hpp
@@ -61,7 +61,7 @@ class BoothFunction
   MatType GetFinalPoint() const { return MatType("1.0; 3.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/bukin_function.hpp
+++ b/include/ensmallen_bits/problems/bukin_function.hpp
@@ -66,7 +66,7 @@ class BukinFunction
   MatType GetFinalPoint() const { return MatType("-10.0; 1.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/colville_function.hpp
+++ b/include/ensmallen_bits/problems/colville_function.hpp
@@ -62,7 +62,7 @@ class ColvilleFunction
   MatType GetFinalPoint() const { return MatType("1; 1; 1; 1"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/drop_wave_function.hpp
+++ b/include/ensmallen_bits/problems/drop_wave_function.hpp
@@ -61,7 +61,7 @@ class DropWaveFunction
   MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/easom_function.hpp
+++ b/include/ensmallen_bits/problems/easom_function.hpp
@@ -61,7 +61,7 @@ class EasomFunction
   MatType GetFinalPoint() const { return MatType("3.14; 3.14"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return -1.0; }
+  double GetFinalObjective() const { return -1.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/eggholder_function.hpp
+++ b/include/ensmallen_bits/problems/eggholder_function.hpp
@@ -62,7 +62,7 @@ class EggholderFunction
   MatType GetFinalPoint() const { return MatType("512; 404.2319"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return -959.6407; }
+  double GetFinalObjective() const { return -959.6407; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/generalized_rosenbrock_function.hpp
+++ b/include/ensmallen_bits/problems/generalized_rosenbrock_function.hpp
@@ -76,7 +76,7 @@ class GeneralizedRosenbrockFunction
   }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/goldstein_price_function.hpp
+++ b/include/ensmallen_bits/problems/goldstein_price_function.hpp
@@ -70,7 +70,7 @@ class GoldsteinPriceFunction
   MatType GetFinalPoint() const { return MatType("0.0; -1.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 3.0; }
+  double GetFinalObjective() const { return 3.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/gradient_descent_test_function.hpp
+++ b/include/ensmallen_bits/problems/gradient_descent_test_function.hpp
@@ -34,7 +34,7 @@ class GDTestFunction
   MatType GetFinalPoint() const { return MatType("0; 0; 0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   //! Evaluate a function.
   template<typename MatType>

--- a/include/ensmallen_bits/problems/levy_function_n13.hpp
+++ b/include/ensmallen_bits/problems/levy_function_n13.hpp
@@ -57,7 +57,7 @@ class LevyFunctionN13
   MatType GetFinalPoint() const { return MatType("1.0; 1.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/matyas_function.hpp
+++ b/include/ensmallen_bits/problems/matyas_function.hpp
@@ -61,7 +61,7 @@ class MatyasFunction
   MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/mc_cormick_function.hpp
+++ b/include/ensmallen_bits/problems/mc_cormick_function.hpp
@@ -61,7 +61,7 @@ class McCormickFunction
   MatType GetFinalPoint() const { return MatType("-0.54719; -1.54719"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return -1.9133; }
+  double GetFinalObjective() const { return -1.9133; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/rastrigin_function.hpp
+++ b/include/ensmallen_bits/problems/rastrigin_function.hpp
@@ -70,7 +70,7 @@ class RastriginFunction
   }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/rosenbrock_function.hpp
+++ b/include/ensmallen_bits/problems/rosenbrock_function.hpp
@@ -64,7 +64,7 @@ class RosenbrockFunction
   MatType GetFinalPoint() const { return MatType("1.0; 1.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/rosenbrock_wood_function.hpp
+++ b/include/ensmallen_bits/problems/rosenbrock_wood_function.hpp
@@ -54,7 +54,7 @@ class RosenbrockWoodFunction
   }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/schaffer_function_n2.hpp
+++ b/include/ensmallen_bits/problems/schaffer_function_n2.hpp
@@ -62,7 +62,7 @@ class SchafferFunctionN2
   MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/schwefel_function.hpp
+++ b/include/ensmallen_bits/problems/schwefel_function.hpp
@@ -72,7 +72,7 @@ class SchwefelFunction
   }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/sgd_test_function.hpp
+++ b/include/ensmallen_bits/problems/sgd_test_function.hpp
@@ -46,7 +46,7 @@ class SGDTestFunction
   MatType GetFinalPoint() const { return MatType("0.0; 0.0; 0.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return -1.0; }
+  double GetFinalObjective() const { return -1.0; }
 
   //! Evaluate a function for a particular batch-size.
   template<typename MatType>

--- a/include/ensmallen_bits/problems/sparse_test_function.hpp
+++ b/include/ensmallen_bits/problems/sparse_test_function.hpp
@@ -41,7 +41,7 @@ class SparseTestFunction
   MatType GetFinalPoint() const { return MatType("2.0 1.0 1.5 4.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 123.75; }
+  double GetFinalObjective() const { return 123.75; }
 
   //! Evaluate a function.
   template<typename MatType>

--- a/include/ensmallen_bits/problems/sphere_function.hpp
+++ b/include/ensmallen_bits/problems/sphere_function.hpp
@@ -71,7 +71,7 @@ class SphereFunction
   }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/styblinski_tang_function.hpp
+++ b/include/ensmallen_bits/problems/styblinski_tang_function.hpp
@@ -75,7 +75,7 @@ class StyblinskiTangFunction
   }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return -39.16599 * n; }
+  double GetFinalObjective() const { return -39.16599 * n; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/three_hump_camel_function.hpp
+++ b/include/ensmallen_bits/problems/three_hump_camel_function.hpp
@@ -67,7 +67,7 @@ class ThreeHumpCamelFunction
   MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.

--- a/include/ensmallen_bits/problems/wood_function.hpp
+++ b/include/ensmallen_bits/problems/wood_function.hpp
@@ -68,7 +68,7 @@ class WoodFunction
   MatType GetFinalPoint() const { return MatType("1; 1; 1; 1"); }
 
   //! Get the final objective.
-  const double GetFinalObjective() const { return 0.0; }
+  double GetFinalObjective() const { return 0.0; }
 
   /**
    * Evaluate a function for a particular batch-size.


### PR DESCRIPTION
Another pretty simple PR.  It should fix many warnings that I see when I compile mlpack.