### PR TITLE
Clarifying comments about test problems

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,9 @@
    ([#270](https://github.com/mlpack/ensmallen/pull/270),
     [#271](https://github.com/mlpack/ensmallen/pull/271)).
 
+ * Add clarifying comments in problems/ implementations
+   ([#276](https://github.com/mlpack/ensmallen/pull/276)).
+
 ### ensmallen 2.16.1: "Severely Dented Can Of Polyurethane"
 ###### 2021-03-02
  * Fix test compilation issue when `ENS_USE_OPENMP` is set

--- a/include/ensmallen_bits/problems/ackley_function.hpp
+++ b/include/ensmallen_bits/problems/ackley_function.hpp
@@ -59,17 +59,6 @@ class AckleyFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("0.02; 0.02"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -122,6 +111,22 @@ class AckleyFunction
   double Epsilon() const { return epsilon; }
   //! Modify the value used for numerical stability.
   double& Epsilon() { return epsilon; }
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("0.02; 0.02"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 
  private:
   //! The value of the multiplicative constant.

--- a/include/ensmallen_bits/problems/beale_function.hpp
+++ b/include/ensmallen_bits/problems/beale_function.hpp
@@ -52,17 +52,6 @@ class BealeFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("2.8; 0.35"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("3.0; 0.5"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -105,6 +94,22 @@ class BealeFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("2.8; 0.35"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("3.0; 0.5"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/booth_function.hpp
+++ b/include/ensmallen_bits/problems/booth_function.hpp
@@ -52,17 +52,6 @@ class BoothFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-9; -9"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("1.0; 3.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -105,6 +94,22 @@ class BoothFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("-9; -9"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1.0; 3.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/bukin_function.hpp
+++ b/include/ensmallen_bits/problems/bukin_function.hpp
@@ -57,17 +57,6 @@ class BukinFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-10; -2.0"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("-10.0; 1.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -115,6 +104,22 @@ class BukinFunction
   double Epsilon() const { return epsilon; }
   //! Modify the value used for numerical stability.
   double& Epsilon() { return epsilon; }
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("-10; -2.0"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("-10.0; 1.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 
  private:
   //! The value used for numerical stability.

--- a/include/ensmallen_bits/problems/colville_function.hpp
+++ b/include/ensmallen_bits/problems/colville_function.hpp
@@ -53,17 +53,6 @@ class ColvilleFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-5; 3; 1; -9"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("1; 1; 1; 1"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -106,6 +95,22 @@ class ColvilleFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient) const;
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("-5; 3; 1; -9"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1; 1; 1; 1"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/cross_in_tray_function.hpp
+++ b/include/ensmallen_bits/problems/cross_in_tray_function.hpp
@@ -57,10 +57,6 @@ class CrossInTrayFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("0; 0"); }
-
   /*
    * Evaluate a function for a particular batch-size.
    *
@@ -80,6 +76,14 @@ class CrossInTrayFunction
    */
   template<typename MatType>
   typename MatType::elem_type Evaluate(const MatType& coordinates) const;
+
+  // Note: GetInitialPoint() is not required for using ensmallen to optimize
+  // this function!  It is specifically used as a convenience just for
+  // ensmallen's testing infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("0; 0"); }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/drop_wave_function.hpp
+++ b/include/ensmallen_bits/problems/drop_wave_function.hpp
@@ -52,17 +52,6 @@ class DropWaveFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("0.5; 0.5"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -105,6 +94,22 @@ class DropWaveFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("0.5; 0.5"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/easom_function.hpp
+++ b/include/ensmallen_bits/problems/easom_function.hpp
@@ -52,17 +52,6 @@ class EasomFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("2.9; 2.9"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("3.14; 3.14"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return -1.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -105,6 +94,22 @@ class EasomFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("2.9; 2.9"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("3.14; 3.14"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return -1.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/eggholder_function.hpp
+++ b/include/ensmallen_bits/problems/eggholder_function.hpp
@@ -53,17 +53,6 @@ class EggholderFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-333; -333"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("512; 404.2319"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return -959.6407; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -106,6 +95,22 @@ class EggholderFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("-333; -333"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("512; 404.2319"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return -959.6407; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/generalized_rosenbrock_function.hpp
+++ b/include/ensmallen_bits/problems/generalized_rosenbrock_function.hpp
@@ -61,23 +61,6 @@ class GeneralizedRosenbrockFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return n - 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  const MatType GetInitialPoint() const
-  {
-    return arma::conv_to<MatType>::from(initialPoint);
-  }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  const MatType GetFinalPoint() const
-  {
-    return arma::ones<MatType>(initialPoint.n_rows, initialPoint.n_cols);
-  }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -120,6 +103,28 @@ class GeneralizedRosenbrockFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient) const;
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  const MatType GetInitialPoint() const
+  {
+    return arma::conv_to<MatType>::from(initialPoint);
+  }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  const MatType GetFinalPoint() const
+  {
+    return arma::ones<MatType>(initialPoint.n_rows, initialPoint.n_cols);
+  }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 
  private:
   //! Locally-stored Initial point.

--- a/include/ensmallen_bits/problems/goldstein_price_function.hpp
+++ b/include/ensmallen_bits/problems/goldstein_price_function.hpp
@@ -61,17 +61,6 @@ class GoldsteinPriceFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("0.2; -0.5"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("0.0; -1.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 3.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -114,6 +103,22 @@ class GoldsteinPriceFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("0.2; -0.5"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; -1.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 3.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/gradient_descent_test_function.hpp
+++ b/include/ensmallen_bits/problems/gradient_descent_test_function.hpp
@@ -25,6 +25,19 @@ class GDTestFunction
   //! Nothing to do for the constructor.
   GDTestFunction() { }
 
+  //! Evaluate a function.
+  template<typename MatType>
+  typename MatType::elem_type Evaluate(const MatType& coordinates) const;
+
+  //! Evaluate the gradient of a function.
+  template<typename MatType, typename GradType>
+  void Gradient(const MatType& coordinates, GradType& gradient) const;
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
   //! Get the starting point.
   template<typename MatType>
   MatType GetInitialPoint() const { return MatType("1; 3; 2"); }
@@ -35,14 +48,6 @@ class GDTestFunction
 
   //! Get the final objective.
   double GetFinalObjective() const { return 0.0; }
-
-  //! Evaluate a function.
-  template<typename MatType>
-  typename MatType::elem_type Evaluate(const MatType& coordinates) const;
-
-  //! Evaluate the gradient of a function.
-  template<typename MatType, typename GradType>
-  void Gradient(const MatType& coordinates, GradType& gradient) const;
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/levy_function_n13.hpp
+++ b/include/ensmallen_bits/problems/levy_function_n13.hpp
@@ -48,17 +48,6 @@ class LevyFunctionN13
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("0.9; 1.1"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("1.0; 1.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -101,6 +90,22 @@ class LevyFunctionN13
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("0.9; 1.1"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1.0; 1.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/matyas_function.hpp
+++ b/include/ensmallen_bits/problems/matyas_function.hpp
@@ -52,17 +52,6 @@ class MatyasFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-3; 3"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -105,6 +94,22 @@ class MatyasFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("-3; 3"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/mc_cormick_function.hpp
+++ b/include/ensmallen_bits/problems/mc_cormick_function.hpp
@@ -52,17 +52,6 @@ class McCormickFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-2; 4"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("-0.54719; -1.54719"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return -1.9133; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -105,6 +94,22 @@ class McCormickFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("-2; 4"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("-0.54719; -1.54719"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return -1.9133; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/rastrigin_function.hpp
+++ b/include/ensmallen_bits/problems/rastrigin_function.hpp
@@ -55,23 +55,6 @@ class RastriginFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return n; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const
-  {
-    return arma::conv_to<MatType>::from(initialPoint);
-  }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const
-  {
-    return arma::zeros<MatType>(initialPoint.n_rows, initialPoint.n_cols);
-  }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -114,6 +97,29 @@ class RastriginFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const
+  {
+    return arma::conv_to<MatType>::from(initialPoint);
+  }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    return arma::zeros<MatType>(initialPoint.n_rows, initialPoint.n_cols);
+  }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
+
  private:
   //! Number of dimensions for the function.
   size_t n;

--- a/include/ensmallen_bits/problems/rosenbrock_function.hpp
+++ b/include/ensmallen_bits/problems/rosenbrock_function.hpp
@@ -55,17 +55,6 @@ class RosenbrockFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-1.2; 1.0"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("1.0; 1.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -115,6 +104,22 @@ class RosenbrockFunction
   template<typename MatType, typename GradType>
   typename MatType::elem_type EvaluateWithGradient(const MatType& coordinates,
                                                    GradType& gradient) const;
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("-1.2; 1.0"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1.0; 1.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/rosenbrock_wood_function.hpp
+++ b/include/ensmallen_bits/problems/rosenbrock_wood_function.hpp
@@ -39,23 +39,6 @@ class RosenbrockWoodFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  const MatType GetInitialPoint() const
-  {
-    return arma::conv_to<MatType>::from(initialPoint);
-  }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const
-  {
-    return arma::ones<MatType>(initialPoint.n_rows, initialPoint.n_cols);
-  }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -98,6 +81,28 @@ class RosenbrockWoodFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient) const;
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  const MatType GetInitialPoint() const
+  {
+    return arma::conv_to<MatType>::from(initialPoint);
+  }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    return arma::ones<MatType>(initialPoint.n_rows, initialPoint.n_cols);
+  }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 
  private:
   //! Locally-stored initial point.

--- a/include/ensmallen_bits/problems/schaffer_function_n2.hpp
+++ b/include/ensmallen_bits/problems/schaffer_function_n2.hpp
@@ -53,17 +53,6 @@ class SchafferFunctionN2
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-100; 100"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -106,6 +95,22 @@ class SchafferFunctionN2
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("-100; 100"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/schwefel_function.hpp
+++ b/include/ensmallen_bits/problems/schwefel_function.hpp
@@ -55,25 +55,6 @@ class SchwefelFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return n; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const
-  {
-    return arma::conv_to<MatType>::from(initialPoint);
-  }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const
-  {
-    MatType result(initialPoint.n_rows, initialPoint.n_cols);
-    result.fill(420.9687);
-    return result;
-  }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -116,6 +97,31 @@ class SchwefelFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const
+  {
+    return arma::conv_to<MatType>::from(initialPoint);
+  }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    MatType result(initialPoint.n_rows, initialPoint.n_cols);
+    result.fill(420.9687);
+    return result;
+  }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
+
  private:
   //! Number of dimensions for the function.
   size_t n;

--- a/include/ensmallen_bits/problems/sgd_test_function.hpp
+++ b/include/ensmallen_bits/problems/sgd_test_function.hpp
@@ -37,17 +37,6 @@ class SGDTestFunction
   //! Return 3 (the number of functions).
   size_t NumFunctions() const { return 3; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("6; -45.6; 6.2"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("0.0; 0.0; 0.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return -1.0; }
-
   //! Evaluate a function for a particular batch-size.
   template<typename MatType>
   typename MatType::elem_type Evaluate(const MatType& coordinates,
@@ -60,6 +49,22 @@ class SGDTestFunction
                 const size_t begin,
                 GradType& gradient,
                 const size_t batchSize) const;
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("6; -45.6; 6.2"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0; 0.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return -1.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/sparse_test_function.hpp
+++ b/include/ensmallen_bits/problems/sparse_test_function.hpp
@@ -32,17 +32,6 @@ class SparseTestFunction
   //! Return 4 (the number of features).
   size_t NumFeatures() const { return 4; }
 
-  //! Get the starting point.
-  template<typename MatType>
-  MatType GetInitialPoint() const { return MatType("0 0 0 0;"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("2.0 1.0 1.5 4.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 123.75; }
-
   //! Evaluate a function.
   template<typename MatType>
   typename MatType::elem_type Evaluate(const MatType& coordinates,
@@ -67,6 +56,22 @@ class SparseTestFunction
   void PartialGradient(const MatType& coordinates,
                        const size_t j,
                        GradType& gradient) const;
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType>
+  MatType GetInitialPoint() const { return MatType("0 0 0 0;"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("2.0 1.0 1.5 4.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 123.75; }
 
  private:
   // Each quadratic polynomial is monic. The intercept and coefficient of the

--- a/include/ensmallen_bits/problems/sphere_function.hpp
+++ b/include/ensmallen_bits/problems/sphere_function.hpp
@@ -56,23 +56,6 @@ class SphereFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return n; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const
-  {
-    return arma::conv_to<MatType>::from(initialPoint);
-  }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const
-  {
-    return arma::zeros<MatType>(initialPoint.n_rows, initialPoint.n_cols);
-  }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -115,6 +98,28 @@ class SphereFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const
+  {
+    return arma::conv_to<MatType>::from(initialPoint);
+  }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    return arma::zeros<MatType>(initialPoint.n_rows, initialPoint.n_cols);
+  }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 
  private:
   //! Number of dimensions for the function.

--- a/include/ensmallen_bits/problems/styblinski_tang_function.hpp
+++ b/include/ensmallen_bits/problems/styblinski_tang_function.hpp
@@ -57,26 +57,6 @@ class StyblinskiTangFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return n; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const
-  {
-    return arma::conv_to<MatType>::from(initialPoint);
-  }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const
-  {
-    MatType result(initialPoint.n_rows, initialPoint.n_cols);
-    for (size_t i = 0; i < result.n_elem; ++i)
-      result[i] = -2.903534;
-    return result;
-  }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return -39.16599 * n; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -119,6 +99,31 @@ class StyblinskiTangFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const
+  {
+    return arma::conv_to<MatType>::from(initialPoint);
+  }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const
+  {
+    MatType result(initialPoint.n_rows, initialPoint.n_cols);
+    for (size_t i = 0; i < result.n_elem; ++i)
+      result[i] = -2.903534;
+    return result;
+  }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return -39.16599 * n; }
 
  private:
   //! Number of dimensions for the function.

--- a/include/ensmallen_bits/problems/three_hump_camel_function.hpp
+++ b/include/ensmallen_bits/problems/three_hump_camel_function.hpp
@@ -58,17 +58,6 @@ class ThreeHumpCamelFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("1; 1"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -111,6 +100,22 @@ class ThreeHumpCamelFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("1; 1"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("0.0; 0.0"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/wood_function.hpp
+++ b/include/ensmallen_bits/problems/wood_function.hpp
@@ -59,17 +59,6 @@ class WoodFunction
   //! Return 1 (the number of functions).
   size_t NumFunctions() const { return 1; }
 
-  //! Get the starting point.
-  template<typename MatType = arma::mat>
-  MatType GetInitialPoint() const { return MatType("-3; -1; -3; -1"); }
-
-  //! Get the final point.
-  template<typename MatType = arma::mat>
-  MatType GetFinalPoint() const { return MatType("1; 1; 1; 1"); }
-
-  //! Get the final objective.
-  double GetFinalObjective() const { return 0.0; }
-
   /**
    * Evaluate a function for a particular batch-size.
    *
@@ -112,6 +101,22 @@ class WoodFunction
    */
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient) const;
+
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
+  // required for using ensmallen to optimize this function!  They are
+  // specifically used as a convenience just for ensmallen's testing
+  // infrastructure.
+
+  //! Get the starting point.
+  template<typename MatType = arma::mat>
+  MatType GetInitialPoint() const { return MatType("-3; -1; -3; -1"); }
+
+  //! Get the final point.
+  template<typename MatType = arma::mat>
+  MatType GetFinalPoint() const { return MatType("1; 1; 1; 1"); }
+
+  //! Get the final objective.
+  double GetFinalObjective() const { return 0.0; }
 };
 
 } // namespace test


### PR DESCRIPTION
In the discussion of #272 we realized it would be a good idea to add comments to each of the test problems that implement `GetInitialPoint()`, `GetFinalObjective()`, and `GetFinalPoint()`, in order to indicate that these are not necessary if you just want to optimize a function, and that these are only there just for the convenience of our testing infrastructure.

So, this PR just adds those comments, and moves those functions to the bottom of the class.