### PR TITLE
Remove AdamSchafferFunctionN2Test test case

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,9 @@
  * Fix compilation warnings
    ([#259](https://github.com/mlpack/ensmallen/pull/259)).
 
+ * Remove `AdamSchafferFunctionN2Test` test from Adam test suite to prevent
+   spurious issue on some aarch64 ([#265](https://github.com/mlpack/ensmallen/pull/259)).
+
 ### ensmallen 2.16.0: "Severely Dented Can Of Polyurethane"
 ###### 2021-02-11
  * Expand README with example installation and add simple example program
@@ -38,7 +41,7 @@
 
 ### ensmallen 2.14.2: "No Direction Home"
 ###### 2020-08-31
- * Fix implementation of fonesca fleming problem function f1 and f2 
+ * Fix implementation of fonesca fleming problem function f1 and f2
    type usage and negative signs. ([#223](https://github.com/mlpack/ensmallen/pull/223))
 
 ### ensmallen 2.14.1: "No Direction Home"
@@ -65,7 +68,7 @@
  * Fix L-BFGS convergence when starting from a minimum
    ([#201](https://github.com/mlpack/ensmallen/pull/201)).
 
-* Add optimizer summary report callback 
+* Add optimizer summary report callback
    ([#213](https://github.com/mlpack/ensmallen/pull/213)).
 
 ### ensmallen 2.13.0: "Automatically Automated Automation"

--- a/tests/adam_test.cpp
+++ b/tests/adam_test.cpp
@@ -322,14 +322,3 @@ TEST_CASE("AdamThreeHumpCamelFunctionTest", "[AdamTest]")
   Adam optimizer(0.001, 2, 0.7, 0.999, 1e-8, 500000, 1e-9, false);
   FunctionTest<ThreeHumpCamelFunction>(optimizer, 0.1, 0.01);
 }
-
-/**
- * Test the Adam optimizer on Schaffer function N.2.
- * This is to test Schaffer function N.2 and not Adam.
- * This test will be removed later.
- */
-TEST_CASE("AdamSchafferFunctionN2Test", "[AdamTest]")
-{
-  Adam optimizer(0.001, 2, 0.7, 0.999, 1e-8, 500000, 1e-9, false);
-  FunctionTest<SchafferFunctionN2>(optimizer, 0.1, 0.01);
-}


### PR DESCRIPTION
Let's see if removing the approximation improves test stability.