### PR TITLE
Add Front() back into the NSGA2 class.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,8 @@
    ([#283](https://github.com/mlpack/ensmallen/pull/283)).
 
  * Refactor NSGA2
-   ([#263](https://github.com/mlpack/ensmallen/pull/263)).
+   ([#263](https://github.com/mlpack/ensmallen/pull/263),
+   [#304](https://github.com/mlpack/ensmallen/pull/304)).
 
  * Add Indicators for Multiobjective optimizers
    ([#285](https://github.com/mlpack/ensmallen/pull/285)).
@@ -26,7 +27,7 @@
 
  * Add Das-Dennis weight initialization method
    ([#295](https://github.com/mlpack/ensmallen/pull/295)).
-   
+
  * Add Dirichlet Weight Initialization
    ([#296](https://github.com/mlpack/ensmallen/pull/296)).
 

--- a/include/ensmallen_bits/nsga2/nsga2.hpp
+++ b/include/ensmallen_bits/nsga2/nsga2.hpp
@@ -181,7 +181,8 @@ class NSGA2
   /**
    * Retrieve the best front (the Pareto frontier).  This returns an empty
    * vector until `Optimize()` has been called.  Note that this function is
-   * deprecated and will be removed in ensmallen 3.10.0!  Use `ParetoFront()` instead.
+   * deprecated and will be removed in ensmallen 3.x!  Use `ParetoFront()`
+   * instead.
    */
   ens_deprecated const std::vector<arma::mat>& Front()
   {
@@ -378,7 +379,7 @@ class NSGA2
   arma::cube paretoFront;
 
   //! A different representation of the Pareto front, for reverse compatibility
-  //! purposes.  This can be removed when ensmallen 3.10.0 is released!  (Along
+  //! purposes.  This can be removed when ensmallen 3.x is released!  (Along
   //! with `Front()`.)  This is only populated when `Front()` is called.
   std::vector<arma::mat> rcFront;
 };

--- a/include/ensmallen_bits/nsga2/nsga2.hpp
+++ b/include/ensmallen_bits/nsga2/nsga2.hpp
@@ -51,7 +51,8 @@ namespace ens {
  * see the documentation on function types included with this distribution or
  * on the ensmallen website.
  */
-class NSGA2 {
+class NSGA2
+{
  public:
   /**
    * Constructor for the NSGA2 optimizer.
@@ -176,6 +177,25 @@ class NSGA2 {
   //! Retrieve the best front (the Pareto frontier). This returns an empty cube until
   //! `Optimize()` has been called.
   const arma::cube& ParetoFront() const { return paretoFront; }
+
+  /**
+   * Retrieve the best front (the Pareto frontier).  This returns an empty
+   * vector until `Optimize()` has been called.  Note that this function is
+   * deprecated and will be removed in ensmallen 3.10.0!  Use `ParetoFront()` instead.
+   */
+  ens_deprecated const std::vector<arma::mat>& Front()
+  {
+    if (rcFront.size() == 0)
+    {
+      // Match the old return format.
+      for (size_t i = 0; i < paretoFront.n_slices; ++i)
+      {
+        rcFront.push_back(arma::mat(paretoFront.slice(i)));
+      }
+    }
+
+    return rcFront;
+  }
 
  private:
   /**
@@ -356,6 +376,11 @@ class NSGA2 {
   //! The set of all the Pareto optimal objective vectors.
   //! Stored after Optimize() is called.
   arma::cube paretoFront;
+
+  //! A different representation of the Pareto front, for reverse compatibility
+  //! purposes.  This can be removed when ensmallen 3.10.0 is released!  (Along
+  //! with `Front()`.)  This is only populated when `Front()` is called.
+  std::vector<arma::mat> rcFront;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/nsga2/nsga2_impl.hpp
+++ b/include/ensmallen_bits/nsga2/nsga2_impl.hpp
@@ -227,6 +227,10 @@ typename MatType::elem_type NSGA2::Optimize(
       arma::conv_to<arma::mat>::from(calculatedObjectives[fronts[0][solutionIdx]]);
   }
 
+  // Clear rcFront, in case it is later requested by the user for reverse
+  // compatibility reasons.
+  rcFront.clear();
+
   // Assign iterate to first element of the Pareto Set.
   iterate = population[fronts[0][0]];
 

--- a/tests/nsga2_test.cpp
+++ b/tests/nsga2_test.cpp
@@ -455,7 +455,7 @@ TEST_CASE("NSGA2ZDTONETest", "[NSGA2Test]")
 /**
  * Ensure that the reverse-compatible Front() function works.
  *
- * This test can be removed when Front() is removed.
+ * This test can be removed when Front() is removed, in ensmallen 3.x.
  */
 TEST_CASE("NSGA2FrontTest", "[NSGA2Test]")
 {

--- a/tests/nsga2_test.cpp
+++ b/tests/nsga2_test.cpp
@@ -462,8 +462,6 @@ TEST_CASE("NSGA2FrontTest", "[NSGA2Test]")
   SchafferFunctionN1<arma::mat> SCH;
   const double lowerBound = -1000;
   const double upperBound = 1000;
-  const double expectedLowerBound = 0.0;
-  const double expectedUpperBound = 2.0;
 
   NSGA2 opt(20, 300, 0.5, 0.5, 1e-3, 1e-6, lowerBound, upperBound);
 

--- a/tests/nsga2_test.cpp
+++ b/tests/nsga2_test.cpp
@@ -59,7 +59,7 @@ TEST_CASE("NSGA2SchafferN1DoubleTest", "[NSGA2Test]")
     std::tuple<ObjectiveTypeA, ObjectiveTypeB> objectives = SCH.GetObjectives();
 
     opt.Optimize(objectives, coords);
-    arma::cube paretoSet= opt.ParetoSet();
+    arma::cube paretoSet = opt.ParetoSet();
 
     bool allInRange = true;
 
@@ -108,7 +108,7 @@ TEST_CASE("NSGA2SchafferN1TestVectorDoubleBounds", "[NSGA2Test]")
     std::tuple<ObjectiveTypeA, ObjectiveTypeB> objectives = SCH.GetObjectives();
 
     opt.Optimize(objectives, coords);
-    arma::cube paretoSet= opt.ParetoSet();
+    arma::cube paretoSet = opt.ParetoSet();
 
     bool allInRange = true;
 
@@ -450,4 +450,38 @@ TEST_CASE("NSGA2ZDTONETest", "[NSGA2Test]")
   double g = 1. + 9. * sum / (static_cast<double>(numVariables - 1));
 
   REQUIRE(g == Approx(1.0).margin(0.99));
+}
+
+/**
+ * Ensure that the reverse-compatible Front() function works.
+ *
+ * This test can be removed when Front() is removed.
+ */
+TEST_CASE("NSGA2FrontTest", "[NSGA2Test]")
+{
+  SchafferFunctionN1<arma::mat> SCH;
+  const double lowerBound = -1000;
+  const double upperBound = 1000;
+  const double expectedLowerBound = 0.0;
+  const double expectedUpperBound = 2.0;
+
+  NSGA2 opt(20, 300, 0.5, 0.5, 1e-3, 1e-6, lowerBound, upperBound);
+
+  typedef decltype(SCH.objectiveA) ObjectiveTypeA;
+  typedef decltype(SCH.objectiveB) ObjectiveTypeB;
+
+  arma::mat coords = SCH.GetInitialPoint();
+  std::tuple<ObjectiveTypeA, ObjectiveTypeB> objectives = SCH.GetObjectives();
+
+  opt.Optimize(objectives, coords);
+  arma::cube paretoFront = opt.ParetoFront();
+
+  std::vector<arma::mat> rcFront = opt.Front();
+
+  REQUIRE(paretoFront.n_slices == rcFront.size());
+  for (size_t i = 0; i < paretoFront.n_slices; ++i)
+  {
+    arma::mat paretoM = paretoFront.slice(i);
+    CheckMatrices(paretoM, rcFront[i]);
+  }
 }


### PR DESCRIPTION
This came out of the discussion for #303---to avoid breaking reverse compatibility, I re-added the `Front()` function to the `NSGA2` class.  Actually it turned out to be slightly more difficult than I thought: to match the API, we have to return a reference, so we actually needed to re-add a member to the `NSGA2` class.  But, that member is only populated if the user calls `Front()`.

Anyway, this can all be removed in the next major version release of ensmallen, but until then, anyone who happens to be using `Front()` from `NSGA2` should not have their code broken. :)