### PR TITLE
Make Callback flexible for MultiObjective Optimizers.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,7 +25,7 @@
  * Add Indicators for Multiobjective optimizers
    ([#285](https://github.com/mlpack/ensmallen/pull/285)).
 
- * Make Callback traits adaptable for MOO
+ * Make Callback flexible for MultiObjective Optimizers
    ([#289](https://github.com/mlpack/ensmallen/pull/289)).
 
 ### ensmallen 2.16.1: "Severely Dented Can Of Polyurethane"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,9 @@
  * Add Indicators for Multiobjective optimizers
    ([#285](https://github.com/mlpack/ensmallen/pull/285)).
 
+ * Make Callback traits adaptable for MOO
+   ([#289](https://github.com/mlpack/ensmallen/pull/289)).
+
 ### ensmallen 2.16.1: "Severely Dented Can Of Polyurethane"
 ###### 2021-03-02
  * Fix test compilation issue when `ENS_USE_OPENMP` is set

--- a/doc/callbacks.md
+++ b/doc/callbacks.md
@@ -472,6 +472,23 @@ an estimate depending on `exactObjective` value.
 | `size_t` | **`epoch`** | The index of the current epoch. |
 | `double` | **`objective`** | Objective value of the current point. |
 
+### GenerationalStepTaken
+
+Called after the evolution of a single generation. Intended specifically for
+MultiObjective Optimizers.
+
+ * `GenerationalStepTaken(`_`optimizer, function, coordinates, objectives, frontIndices`_`)`
+
+#### Attributes
+
+| **type** | **name** | **description** |
+|----------|----------|-----------------|
+| `OptimizerType` | **`optimizer`** | The optimizer used to update the function. |
+| `FunctionType` | **`function`** | The function to be optimized. |
+| `MatType` | **`coordinates`** | The current function parameter. |
+| `ObjectivesVecType` | **`objectives`** | The set of calculated objectives so far. |
+| `IndicesType` | **`frontIndices`** | The indices of the members belonging to Pareto Front. |
+
 ## Custom Callbacks
 
 ### Learning rate scheduling

--- a/include/ensmallen.hpp
+++ b/include/ensmallen.hpp
@@ -76,6 +76,7 @@
 #include "ensmallen_bits/callbacks/early_stop_at_min_loss.hpp"
 #include "ensmallen_bits/callbacks/print_loss.hpp"
 #include "ensmallen_bits/callbacks/progress_bar.hpp"
+#include "ensmallen_bits/callbacks/query_front.hpp"
 #include "ensmallen_bits/callbacks/report.hpp"
 #include "ensmallen_bits/callbacks/store_best_coordinates.hpp"
 #include "ensmallen_bits/callbacks/timer_stop.hpp"

--- a/include/ensmallen_bits/callbacks/callbacks.hpp
+++ b/include/ensmallen_bits/callbacks/callbacks.hpp
@@ -776,17 +776,6 @@ class Callback
       function, coordinates, objectives, frontIndices);
   }
 
- /**
-  * Invoke the StepTaken() callback if it exists.
-  * Specialization for MultiObjective case.
-  *
-  * @param callback The callback to call.
-  * @param optimizer The optimizer used to update the function.
-  * @param function Function to optimize.
-  * @param coordinates Starting point.
-  * @param objectives The set of calculated objectives so far.
-  * @param frontIndices The indices of the members belonging to Pareto Front.
-  */
   template<typename CallbackType,
            typename OptimizerType,
            typename FunctionType,
@@ -810,17 +799,6 @@ class Callback
     return false;
   }
 
- /**
-  * Invoke the StepTaken() callback if it exists.
-  * Specialization for MultiObjective case.
-  *
-  * @param callback The callback to call.
-  * @param optimizer The optimizer used to update the function.
-  * @param function Function to optimize.
-  * @param coordinates Starting point.
-  * @param objectives The set of calculated objectives so far.
-  * @param frontIndices The indices of the members belonging to Pareto Front.
-  */
   template<typename CallbackType,
            typename OptimizerType,
            typename FunctionType,

--- a/include/ensmallen_bits/callbacks/callbacks.hpp
+++ b/include/ensmallen_bits/callbacks/callbacks.hpp
@@ -752,28 +752,28 @@ class Callback
   * @param optimizer The optimizer used to update the function.
   * @param function Function to optimize.
   * @param coordinates Starting point.
-  * @param calculatedObjectives The set of calculated objectives so far.
+  * @param objectives The set of calculated objectives so far.
   * @param frontIndices The indices of the members belonging to Pareto Front.
   */
   template<typename CallbackType,
            typename OptimizerType,
            typename FunctionType,
            typename MatType,
-           typename ObjectivesArrayType,
+           typename ObjectivesVecType,
            typename IndicesType>
     static typename std::enable_if<
     callbacks::traits::HasMOOStepTakenSignature<
-    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesArrayType,
+    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
     IndicesType>::hasBool, bool>::type
     StepTakenFunction(CallbackType& callback,
       OptimizerType& optimizer,
       FunctionType& function,
       MatType& coordinates,
-      ObjectivesArrayType& calculatedObjectives,
+      ObjectivesVecType& objectives,
       IndicesType& frontIndices)
   {
     return const_cast<CallbackType&>(callback).StepTaken(optimizer,
-      function, coordinates, calculatedObjectives, frontIndices);
+      function, coordinates, objectives, frontIndices);
   }
 
  /**
@@ -784,28 +784,28 @@ class Callback
   * @param optimizer The optimizer used to update the function.
   * @param function Function to optimize.
   * @param coordinates Starting point.
-  * @param calculatedObjectives The set of calculated objectives so far.
+  * @param objectives The set of calculated objectives so far.
   * @param frontIndices The indices of the members belonging to Pareto Front.
   */
   template<typename CallbackType,
            typename OptimizerType,
            typename FunctionType,
            typename MatType,
-           typename ObjectivesArrayType,
+           typename ObjectivesVecType,
            typename IndicesType>
     static typename std::enable_if<
     callbacks::traits::HasMOOStepTakenSignature<
-    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesArrayType,
+    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
     IndicesType>::hasVoid, bool>::type
     StepTakenFunction(CallbackType& callback,
                       OptimizerType& optimizer,
                       FunctionType& function,
                       MatType& coordinates,
-                      ObjectivesArrayType& calculatedObjectives,
+                      ObjectivesVecType& objectives,
                       IndicesType& frontIndices)
   {
     const_cast<CallbackType&>(callback).StepTaken(optimizer,
-      function, coordinates, calculatedObjectives, frontIndices);
+      function, coordinates, objectives, frontIndices);
 
     return false;
   }
@@ -818,24 +818,24 @@ class Callback
   * @param optimizer The optimizer used to update the function.
   * @param function Function to optimize.
   * @param coordinates Starting point.
-  * @param calculatedObjectives The set of calculated objectives so far.
+  * @param objectives The set of calculated objectives so far.
   * @param frontIndices The indices of the members belonging to Pareto Front.
   */
   template<typename CallbackType,
            typename OptimizerType,
            typename FunctionType,
            typename MatType,
-           typename ObjectivesArrayType,
+           typename ObjectivesVecType,
            typename IndicesType>
     static typename std::enable_if<
     callbacks::traits::HasMOOStepTakenSignature<
-    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesArrayType,
+    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
     IndicesType>::hasNone, bool>::type
     StepTakenFunction(CallbackType& callback,
                       OptimizerType& optimizer,
                       FunctionType& function,
                       MatType& coordinates,
-                      ObjectivesArrayType& calculatedObjectives,
+                      ObjectivesVecType& objectives,
                       IndicesType& frontIndices)
   { return false; }
 
@@ -869,26 +869,26 @@ class Callback
 /**
  * Iterate over the callbacks and invoke the StepTaken() callback if it
  * exists.
- * 
+ *
  * Specialization for MultiObjective case.
- * 
+ *
  * @param optimizer The optimizer used to update the function.
  * @param function Function to optimize.
  * @param coordinates Starting point.
- * @param calculatedObjectives The set of calculated objectives so far.
+ * @param objectives The set of calculated objectives so far.
  * @param frontIndices The indices of the members belonging to Pareto Front.
  * @param callbacks The callbacks container.
  */
 template<typename OptimizerType,
          typename FunctionType,
-         typename ObjectivesArrayType,
+         typename ObjectivesVecType,
          typename IndicesType,
          typename MatType,
          typename ...CallbackTypes>
   static bool StepTaken(OptimizerType& optimizer,
                         FunctionType& functions,
                         MatType& coordinates,
-                        ObjectivesArrayType& calculatedObjectives,
+                        ObjectivesVecType& objectives,
                         IndicesType& frontIndices,
                         CallbackTypes&... callbacks)
 {
@@ -896,7 +896,7 @@ template<typename OptimizerType,
   bool result = false;
   (void)std::initializer_list<bool>{ result =
     result || Callback::StepTakenFunction(callbacks, optimizer,
-      function, coordinates, calculatedObjectives, frontIndices)... };
+      functions, coordinates, objectives, frontIndices)... };
   return result;
 }
 

--- a/include/ensmallen_bits/callbacks/callbacks.hpp
+++ b/include/ensmallen_bits/callbacks/callbacks.hpp
@@ -745,7 +745,7 @@ class Callback
   { return false; }
 
  /**
-  * Invoke the StepTaken() callback if it exists.
+  * Invoke the GenerationalStepTaken() callback if it exists.
   * Specialization for MultiObjective case.
   *
   * @param callback The callback to call.
@@ -762,18 +762,18 @@ class Callback
            typename ObjectivesVecType,
            typename IndicesType>
   static typename std::enable_if<
-      callbacks::traits::HasMOOStepTakenSignature<
+      callbacks::traits::HasGenerationalStepTakenSignature<
       CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
       IndicesType>::hasBool, bool>::type
-  StepTakenFunction(CallbackType& callback,
-                    OptimizerType& optimizer,
-                    FunctionType& function,
-                    MatType& coordinates,
-                    ObjectivesVecType& objectives,
-                    IndicesType& frontIndices)
+  GenerationalStepTakenFunction(CallbackType& callback,
+                                OptimizerType& optimizer,
+                                FunctionType& function,
+                                MatType& coordinates,
+                                ObjectivesVecType& objectives,
+                                IndicesType& frontIndices)
   {
-    return const_cast<CallbackType&>(callback).StepTaken(optimizer,
-      function, coordinates, objectives, frontIndices);
+    return const_cast<CallbackType&>(callback).GenerationalStepTaken(
+        optimizer, function, coordinates, objectives, frontIndices);
   }
 
   template<typename CallbackType,
@@ -783,18 +783,18 @@ class Callback
            typename ObjectivesVecType,
            typename IndicesType>
   static typename std::enable_if<
-      callbacks::traits::HasMOOStepTakenSignature<
+      callbacks::traits::HasGenerationalStepTakenSignature<
       CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
       IndicesType>::hasVoid, bool>::type
-  StepTakenFunction(CallbackType& callback,
-                    OptimizerType& optimizer,
-                    FunctionType& function,
-                    MatType& coordinates,
-                    ObjectivesVecType& objectives,
-                    IndicesType& frontIndices)
+  GenerationalStepTakenFunction(CallbackType& callback,
+                                OptimizerType& optimizer,
+                                FunctionType& function,
+                                MatType& coordinates,
+                                ObjectivesVecType& objectives,
+                                IndicesType& frontIndices)
   {
-    const_cast<CallbackType&>(callback).StepTaken(optimizer,
-      function, coordinates, objectives, frontIndices);
+    const_cast<CallbackType&>(callback).GenerationalStepTaken(
+        optimizer, function, coordinates, objectives, frontIndices);
 
     return false;
   }
@@ -806,15 +806,15 @@ class Callback
            typename ObjectivesVecType,
            typename IndicesType>
   static typename std::enable_if<
-      callbacks::traits::HasMOOStepTakenSignature<
+      callbacks::traits::HasGenerationalStepTakenSignature<
       CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
       IndicesType>::hasNone, bool>::type
-  StepTakenFunction(CallbackType& callback,
-                    OptimizerType& optimizer,
-                    FunctionType& function,
-                    MatType& coordinates,
-                    ObjectivesVecType& objectives,
-                    IndicesType& frontIndices)
+  GenerationalStepTakenFunction(CallbackType& /* callback */,
+                                OptimizerType& /* optimizer */,
+                                FunctionType& /* function */,
+                                MatType& /* coordinates */,
+                                ObjectivesVecType& /* objectives */,
+                                IndicesType& /* frontIndices */)
   { return false; }
 
   /**
@@ -842,10 +842,9 @@ class Callback
             function, coordinates)... };
      return result;
   }
-};
 
 /**
- * Iterate over the callbacks and invoke the StepTaken() callback if it
+ * Iterate over the callbacks and invoke the GenerationalStepTaken() callback if it
  * exists.
  *
  * Specialization for MultiObjective case.
@@ -863,21 +862,21 @@ template<typename OptimizerType,
          typename IndicesType,
          typename MatType,
          typename ...CallbackTypes>
-  static bool StepTaken(OptimizerType& optimizer,
-                        FunctionType& functions,
-                        MatType& coordinates,
-                        ObjectivesVecType& objectives,
-                        IndicesType& frontIndices,
-                        CallbackTypes&... callbacks)
+  static bool GenerationalStepTaken(OptimizerType& optimizer,
+                                    FunctionType& functions,
+                                    MatType& coordinates,
+                                    ObjectivesVecType& objectives,
+                                    IndicesType& frontIndices,
+                                    CallbackTypes&... callbacks)
 {
   // This will return immediately once a callback returns true.
   bool result = false;
   (void)std::initializer_list<bool>{ result =
-    result || Callback::StepTakenFunction(callbacks, optimizer,
+    result || Callback::GenerationalStepTakenFunction(callbacks, optimizer,
       functions, coordinates, objectives, frontIndices)... };
   return result;
 }
-
+};
 } // namespace ens
 
 #endif

--- a/include/ensmallen_bits/callbacks/callbacks.hpp
+++ b/include/ensmallen_bits/callbacks/callbacks.hpp
@@ -761,16 +761,16 @@ class Callback
            typename MatType,
            typename ObjectivesVecType,
            typename IndicesType>
-    static typename std::enable_if<
-    callbacks::traits::HasMOOStepTakenSignature<
-    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
-    IndicesType>::hasBool, bool>::type
-    StepTakenFunction(CallbackType& callback,
-      OptimizerType& optimizer,
-      FunctionType& function,
-      MatType& coordinates,
-      ObjectivesVecType& objectives,
-      IndicesType& frontIndices)
+  static typename std::enable_if<
+      callbacks::traits::HasMOOStepTakenSignature<
+      CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
+      IndicesType>::hasBool, bool>::type
+  StepTakenFunction(CallbackType& callback,
+                    OptimizerType& optimizer,
+                    FunctionType& function,
+                    MatType& coordinates,
+                    ObjectivesVecType& objectives,
+                    IndicesType& frontIndices)
   {
     return const_cast<CallbackType&>(callback).StepTaken(optimizer,
       function, coordinates, objectives, frontIndices);
@@ -793,16 +793,16 @@ class Callback
            typename MatType,
            typename ObjectivesVecType,
            typename IndicesType>
-    static typename std::enable_if<
-    callbacks::traits::HasMOOStepTakenSignature<
-    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
-    IndicesType>::hasVoid, bool>::type
-    StepTakenFunction(CallbackType& callback,
-                      OptimizerType& optimizer,
-                      FunctionType& function,
-                      MatType& coordinates,
-                      ObjectivesVecType& objectives,
-                      IndicesType& frontIndices)
+  static typename std::enable_if<
+      callbacks::traits::HasMOOStepTakenSignature<
+      CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
+      IndicesType>::hasVoid, bool>::type
+  StepTakenFunction(CallbackType& callback,
+                    OptimizerType& optimizer,
+                    FunctionType& function,
+                    MatType& coordinates,
+                    ObjectivesVecType& objectives,
+                    IndicesType& frontIndices)
   {
     const_cast<CallbackType&>(callback).StepTaken(optimizer,
       function, coordinates, objectives, frontIndices);
@@ -827,16 +827,16 @@ class Callback
            typename MatType,
            typename ObjectivesVecType,
            typename IndicesType>
-    static typename std::enable_if<
-    callbacks::traits::HasMOOStepTakenSignature<
-    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
-    IndicesType>::hasNone, bool>::type
-    StepTakenFunction(CallbackType& callback,
-                      OptimizerType& optimizer,
-                      FunctionType& function,
-                      MatType& coordinates,
-                      ObjectivesVecType& objectives,
-                      IndicesType& frontIndices)
+  static typename std::enable_if<
+      callbacks::traits::HasMOOStepTakenSignature<
+      CallbackType, OptimizerType, FunctionType, MatType, ObjectivesVecType,
+      IndicesType>::hasNone, bool>::type
+  StepTakenFunction(CallbackType& callback,
+                    OptimizerType& optimizer,
+                    FunctionType& function,
+                    MatType& coordinates,
+                    ObjectivesVecType& objectives,
+                    IndicesType& frontIndices)
   { return false; }
 
   /**

--- a/include/ensmallen_bits/callbacks/callbacks.hpp
+++ b/include/ensmallen_bits/callbacks/callbacks.hpp
@@ -744,6 +744,101 @@ class Callback
                     MatType& /* coordinates */)
   { return false; }
 
