### PR TITLE
Recursively check for Evaluate() in MOO

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,9 @@
  * Add clarifying comments in problems/ implementations
    ([#276](https://github.com/mlpack/ensmallen/pull/276)).
 
+ * CheckArbitraryFunctionTypeAPI extended for MOO support
+   ([#283](https://github.com/mlpack/ensmallen/pull/283)).
+
 ### ensmallen 2.16.1: "Severely Dented Can Of Polyurethane"
 ###### 2021-03-02
  * Fix test compilation issue when `ENS_USE_OPENMP` is set

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -375,7 +375,7 @@ inline void CheckSparseFunctionTypeAPI()
 /**
  * Perform checks for the ArbitraryFunctionType API.
  */
-template<typename FunctionType, typename MatType, std::size_t I = 0U>
+template<typename FunctionType, typename MatType, std::size_t I = 0>
 inline void CheckArbitraryFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
@@ -387,8 +387,8 @@ inline void CheckArbitraryFunctionTypeAPI()
 #endif
 }
 
-template<typename... FunctionAndMatTypes, std::size_t I = 0U>
-typename std::enable_if<I < sizeof...(FunctionAndMatTypes) - 2U, void>::type
+template<typename... FunctionAndMatTypes, std::size_t I = 0>
+typename std::enable_if<I < sizeof...(FunctionAndMatTypes) - 2, void>::type
 CheckArbitraryFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -375,7 +375,7 @@ inline void CheckSparseFunctionTypeAPI()
 /**
  * Perform checks for the ArbitraryFunctionType API.
  */
-template<typename FunctionType, typename MatType, std::size_t I = 0>
+template<typename FunctionType, typename MatType>
 inline void CheckArbitraryFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
@@ -387,14 +387,13 @@ inline void CheckArbitraryFunctionTypeAPI()
 #endif
 }
 
-template<typename... FunctionAndMatTypes, std::size_t I = 0>
-typename std::enable_if<I < sizeof...(FunctionAndMatTypes) - 2, void>::type
+template<typename FunctionType, typename... RemainingTypes>
+typename std::enable_if<(sizeof...(RemainingTypes) > 1), void>::type
 CheckArbitraryFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
-  constexpr size_t size = sizeof...(FunctionAndMatTypes);
-  using TupleType = typename std::tuple<FunctionAndMatTypes...>;
-  using FunctionType = typename std::tuple_element<I, TupleType>::type;
+  constexpr size_t size = sizeof...(RemainingTypes);
+  using TupleType = typename std::tuple<RemainingTypes...>;
   using MatType = typename std::tuple_element<size - 1, TupleType>::type;
 
   static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
@@ -403,7 +402,7 @@ CheckArbitraryFunctionTypeAPI()
       "of the ArbitraryFunctionType API; see the optimizer tutorial for "
       "more details.");
 
-  CheckArbitraryFunctionTypeAPI<FunctionAndMatTypes..., I + 1>();
+  CheckArbitraryFunctionTypeAPI<RemainingTypes...>();
 #endif
 }
 

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -375,16 +375,10 @@ inline void CheckSparseFunctionTypeAPI()
 /**
  * Perform checks for the ArbitraryFunctionType API.
  */
-template<typename... FunctionAndMatTypes, std::size_t I = 0U>
-typename std::enable_if<I == sizeof...(FunctionAndMatTypes) - 2U, void> :: type
-CheckArbitraryFunctionTypeAPI()
+template<typename FunctionType, typename MatType, std::size_t I = 0U>
+void CheckArbitraryFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
-  constexpr size_t size = sizeof...(FunctionAndMatTypes);
-  using TupleType = typename std::tuple<FunctionAndMatTypes...>;
-  using FunctionType = typename std::tuple_element<I, TupleType>::type;
-  using MatType = typename std::tuple_element<size - 1, TupleType>::type;
-
   static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
     "The FunctionType does not have a correct definition of Evaluate(). "
     "Please check that the FunctionType fully satisfies the requirements of "
@@ -404,9 +398,9 @@ CheckArbitraryFunctionTypeAPI()
   using MatType = typename std::tuple_element<size - 1, TupleType>::type;
 
   static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
