### PR TITLE
SchafferN1 Initial Point fix

### DIFF
--- a/include/ensmallen_bits/problems/schaffer_function_n1.hpp
+++ b/include/ensmallen_bits/problems/schaffer_function_n1.hpp
@@ -63,7 +63,10 @@ class SchafferFunctionN1
   //! Get the starting point.
   MatType GetInitialPoint()
   {
-    return arma::vec(numVariables, 1, arma::fill::zeros);
+    // Convenience typedef.
+    typedef typename MatType::elem_type ElemType;
+
+    return arma::Col<ElemType>(numVariables, 1, arma::fill::zeros);
   }
 
   struct ObjectiveA


### PR DESCRIPTION
Deceptively innocent but causes compile-time error when ```arma::fmat``` is used to collect initial point. Can we have a quick merge on this, please? @zoq 