+ /**
+  * Invoke the StepTaken() callback if it exists.
+  * Specialization for MultiObjective case.
+  *
+  * @param callback The callback to call.
+  * @param optimizer The optimizer used to update the function.
+  * @param function Function to optimize.
+  * @param coordinates Starting point.
+  * @param calculatedObjectives The set of calculated objectives so far.
+  * @param frontIndices The indices of the members belonging to Pareto Front.
+  */
+  template<typename CallbackType,
+           typename OptimizerType,
+           typename FunctionType,
+           typename MatType,
+           typename ObjectivesArrayType,
+           typename IndicesType>
+    static typename std::enable_if<
+    callbacks::traits::HasMOOStepTakenSignature<
+    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesArrayType,
+    IndicesType>::hasBool, bool>::type
+    StepTakenFunction(CallbackType& callback,
+      OptimizerType& optimizer,
+      FunctionType& function,
+      MatType& coordinates,
+      ObjectivesArrayType& calculatedObjectives,
+      IndicesType& frontIndices)
+  {
+    return const_cast<CallbackType&>(callback).StepTaken(optimizer,
+      function, coordinates, calculatedObjectives, frontIndices);
+  }
+
+ /**
+  * Invoke the StepTaken() callback if it exists.
+  * Specialization for MultiObjective case.
+  *
+  * @param callback The callback to call.
+  * @param optimizer The optimizer used to update the function.
+  * @param function Function to optimize.
+  * @param coordinates Starting point.
+  * @param calculatedObjectives The set of calculated objectives so far.
+  * @param frontIndices The indices of the members belonging to Pareto Front.
+  */
+  template<typename CallbackType,
+           typename OptimizerType,
+           typename FunctionType,
+           typename MatType,
+           typename ObjectivesArrayType,
+           typename IndicesType>
+    static typename std::enable_if<
+    callbacks::traits::HasMOOStepTakenSignature<
+    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesArrayType,
+    IndicesType>::hasVoid, bool>::type
+    StepTakenFunction(CallbackType& callback,
+                      OptimizerType& optimizer,
+                      FunctionType& function,
+                      MatType& coordinates,
+                      ObjectivesArrayType& calculatedObjectives,
+                      IndicesType& frontIndices)
+  {
+    const_cast<CallbackType&>(callback).StepTaken(optimizer,
+      function, coordinates, calculatedObjectives, frontIndices);
+
+    return false;
+  }
+
+ /**
+  * Invoke the StepTaken() callback if it exists.
+  * Specialization for MultiObjective case.
+  *
+  * @param callback The callback to call.
+  * @param optimizer The optimizer used to update the function.
+  * @param function Function to optimize.
+  * @param coordinates Starting point.
+  * @param calculatedObjectives The set of calculated objectives so far.
+  * @param frontIndices The indices of the members belonging to Pareto Front.
+  */
+  template<typename CallbackType,
+           typename OptimizerType,
+           typename FunctionType,
+           typename MatType,
+           typename ObjectivesArrayType,
+           typename IndicesType>
+    static typename std::enable_if<
+    callbacks::traits::HasMOOStepTakenSignature<
+    CallbackType, OptimizerType, FunctionType, MatType, ObjectivesArrayType,
+    IndicesType>::hasNone, bool>::type
+    StepTakenFunction(CallbackType& callback,
+                      OptimizerType& optimizer,
+                      FunctionType& function,
+                      MatType& coordinates,
+                      ObjectivesArrayType& calculatedObjectives,
+                      IndicesType& frontIndices)
+  { return false; }
+
   /**
    * Iterate over the callbacks and invoke the StepTaken() callback if it
    * exists.
@@ -770,6 +865,40 @@ class Callback
      return result;
   }
 };
+
+/**
+ * Iterate over the callbacks and invoke the StepTaken() callback if it
+ * exists.
+ * 
+ * Specialization for MultiObjective case.
+ * 
+ * @param optimizer The optimizer used to update the function.
+ * @param function Function to optimize.
+ * @param coordinates Starting point.
+ * @param calculatedObjectives The set of calculated objectives so far.
+ * @param frontIndices The indices of the members belonging to Pareto Front.
+ * @param callbacks The callbacks container.
+ */
+template<typename OptimizerType,
+         typename FunctionType,
+         typename ObjectivesArrayType,
+         typename IndicesType,
+         typename MatType,
+         typename ...CallbackTypes>
+  static bool StepTaken(OptimizerType& optimizer,
+                        FunctionType& functions,
+                        MatType& coordinates,
+                        ObjectivesArrayType& calculatedObjectives,
+                        IndicesType& frontIndices,
+                        CallbackTypes&... callbacks)
+{
+  // This will return immediately once a callback returns true.
+  bool result = false;
+  (void)std::initializer_list<bool>{ result =
+    result || Callback::StepTakenFunction(callbacks, optimizer,
+      function, coordinates, calculatedObjectives, frontIndices)... };
+  return result;
+}
 
 } // namespace ens
 