-    "The FunctionType does not have a correct definition of Evaluate(). "
-    "Please check that the FunctionType fully satisfies the requirements of "
-    "the ArbitraryFunctionType API; see the optimizer tutorial for "
+    "One of the provided FunctionType does not have a correct definition of Evaluate(). "
+    "Please check that the corresponding FunctionType fully satisfies the requirements"
+    "of the ArbitraryFunctionType API; see the optimizer tutorial for "
     "more details.");
 
   CheckArbitraryFunctionTypeAPI<FunctionAndMatTypes..., I + 1>();

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -388,6 +388,40 @@ inline void CheckArbitraryFunctionTypeAPI()
 }
 
 /**
+* Perform checks for the ArbitraryFunctionType API.
+* Multiobjective case.
+*/
+template <typename MatType,
+          typename FunctionType,
+          std::size_t I = 1U>
+typename std::enable_if<I == 1U, void>::type
+CheckMultiArbitraryFunctionTypeAPI()
+{
+  CheckArbitraryFunctionTypeAPI<FunctionType, MatType>();
+}
+
+/**
+ * Perform checks for the ArbitraryFunctionType API.
+ * Multiobjective case.
+ */
+template<typename MatType,
+         typename FunctionType,
+         typename... RemainingFunctionTypes,
+         std::size_t I = sizeof...(RemainingFunctionTypes) + 1U>
+typename std::enable_if<(I > 1U), void>::type
+CheckMultiArbitraryFunctionTypeAPI()
+{
+#ifndef ENS_DISABLE_TYPE_CHECKS
+  static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
+      "One of the FunctionType does not have a correct definition of Evaluate(). "
+      "Please ensure that each of the FunctionTypes fully satisfies the requirements of "
+      "the ArbitraryFunctionType API; see the optimizer tutorial for "
+      "more details.");
+  CheckMultiArbitraryFunctionTypeAPI<MatType, RemainingFunctionTypes..., I - 1U>();
+#endif
+}
+
+/**
  * Perform checks for the ResolvableFunctionType API.
  */
 template<typename FunctionType, typename MatType, typename GradType>

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -376,7 +376,7 @@ inline void CheckSparseFunctionTypeAPI()
  * Perform checks for the ArbitraryFunctionType API.
  */
 template<typename FunctionType, typename MatType, std::size_t I = 0U>
-void CheckArbitraryFunctionTypeAPI()
+inline void CheckArbitraryFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
   static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -375,45 +375,42 @@ inline void CheckSparseFunctionTypeAPI()
 /**
  * Perform checks for the ArbitraryFunctionType API.
  */
-template<typename FunctionType, typename MatType>
-inline void CheckArbitraryFunctionTypeAPI()
+template<typename... FunctionAndMatTypes, std::size_t I = 0U>
+typename std::enable_if<I == sizeof...(FunctionAndMatTypes) - 2U, void> :: type
+CheckArbitraryFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
+  constexpr size_t size = sizeof...(FunctionAndMatTypes);
+  using TupleType = typename std::tuple<FunctionAndMatTypes...>;
+  using FunctionType = typename std::tuple_element<I, TupleType>::type;
+  using MatType = typename std::tuple_element<size - 1, TupleType>::type;
+
   static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
-      "The FunctionType does not have a correct definition of Evaluate(). "
-      "Please check that the FunctionType fully satisfies the requirements of "
-      "the ArbitraryFunctionType API; see the optimizer tutorial for "
-      "more details.");
+    "The FunctionType does not have a correct definition of Evaluate(). "
+    "Please check that the FunctionType fully satisfies the requirements of "
+    "the ArbitraryFunctionType API; see the optimizer tutorial for "
+    "more details.");
 #endif
 }
 
-/**
- * Perform checks for the ArbitraryFunctionType API.
- * Multiobjective case.
- */
-template<typename... FunctionAndMatTypes, std::size_t I = 0>
-typename std::enable_if<I == sizeof...(FunctionAndMatTypes) - 2U, void> :: type
-CheckMultiArbitraryFunctionTypeAPI()
-{
-  constexpr size_t size = sizeof...(FunctionAndMatTypes);
-  using TupleType = typename std::tuple<FunctionAndMatTypes...>;
-  using FunctionType = typename std::tuple_element<I, TupleType>::type;
-  using MatType = typename std::tuple_element<size - 1, TupleType>::type;
-
-  CheckArbitraryFunctionTypeAPI<FunctionType, MatType>();
-}
-
-template<typename... FunctionAndMatTypes, std::size_t I = 0>
+template<typename... FunctionAndMatTypes, std::size_t I = 0U>
 typename std::enable_if<I < sizeof...(FunctionAndMatTypes) - 2U, void>::type
