### PR TITLE
Make Test Functions flexible for MultiObjective Optimizers

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,7 +15,6 @@
 
  * Add clarifying comments in problems/ implementations
    ([#276](https://github.com/mlpack/ensmallen/pull/276)).
-   
  * CheckArbitraryFunctionTypeAPI extended for MOO support
    ([#283](https://github.com/mlpack/ensmallen/pull/283)).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,9 @@
  * Add clarifying comments in problems/ implementations
    ([#276](https://github.com/mlpack/ensmallen/pull/276)).
 
+ * Add bounds of search space for problem functions.
+   ([#276](https://github.com/mlpack/ensmallen/pull/279)).
+
 ### ensmallen 2.16.1: "Severely Dented Can Of Polyurethane"
 ###### 2021-03-02
  * Fix test compilation issue when `ENS_USE_OPENMP` is set

--- a/include/ensmallen_bits/problems/ackley_function.hpp
+++ b/include/ensmallen_bits/problems/ackley_function.hpp
@@ -113,7 +113,7 @@ class AckleyFunction
   double& Epsilon() { return epsilon; }
 
   // Note: GetInitialPoint(), GetFinalPoint(), GetFinalObjective(), and
-  // GetVariablesBounds() are not required for using ensmallen to
+  // GetVariableBounds() are not required for using ensmallen to
   // optimize this function!  They are specifically used as a
   // convenience just for ensmallen's testing infrastructure.
 

--- a/include/ensmallen_bits/problems/ackley_function.hpp
+++ b/include/ensmallen_bits/problems/ackley_function.hpp
@@ -112,7 +112,7 @@ class AckleyFunction
   //! Modify the value used for numerical stability.
   double& Epsilon() { return epsilon; }
 
-  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective(),
+  // Note: GetInitialPoint(), GetFinalPoint(), GetFinalObjective(), and
   // GetVariablesBounds() are not required for using ensmallen to
   // optimize this function!  They are specifically used as a
   // convenience just for ensmallen's testing infrastructure.

--- a/include/ensmallen_bits/problems/ackley_function.hpp
+++ b/include/ensmallen_bits/problems/ackley_function.hpp
@@ -129,7 +129,7 @@ class AckleyFunction
   double GetFinalObjective() const { return 0.0; }
 
   //! Get the bounds of variable space.
-  std::tuple<arma::vec, arma::vec> GetVariablesBounds() const
+  std::tuple<arma::vec, arma::vec> GetVariableBounds() const
   {
     arma::vec lowerBound {-32.768, -32.768};
     arma::vec upperBound {+32.768, +32.768};

--- a/include/ensmallen_bits/problems/ackley_function.hpp
+++ b/include/ensmallen_bits/problems/ackley_function.hpp
@@ -112,10 +112,10 @@ class AckleyFunction
   //! Modify the value used for numerical stability.
   double& Epsilon() { return epsilon; }
 
-  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
-  // required for using ensmallen to optimize this function!  They are
-  // specifically used as a convenience just for ensmallen's testing
-  // infrastructure.
+  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective(),
+  // GetVariablesBounds() are not required for using ensmallen to
+  // optimize this function!  They are specifically used as a
+  // convenience just for ensmallen's testing infrastructure.
 
   //! Get the starting point.
   template<typename MatType = arma::mat>
@@ -127,6 +127,15 @@ class AckleyFunction
 
   //! Get the final objective.
   double GetFinalObjective() const { return 0.0; }
+
+  //! Get the bounds of variable space.
+  std::tuple<arma::vec, arma::vec> GetVariablesBounds() const
+  {
+    arma::vec lowerBound {-32.768, -32.768};
+    arma::vec upperBound {+32.768, +32.768};
+
+    return std::make_tuple(lowerBound, upperBound);
+  }
 
  private:
   //! The value of the multiplicative constant.

--- a/include/ensmallen_bits/problems/beale_function.hpp
+++ b/include/ensmallen_bits/problems/beale_function.hpp
@@ -95,10 +95,10 @@ class BealeFunction
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
 
-  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
-  // required for using ensmallen to optimize this function!  They are
-  // specifically used as a convenience just for ensmallen's testing
-  // infrastructure.
+  // Note: GetInitialPoint(), GetFinalPoint(), GetFinalObjective(), and
+  // GetVariablesBounds() are not required for using ensmallen to
+  // optimize this function!  They are specifically used as a
+  // convenience just for ensmallen's testing infrastructure.
 
   //! Get the starting point.
   template<typename MatType = arma::mat>
@@ -110,6 +110,15 @@ class BealeFunction
 
   //! Get the final objective.
   double GetFinalObjective() const { return 0.0; }
+
+  //! Get the bounds of variable space.
+  std::tuple<arma::vec, arma::vec> GetVariableBounds() const
+  {
+    arma::vec lowerBound {-4.5, -4.5};
+    arma::vec upperBound {+4.5, +4.5};
+
+    return std::make_tuple(lowerBound, upperBound);
+  }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/booth_function.hpp
+++ b/include/ensmallen_bits/problems/booth_function.hpp
@@ -95,10 +95,10 @@ class BoothFunction
   template<typename MatType, typename GradType>
   void Gradient(const MatType& coordinates, GradType& gradient);
 
-  // Note: GetInitialPoint(), GetFinalPoint(), and GetFinalObjective() are not
-  // required for using ensmallen to optimize this function!  They are
-  // specifically used as a convenience just for ensmallen's testing
-  // infrastructure.
+  // Note: GetInitialPoint(), GetFinalPoint(), GetFinalObjective(), and
+  // GetVariablesBounds() are not required for using ensmallen to
+  // optimize this function!  They are specifically used as a
+  // convenience just for ensmallen's testing infrastructure.
 
   //! Get the starting point.
   template<typename MatType = arma::mat>
@@ -110,6 +110,15 @@ class BoothFunction
 
   //! Get the final objective.
   double GetFinalObjective() const { return 0.0; }
+
+  //! Get the bounds of variable space.
+  std::tuple<arma::vec, arma::vec> GetVariableBounds() const
+  {
+    arma::vec lowerBound {-10.0, -10.0};
+    arma::vec upperBound {+10.0, +10.0};
+
+    return std::make_tuple(lowerBound, upperBound);
+  }
 };
 
 } // namespace test

--- a/include/ensmallen_bits/problems/schaffer_function_n1.hpp
+++ b/include/ensmallen_bits/problems/schaffer_function_n1.hpp
@@ -60,15 +60,6 @@ class SchafferFunctionN1
     return objectives;
   }
 
-  //! Get the starting point.
-  MatType GetInitialPoint()
-  {
-    // Convenience typedef.
-    typedef typename MatType::elem_type ElemType;
-
-    return arma::Col<ElemType>(numVariables, 1, arma::fill::zeros);
-  }
-
   struct ObjectiveA
   {
     typename MatType::elem_type Evaluate(const MatType& coords)
@@ -89,6 +80,29 @@ class SchafferFunctionN1
   std::tuple<ObjectiveA, ObjectiveB> GetObjectives()
   {
     return std::make_tuple(objectiveA, objectiveB);
+  }
+
+  // Note: GetInitialPoint() and GetVariableBounds() are not
+  // required for using ensmallen to optimize this function!
+  // They are specifically used as a convenience just for
+  // ensmallen's testing infrastructure.
+
+  //! Get the starting point.
+  MatType GetInitialPoint()
+  {
+    // Convenience typedef.
+    typedef typename MatType::elem_type ElemType;
+
+    return arma::Col<ElemType>(numVariables, 1, arma::fill::zeros);
+  }
+
+  //! Get the bounds of variable search space.
+  std::tuple<arma::vec, arma::vec> GetVariableBounds() const
+  {
+    arma::vec lowerBound{ -1000., -1000. };
+    arma::vec upperBound{ +1000., +1000. };
+
+    return std::make_tuple(lowerBound, upperBound);
   }
 };
 } // namespace test


### PR DESCRIPTION
Following the discussion of #272.  It was decided that adding bounds to the problem function is convenient (**but not necessary**) and is mostly restricted for testing purposes.

Once this PR gets merged we can have a series of followup (or even continue this?) PR to complete the task.

**LOGS**
- [x] ackley_function.hpp: Molga, Marcin, and Czesław Smutnicki. "Test functions for optimization needs." Test functions for optimization needs 101 (2005): 48.  
- [ ] easom_function.hpp                   
- [ ] himmelblau_function.hpp          
- [ ] rastrigin_function.hpp        
- [x] beale_function.hpp : Wikipedia
- [ ] eggholder_function.hpp
- [ ] holder_table_function.hpp
- [ ] rosenbrock_function.hpp
- [x] booth_function.hpp  : Wikipedia
- [ ] fonseca_fleming_function.hpp         
- [ ] levy_function_n13.hpp             
- [ ] rosenbrock_wood_function.hpp 
- [ ] sparse_test_function.hpp
- [ ] bukin_function.hpp         
- [ ] fw_test_function.hpp
- [x] schaffer_function_n1.hpp: "Multiple Objective Optimization with Vector Evaluated Genetic Algorithms" (Wikipedia suggest -10 to -10^5 for lowerBound is OK so i went with -10^3).
- [ ] sphere_function.hpp
- [ ] colville_function.hpp       
- [ ] generalized_rosenbrock_function.hpp  
- [ ] matyas_function.hpp               
- [ ] schaffer_function_n2.hpp      
- [ ] styblinski_tang_function.hpp
- [ ] cross_in_tray_function.hpp 
- [ ] goldstein_price_function.hpp         
- [ ] mc_cormick_function.hpp           
- [ ] schaffer_function_n4.hpp      
- [ ] three_hump_camel_function.hpp
- [ ] drop_wave_function.hpp      
- [ ] schwefel_function.hpp       
- [ ] wood_function.hpp