--- a/include/ensmallen_bits/callbacks/query_front.hpp
+++ b/include/ensmallen_bits/callbacks/query_front.hpp
@@ -25,7 +25,6 @@ class QueryFront
    *
    * @param queryRate The frequency at which the Pareto Front is queried.
    * @param paretoFrontArray A reference to a vector of cube to store the queried fronts.
-   * @param genCounter Internal clock to count generations passed.
    */
     QueryFront(const size_t queryRate, std::vector<arma::cube>& paretoFrontArray) :
         queryRate(queryRate),

--- a/include/ensmallen_bits/callbacks/query_front.hpp
+++ b/include/ensmallen_bits/callbacks/query_front.hpp
@@ -1,0 +1,87 @@
+/**
+ * @file query_front.hpp
+ * @author Nanubala Gnana Sai
+ *
+ * Implementation of the query front callback function.
+ *
+ * ensmallen is free software; you may redistribute it and/or modify it under
+ * the terms of the 3-clause BSD license.  You should have received a copy of
+ * the 3-clause BSD license along with ensmallen.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef ENSMALLEN_CALLBACKS_QUERY_FRONT_HPP
+#define ENSMALLEN_CALLBACKS_QUERY_FRONT_HPP
+
+namespace ens {
+
+/**
+ * Query the current Pareto Front after every GenerationalStepTaken callback function.
+ */
+class QueryFront
+{
+ public:
+  /**
+   * Set up the query front callback class with the specified inputs.
+   *
+   * @param queryRate The frequency at which the Pareto Front is queried.
+   * @param paretoFrontArray A reference to a vector of cube to store the queried fronts.
+   * @param genCounter Internal clock to count generations passed.
+   */
+    QueryFront(const size_t queryRate, std::vector<arma::cube>& paretoFrontArray) :
+        queryRate(queryRate),
+        paretoFrontArray(paretoFrontArray),
+        genCounter(0)
+    { /* Nothing to do here */ }
+
+   /**
+    * Callback function called at the end of a single generational run.
+    *
+    * @param optimizer The optimizer used to update the function.
+    * @param function Function to optimize.
+    * @param coordinates Starting point.
+    * @param objectives The set of calculated objectives so far.
+    * @param frontIndices The indices of the members belonging to Pareto Front.
+    */
+    template<typename OptimizerType,
+             typename FunctionType,
+             typename MatType,
+             typename ObjectivesVecType,
+             typename IndicesType>
+    void GenerationalStepTaken(OptimizerType& opt,
+                               FunctionType& /* function */,
+                               const MatType& /* coordinates */,
+                               const ObjectivesVecType& objectives,
+                               const IndicesType& frontIndices)
+    {
+      arma::cube currentParetoFront{};
+
+      if (genCounter % queryRate == 0)
+      {
+        currentParetoFront.resize(objectives[0].n_rows, objectives[0].n_cols,
+            frontIndices[0].size());
+        for (size_t solutionIdx = 0; solutionIdx < frontIndices[0].size(); ++solutionIdx)
+        {
+          currentParetoFront.slice(solutionIdx) =
+              arma::conv_to<arma::mat>::from(objectives[frontIndices[0][solutionIdx]]);
+        }
+
+        paretoFrontArray.emplace_back(std::move(currentParetoFront));
+      }
+
+      ++genCounter;
+    }
+
+
+ private:
+  //! The rate of query.
+  size_t queryRate;
+  //! A reference to the array of pareto fronts.
+  std::vector<arma::cube>& paretoFrontArray;
+  //! A counter for the current generation.
+  size_t genCounter;
+
+};
+
+} // namespace ens
+
+#endif