-CheckMultiArbitraryFunctionTypeAPI()
+CheckArbitraryFunctionTypeAPI()
 {
+#ifndef ENS_DISABLE_TYPE_CHECKS
   constexpr size_t size = sizeof...(FunctionAndMatTypes);
   using TupleType = typename std::tuple<FunctionAndMatTypes...>;
   using FunctionType = typename std::tuple_element<I, TupleType>::type;
   using MatType = typename std::tuple_element<size - 1, TupleType>::type;
-  CheckArbitraryFunctionTypeAPI<FunctionType, MatType>();
 
-  CheckMultiArbitraryFunctionTypeAPI<FunctionAndMatTypes..., I + 1>();
+  static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
+    "The FunctionType does not have a correct definition of Evaluate(). "
+    "Please check that the FunctionType fully satisfies the requirements of "
+    "the ArbitraryFunctionType API; see the optimizer tutorial for "
+    "more details.");
+
+  CheckArbitraryFunctionTypeAPI<FunctionAndMatTypes..., I + 1>();
+#endif
 }
 
 /**

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -380,10 +380,10 @@ void CheckArbitraryFunctionTypeAPI()
 {
 #ifndef ENS_DISABLE_TYPE_CHECKS
   static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
-    "The FunctionType does not have a correct definition of Evaluate(). "
-    "Please check that the FunctionType fully satisfies the requirements of "
-    "the ArbitraryFunctionType API; see the optimizer tutorial for "
-    "more details.");
+      "The FunctionType does not have a correct definition of Evaluate(). "
+      "Please check that the FunctionType fully satisfies the requirements of "
+      "the ArbitraryFunctionType API; see the optimizer tutorial for "
+      "more details.");
 #endif
 }
 
@@ -398,10 +398,10 @@ CheckArbitraryFunctionTypeAPI()
   using MatType = typename std::tuple_element<size - 1, TupleType>::type;
 
   static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
-    "One of the provided FunctionType does not have a correct definition of Evaluate(). "
-    "Please check that the corresponding FunctionType fully satisfies the requirements"
-    "of the ArbitraryFunctionType API; see the optimizer tutorial for "
-    "more details.");
+      "One of the provided FunctionType does not have a correct definition of Evaluate(). "
+      "Please check that the corresponding FunctionType fully satisfies the requirements"
+      "of the ArbitraryFunctionType API; see the optimizer tutorial for "
+      "more details.");
 
   CheckArbitraryFunctionTypeAPI<FunctionAndMatTypes..., I + 1>();
 #endif

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -404,10 +404,10 @@ CheckMultiArbitraryFunctionTypeAPI()
  * Perform checks for the ArbitraryFunctionType API.
  * Multiobjective case.
  */
-template<typename MatType,
-         typename FunctionType,
+template<typename FunctionType,
          typename... RemainingFunctionTypes,
-         std::size_t I = sizeof...(RemainingFunctionTypes) + 1U>
+         std::size_t I = sizeof...(RemainingFunctionTypes) + 1U,
+         typename MatType>
 typename std::enable_if<(I > 1U), void>::type
 CheckMultiArbitraryFunctionTypeAPI()
 {
@@ -417,7 +417,7 @@ CheckMultiArbitraryFunctionTypeAPI()
       "Please ensure that each of the FunctionTypes fully satisfies the requirements of "
       "the ArbitraryFunctionType API; see the optimizer tutorial for "
       "more details.");
-  CheckMultiArbitraryFunctionTypeAPI<MatType, RemainingFunctionTypes..., I - 1U>();
+  CheckMultiArbitraryFunctionTypeAPI<RemainingFunctionTypes..., I - 1U>();
 #endif
 }
 

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -399,7 +399,7 @@ CheckArbitraryFunctionTypeAPI()
 
   static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
       "One of the provided FunctionType does not have a correct definition of Evaluate(). "
-      "Please check that the corresponding FunctionType fully satisfies the requirements"
+      "Please check that the corresponding FunctionType fully satisfies the requirements "
       "of the ArbitraryFunctionType API; see the optimizer tutorial for "
       "more details.");
 

--- a/include/ensmallen_bits/function/static_checks.hpp
+++ b/include/ensmallen_bits/function/static_checks.hpp
@@ -388,37 +388,32 @@ inline void CheckArbitraryFunctionTypeAPI()
 }
 
 /**
-* Perform checks for the ArbitraryFunctionType API.
-* Multiobjective case.
-*/
-template <typename MatType,
-          typename FunctionType,
-          std::size_t I = 1U>
-typename std::enable_if<I == 1U, void>::type
-CheckMultiArbitraryFunctionTypeAPI()
-{
-  CheckArbitraryFunctionTypeAPI<FunctionType, MatType>();
-}
-
-/**
  * Perform checks for the ArbitraryFunctionType API.
  * Multiobjective case.
  */
