### PR TITLE
don't build tests by default

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Disable building the tests by default for faster installation
+   ([#303](https://github.com/mlpack/ensmallen/pull/303)).
+
  * Improved installation and compilation instructions
    ([#300](https://github.com/mlpack/ensmallen/pull/300)).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ensmallen can be installed in several ways: either manually or via cmake,
 with or without root access.
 
 The cmake based installation will check the requirements 
-and also build the tests. If cmake 3.3 (or a later version) 
+and optionally build the tests. If cmake 3.3 (or a later version) 
 is not already available on your system, it can be obtained 
 from [cmake.org](https://cmake.org). If you are using an older 
 system such as RHEL 7 or CentOS 7, an updated version of cmake 
@@ -54,6 +54,14 @@ make install
 The above will create a directory named `/home/blah/include/` 
 and place all ensmallen headers there.
 
+To optionally build and run the tests
+(after running cmake as above),
+use the following additional commands:
+
+```
+make ensmallen_tests
+./ensmallen_tests --durations yes
+````
 
 Manual installation involves simply copying the `include/ensmallen.hpp` header 
 ***and*** the associated `include/ensmallen_bits` directory to a location 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ use the following additional commands:
 ```
 make ensmallen_tests
 ./ensmallen_tests --durations yes
-````
+```
 
 Manual installation involves simply copying the `include/ensmallen.hpp` header 
 ***and*** the associated `include/ensmallen_bits` directory to a location 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,7 @@ set(ENSMALLEN_TESTS_SOURCES
 )
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-add_executable(ensmallen_tests ${ENSMALLEN_TESTS_SOURCES})
+add_executable(ensmallen_tests EXCLUDE_FROM_ALL ${ENSMALLEN_TESTS_SOURCES})
 target_link_libraries(ensmallen_tests PRIVATE ensmallen)
 
 # Copy test data into place.


### PR DESCRIPTION
Disable building the tests by default, as discussed in https://github.com/mlpack/ensmallen/issues/301
Tests can still be optionally built.

Advantages: faster and easier installation by users.  