--- a/include/ensmallen_bits/callbacks/traits.hpp
+++ b/include/ensmallen_bits/callbacks/traits.hpp
@@ -37,6 +37,8 @@ ENS_HAS_EXACT_METHOD_FORM(BeginEpoch, HasBeginEpoch)
 ENS_HAS_EXACT_METHOD_FORM(EndEpoch, HasEndEpoch)
 //! Detect an StepTaken() method.
 ENS_HAS_EXACT_METHOD_FORM(StepTaken, HasStepTaken)
+//! Detect an GenerationalStepTaken() method.
+ENS_HAS_EXACT_METHOD_FORM(GenerationalStepTaken, HasGenerationalStepTaken)
 
 template<typename OptimizerType,
          typename FunctionType,
@@ -189,35 +191,6 @@ struct TypedForms
       void(CallbackType::*)(OptimizerType&,
                             FunctionType&,
                             const MatType&);
-};
-
-//! A utility struct for Typed Forms required in
-//! callbacks for MultiObjective Optimizers.
-template<typename OptimizerType,
-         typename FunctionType,
-         typename MatType,
-         typename ObjectivesVecType,
-         typename IndicesType,
-         typename GradType = MatType>
-struct MOOTypedForms
-{
-  //! This is the form of a bool StepTaken() for MOO callback method.
-  template<typename CallbackType>
-  using StepTakenBoolForm =
-      bool(CallbackType::*)(OptimizerType&,
-                            FunctionType&,
-                            const MatType&,
-                            const ObjectivesVecType&,
-                            const IndicesType&);
-
-  //! This is the form of a void StepTaken() for MOO callback method.
-  template<typename CallbackType>
-  using StepTakenVoidForm =
-      void(CallbackType::*)(OptimizerType&,
-                            FunctionType&,
-                            const MatType&,
-                            const ObjectivesVecType&,
-                            const IndicesType&);
 };
 
 //! Utility struct, check if either void BeginOptimization() or
