### PR TITLE
Use Catch2 seed command-line argument to set ensmallen seeds

### DIFF
--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -17,18 +17,23 @@
 
 int main(int argc, char** argv)
 {
-  /**
-   * Uncomment these three lines if you want to test with different random seeds
-   * each run.  This is good for ensuring that a test's tolerance is sufficient
-   * across many different runs.
-   */
-  //size_t seed = std::time(NULL);
-  //srand((unsigned int) seed);
-  //arma::arma_rng::set_seed(seed);
+  Catch::Session session;
+  const int returnCode = session.applyCommandLine(argc, argv);
+  // Check for a command line error.
+  if (returnCode != 0)
+    return returnCode;
 
   std::cout << "ensmallen version: " << ens::version::as_string() << std::endl;
-
   std::cout << "armadillo version: " << arma::arma_version::as_string() << std::endl;
 
-  return Catch::Session().run(argc, argv);
+  // Use Catch2 command-line to set the random seed.
+  // -rng-seed <'time'|number>
+  // If a number is provided this is used directly as the seed. Alternatively
+  // if the keyword 'time' is provided then the result of calling std::time(0)
+  // is used.
+  const size_t seed = session.config().rngSeed();
+  srand((unsigned int) seed);
+  arma::arma_rng::set_seed(seed);
+
+  return session.run();
 }


### PR DESCRIPTION
Use Catch2 seed command-line argument to set ensmallen seeds; this enables us to improve the automatic test pipeline to run the tests multiple times with different random seeds.