-template<typename FunctionType,
-         typename... RemainingFunctionTypes,
-         std::size_t I = sizeof...(RemainingFunctionTypes) + 1U,
-         typename MatType>
-typename std::enable_if<(I > 1U), void>::type
+template<typename... FunctionAndMatTypes, std::size_t I = 0>
+typename std::enable_if<I == sizeof...(FunctionAndMatTypes) - 2U, void> :: type
 CheckMultiArbitraryFunctionTypeAPI()
 {
-#ifndef ENS_DISABLE_TYPE_CHECKS
-  static_assert(CheckEvaluate<FunctionType, MatType, MatType>::value,
-      "One of the FunctionType does not have a correct definition of Evaluate(). "
-      "Please ensure that each of the FunctionTypes fully satisfies the requirements of "
-      "the ArbitraryFunctionType API; see the optimizer tutorial for "
-      "more details.");
-  CheckMultiArbitraryFunctionTypeAPI<RemainingFunctionTypes..., I - 1U>();
-#endif
+  constexpr size_t size = sizeof...(FunctionAndMatTypes);
+  using TupleType = typename std::tuple<FunctionAndMatTypes...>;
+  using FunctionType = typename std::tuple_element<I, TupleType>::type;
+  using MatType = typename std::tuple_element<size - 1, TupleType>::type;
+
+  CheckArbitraryFunctionTypeAPI<FunctionType, MatType>();
+}
+
+template<typename... FunctionAndMatTypes, std::size_t I = 0>
+typename std::enable_if<I < sizeof...(FunctionAndMatTypes) - 2U, void>::type
+CheckMultiArbitraryFunctionTypeAPI()
+{
+  constexpr size_t size = sizeof...(FunctionAndMatTypes);
+  using TupleType = typename std::tuple<FunctionAndMatTypes...>;
+  using FunctionType = typename std::tuple_element<I, TupleType>::type;
+  using MatType = typename std::tuple_element<size - 1, TupleType>::type;
+  CheckArbitraryFunctionTypeAPI<FunctionType, MatType>();
+
+  CheckMultiArbitraryFunctionTypeAPI<FunctionAndMatTypes..., I + 1>();
 }
 
 /**

--- a/include/ensmallen_bits/nsga2/nsga2_impl.hpp
+++ b/include/ensmallen_bits/nsga2/nsga2_impl.hpp
@@ -227,10 +227,6 @@ NSGA2::EvaluateObjectives(
 {
   for (size_t i = 0; i < populationSize; i++)
   {
-    using FunctionType = typename std::tuple_element<
-        I, std::tuple<ArbitraryFunctionType...>>::type;
-    traits::CheckArbitraryFunctionTypeAPI<
-        FunctionType, MatType>();
     calculatedObjectives[i](I) = std::get<I>(objectives).Evaluate(population[i]);
     EvaluateObjectives<I+1, MatType, ArbitraryFunctionType...>(population, objectives,
                                                                calculatedObjectives);

--- a/include/ensmallen_bits/nsga2/nsga2_impl.hpp
+++ b/include/ensmallen_bits/nsga2/nsga2_impl.hpp
@@ -227,6 +227,10 @@ NSGA2::EvaluateObjectives(
 {
   for (size_t i = 0; i < populationSize; i++)
   {
+    using FunctionType = typename std::tuple_element<
+        I, std::tuple<ArbitraryFunctionType...>>::type;
+    traits::CheckArbitraryFunctionTypeAPI<
+        FunctionType, MatType>();
     calculatedObjectives[i](I) = std::get<I>(objectives).Evaluate(population[i]);
     EvaluateObjectives<I+1, MatType, ArbitraryFunctionType...>(population, objectives,
                                                                calculatedObjectives);


### PR DESCRIPTION
Refer #282 Section II.

Is there a strong reason for having ```template<MatType, FunctionType>``` instead of ```template<FunctionType, MatType>```, the problem is when we do recursive call, I need the FunctionType to be the at the end for it to work. I don't see any other way.

Infact if we go by ```template<MatType, FunctionType>```, I can integrate ```CheckMultiArbitraryFunctionTypeAPI()``` into ```CheckArbitraryFunctionTypeAPI()```, and it will work like normal + MOO checks.