@@ -394,6 +367,35 @@ struct HasStepTakenSignature
          FunctionType, MatType>::template StepTakenVoidForm>::value;
 };
 
+//! A utility struct for Typed Forms required in
+//! callbacks for MultiObjective Optimizers.
+template<typename OptimizerType,
+         typename FunctionType,
+         typename MatType,
+         typename ObjectivesVecType,
+         typename IndicesType,
+         typename GradType = MatType>
+struct MOOTypedForms
+{
+  //! This is the form of a bool GenerationalStepTaken() for MOO callback method.
+  template<typename CallbackType>
+  using GenerationalStepTakenBoolForm =
+      bool(CallbackType::*)(OptimizerType&,
+                            FunctionType&,
+                            const MatType&,
+                            const ObjectivesVecType&,
+                            const IndicesType&);
+
+  //! This is the form of a void StepTaken() for MOO callback method.
+  template<typename CallbackType>
+  using GenerationalStepTakenVoidForm =
+      void(CallbackType::*)(OptimizerType&,
+                            FunctionType&,
+                            const MatType&,
+                            const ObjectivesVecType&,
+                            const IndicesType&);
+};
+
 //! Utility struct, check if either void StepTaken() or bool StepTaken() exists.
 //! Specialization for Multiobjective case.
 template<typename CallbackType,
