### PR TITLE
Switch from Ubuntu Trusty 14.04 to Ubuntu Focal 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: trusty
+dist: focal
 language: cpp
 
 env:


### PR DESCRIPTION
For some reason travis marks the build as failed (I guess it's because it can't download some packages), let's see if switching to an more up-t-date ubuntu solves the issue.