@@ -402,31 +404,31 @@ template<typename CallbackType,
          typename ObjectivesVecType,
          typename IndicesType,
          typename MatType>
- struct HasMOOStepTakenSignature
+ struct HasGenerationalStepTakenSignature
 {
   const static bool hasBool =
-    HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+    HasGenerationalStepTaken<CallbackType, MOOTypedForms<OptimizerType,
         FunctionType, MatType, ObjectivesVecType, IndicesType>::
-        template StepTakenBoolForm>::value &&
-    !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+        template GenerationalStepTakenBoolForm>::value &&
+    !HasGenerationalStepTaken<CallbackType, MOOTypedForms<OptimizerType,
         FunctionType, MatType, ObjectivesVecType, IndicesType>::
-        template StepTakenVoidForm>::value;
+        template GenerationalStepTakenVoidForm>::value;
 
   const static bool hasVoid =
-    !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+    !HasGenerationalStepTaken<CallbackType, MOOTypedForms<OptimizerType,
         FunctionType, MatType, ObjectivesVecType, IndicesType>::
-        template StepTakenBoolForm>::value &&
-    HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+        template GenerationalStepTakenBoolForm>::value &&
+    HasGenerationalStepTaken<CallbackType, MOOTypedForms<OptimizerType,
         FunctionType, MatType, ObjectivesVecType, IndicesType>::
-        template StepTakenVoidForm>::value;
+        template GenerationalStepTakenVoidForm>::value;
 
   const static bool hasNone =
-    !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+    !HasGenerationalStepTaken<CallbackType, MOOTypedForms<OptimizerType,
         FunctionType, MatType, ObjectivesVecType, IndicesType>::
-        template StepTakenBoolForm>::value &&
-    !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+        template GenerationalStepTakenBoolForm>::value &&
+    !HasGenerationalStepTaken<CallbackType, MOOTypedForms<OptimizerType,
         FunctionType, MatType, ObjectivesVecType, IndicesType>::
-        template StepTakenVoidForm>::value;
+        template GenerationalStepTakenVoidForm>::value;
 };
 } // namespace traits
 } // namespace callbacks

--- a/include/ensmallen_bits/callbacks/traits.hpp
+++ b/include/ensmallen_bits/callbacks/traits.hpp
@@ -196,7 +196,7 @@ struct TypedForms
 template<typename OptimizerType,
          typename FunctionType,
          typename MatType,
-         typename ObjectivesArrayType,
+         typename ObjectivesVecType,
          typename IndicesType,
          typename GradType = MatType>
 struct MOOTypedForms
@@ -207,7 +207,7 @@ struct MOOTypedForms
     bool(CallbackType::*)(OptimizerType&,
                           FunctionType&,
                           const MatType&,
-                          const ObjectivesArrayType&,
+                          const ObjectivesVecType&,
                           const IndicesType&);
 
   //! This is the form of a void StepTaken() for MOO callback method.
@@ -215,8 +215,8 @@ struct MOOTypedForms
   using StepTakenVoidForm =
     void(CallbackType::*)(OptimizerType&,
                           FunctionType&,
-                          const MatType&
-                          const ObjectivesArrayType&,
+                          const MatType&,
+                          const ObjectivesVecType&,
                           const IndicesType&);
 };
 
@@ -399,33 +399,33 @@ struct HasStepTakenSignature
 template<typename CallbackType,
          typename OptimizerType,
          typename FunctionType,
-         typename ObjectivesArrayType,
+         typename ObjectivesVecType,
          typename IndicesType,
          typename MatType>
  struct HasMOOStepTakenSignature
 {
   const static bool hasBool =
     HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
-        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        FunctionType, MatType, ObjectivesVecType, IndicesType>::
         template StepTakenBoolForm>::value &&
     !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
-        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        FunctionType, MatType, ObjectivesVecType, IndicesType>::
         template StepTakenVoidForm>::value;
 
   const static bool hasVoid =
     !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
-        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        FunctionType, MatType, ObjectivesVecType, IndicesType>::
         template StepTakenBoolForm>::value &&
     HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
-        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        FunctionType, MatType, ObjectivesVecType, IndicesType>::
         template StepTakenVoidForm>::value;
 
   const static bool hasNone =
     !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
-        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        FunctionType, MatType, ObjectivesVecType, IndicesType>::
         template StepTakenBoolForm>::value &&
     !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
-        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        FunctionType, MatType, ObjectivesVecType, IndicesType>::
         template StepTakenVoidForm>::value;
 };
 } // namespace traits

--- a/include/ensmallen_bits/callbacks/traits.hpp
+++ b/include/ensmallen_bits/callbacks/traits.hpp
@@ -204,20 +204,20 @@ struct MOOTypedForms
   //! This is the form of a bool StepTaken() for MOO callback method.
   template<typename CallbackType>
   using StepTakenBoolForm =
-    bool(CallbackType::*)(OptimizerType&,
-                          FunctionType&,
-                          const MatType&,
-                          const ObjectivesVecType&,
-                          const IndicesType&);
+      bool(CallbackType::*)(OptimizerType&,
+                            FunctionType&,
+                            const MatType&,
+                            const ObjectivesVecType&,
+                            const IndicesType&);
 
   //! This is the form of a void StepTaken() for MOO callback method.
   template<typename CallbackType>
   using StepTakenVoidForm =
-    void(CallbackType::*)(OptimizerType&,
-                          FunctionType&,
-                          const MatType&,
-                          const ObjectivesVecType&,
-                          const IndicesType&);
+      void(CallbackType::*)(OptimizerType&,
+                            FunctionType&,
+                            const MatType&,
+                            const ObjectivesVecType&,
+                            const IndicesType&);
 };
 
 //! Utility struct, check if either void BeginOptimization() or

--- a/include/ensmallen_bits/callbacks/traits.hpp
+++ b/include/ensmallen_bits/callbacks/traits.hpp
@@ -191,6 +191,35 @@ struct TypedForms
                             const MatType&);
 };
 
+//! A utility struct for Typed Forms required in
+//! callbacks for MultiObjective Optimizers.
+template<typename OptimizerType,
+         typename FunctionType,
+         typename MatType,
+         typename ObjectivesArrayType,
+         typename IndicesType,
+         typename GradType = MatType>
+struct MOOTypedForms
+{
+  //! This is the form of a bool StepTaken() for MOO callback method.
+  template<typename CallbackType>
+  using StepTakenBoolForm =
+    bool(CallbackType::*)(OptimizerType&,
+                          FunctionType&,
+                          const MatType&,
+                          const ObjectivesArrayType&,
+                          const IndicesType&);
+
+  //! This is the form of a void StepTaken() for MOO callback method.
+  template<typename CallbackType>
+  using StepTakenVoidForm =
+    void(CallbackType::*)(OptimizerType&,
+                          FunctionType&,
+                          const MatType&
+                          const ObjectivesArrayType&,
+                          const IndicesType&);
+};
+
 //! Utility struct, check if either void BeginOptimization() or
 //! bool BeginOptimization() exists.
 template<typename CallbackType,
@@ -365,6 +394,40 @@ struct HasStepTakenSignature
          FunctionType, MatType>::template StepTakenVoidForm>::value;
 };
 
+//! Utility struct, check if either void StepTaken() or bool StepTaken() exists.
+//! Specialization for Multiobjective case.
+template<typename CallbackType,
+         typename OptimizerType,
+         typename FunctionType,
+         typename ObjectivesArrayType,
+         typename IndicesType,
+         typename MatType>
+ struct HasMOOStepTakenSignature
+{
+  const static bool hasBool =
+    HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        template StepTakenBoolForm>::value &&
+    !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        template StepTakenVoidForm>::value;
+
+  const static bool hasVoid =
+    !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        template StepTakenBoolForm>::value &&
+    HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        template StepTakenVoidForm>::value;
+
+  const static bool hasNone =
+    !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        template StepTakenBoolForm>::value &&
+    !HasStepTaken<CallbackType, MOOTypedForms<OptimizerType,
+        FunctionType, MatType, ObjectivesArrayType, IndicesType>::
+        template StepTakenVoidForm>::value;
+};
 } // namespace traits
 } // namespace callbacks
 } // namespace ens

--- a/include/ensmallen_bits/nsga2/nsga2_impl.hpp
+++ b/include/ensmallen_bits/nsga2/nsga2_impl.hpp
@@ -155,7 +155,8 @@ typename MatType::elem_type NSGA2::Optimize(
   for (size_t generation = 1; generation <= maxGenerations && !terminate; generation++)
   {
     Info << "NSGA2: iteration " << generation << "." << std::endl;
-    terminate |= Callback::StepTaken(*this, objectives, iterate, callbacks...);
+    terminate |= Callback::StepTaken(*this, objectives, iterate,
+        calculatedObjectives, fronts, callbacks...);
 
     // Create new population of candidate from the present elite population.
     // Have P_t, generate G_t using P_t.

--- a/include/ensmallen_bits/nsga2/nsga2_impl.hpp
+++ b/include/ensmallen_bits/nsga2/nsga2_impl.hpp
@@ -155,8 +155,6 @@ typename MatType::elem_type NSGA2::Optimize(
   for (size_t generation = 1; generation <= maxGenerations && !terminate; generation++)
   {
     Info << "NSGA2: iteration " << generation << "." << std::endl;
-    terminate |= Callback::StepTaken(*this, objectives, iterate,
-        calculatedObjectives, fronts, callbacks...);
 
     // Create new population of candidate from the present elite population.
     // Have P_t, generate G_t using P_t.
@@ -203,6 +201,9 @@ typename MatType::elem_type NSGA2::Optimize(
     // Yield a new population P_{t+1} of size populationSize.
     // Discards unfit population from the R_{t} to yield P_{t+1}.
     population.resize(populationSize);
+
+    terminate |= Callback::GenerationalStepTaken(*this, objectives, iterate,
+        calculatedObjectives, fronts, callbacks...);
   }
 
   // Set the candidates from the Pareto Set as the output.

--- a/tests/callbacks_test.cpp
+++ b/tests/callbacks_test.cpp
@@ -106,6 +106,18 @@ class CompleteCallbackTestFunction
                  MatType& /* coordinates */)
   { calledStepTaken = true; }
 
+    template<typename OptimizerType,
+             typename FunctionType,
+             typename MatType,
+             typename ObjectivesVecType,
+             typename IndicesType>
+    void GenerationalStepTaken(OptimizerType& /* optimizer */,
+                               FunctionType& /* function */,
+                               MatType& /* coordinates */,
+                               ObjectivesVecType& /* objectives */,
+                               IndicesType& /* frontIndices */)
+    { calledGenerationalStepTaken = true; }
+
   bool calledEvaluate;
   bool calledGradient;
   bool calledBeginEpoch;
@@ -115,6 +127,7 @@ class CompleteCallbackTestFunction
   bool calledEvaluateConstraint;
   bool calledGradientConstraint;
   bool calledStepTaken;
+  bool calledGenerationalStepTaken;
 };
 
 template<typename OptimizerType>
@@ -162,7 +175,8 @@ void CallbacksFullMultiobjectiveFunctionTest(OptimizerType& optimizer,
                                              bool calledEndOptimization,
                                              bool calledEvaluateConstraint,
                                              bool calledGradientConstraint,
-                                             bool calledStepTaken)
+                                             bool calledStepTaken,
+                                             bool calledGenerationalStepTaken)
 {
   SchafferFunctionN1<arma::mat> SCH;
 
@@ -185,6 +199,7 @@ void CallbacksFullMultiobjectiveFunctionTest(OptimizerType& optimizer,
   REQUIRE(cb.calledEvaluateConstraint == calledEvaluateConstraint);
   REQUIRE(cb.calledGradientConstraint == calledGradientConstraint);
   REQUIRE(cb.calledStepTaken == calledStepTaken);
+  REQUIRE(cb.calledGenerationalStepTaken == calledGenerationalStepTaken);
 }
 
 template<typename OptimizerType>
@@ -380,7 +395,7 @@ TEST_CASE("NSGA2CallbacksFullFunctionTest", "[CallbackTest]")
   arma::vec upperBound = {1000};
   NSGA2 optimizer(20, 5000, 0.5, 0.5, 1e-3, 1e-6, lowerBound, upperBound);
   CallbacksFullMultiobjectiveFunctionTest(optimizer, false, false, false, false,
-      true, true, false, false, true);
+      true, true, false, false, false, true);
 }
 
 /**

--- a/tests/callbacks_test.cpp
+++ b/tests/callbacks_test.cpp
@@ -33,7 +33,8 @@ class CompleteCallbackTestFunction
       calledEndOptimization(false),
       calledEvaluateConstraint(false),
       calledGradientConstraint(false),
-      calledStepTaken(false)
+      calledStepTaken(false),
+      calledGenerationalStepTaken(false)
   { }
 
   template<typename OptimizerType, typename FunctionType, typename MatType>


### PR DESCRIPTION
Related to #282  

- [x] Create ```MOOTypedForms``` struct specifically for MOO related type forms.
- [x] Create ```GenerationalStepTaken```, replacement for StepTaken in MOO.
- [x] Register the above using ENS MACRO.
- [x] Write in built callback for Querying Front.
- [x] Adapt the tests for this.

@zoq Let me know if you agree with this methodology. You can check the commit message to see what I've done.