### PR TITLE
various fixes for matrix initialisation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Modify matrix initialisation to take into account
+   default element zeroing in Armadillo 10.5
+   ([#303](https://github.com/mlpack/ensmallen/pull/305)).
+
  * Disable building the tests by default for faster installation
    ([#303](https://github.com/mlpack/ensmallen/pull/303)).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 ###### ????-??-??
  * Modify matrix initialisation to take into account
    default element zeroing in Armadillo 10.5
-   ([#303](https://github.com/mlpack/ensmallen/pull/305)).
+   ([#305](https://github.com/mlpack/ensmallen/pull/305)).
 
  * Disable building the tests by default for faster installation
    ([#303](https://github.com/mlpack/ensmallen/pull/303)).

--- a/include/ensmallen_bits/problems/schwefel_function.hpp
+++ b/include/ensmallen_bits/problems/schwefel_function.hpp
@@ -114,7 +114,7 @@ class SchwefelFunction
   template<typename MatType = arma::mat>
   MatType GetFinalPoint() const
   {
-    MatType result(initialPoint.n_rows, initialPoint.n_cols);
+    MatType result(initialPoint.n_rows, initialPoint.n_cols, arma::fill::none);
     result.fill(420.9687);
     return result;
   }

--- a/include/ensmallen_bits/sa/sa_impl.hpp
+++ b/include/ensmallen_bits/sa/sa_impl.hpp
@@ -76,7 +76,7 @@ typename MatType::elem_type SA<CoolingScheduleType>::Optimize(
   size_t sweepCounter = 0;
 
   BaseMatType accept(rows, cols, arma::fill::zeros);
-  BaseMatType moveSize(rows, cols);
+  BaseMatType moveSize(rows, cols, arma::fill::none);
   moveSize.fill(initMoveCoef);
 
   terminate |= Callback::BeginOptimization(*this, function, iterate,

--- a/include/ensmallen_bits/sdp/primal_dual_impl.hpp
+++ b/include/ensmallen_bits/sdp/primal_dual_impl.hpp
@@ -303,7 +303,7 @@ typename MatType::elem_type PrimalDualSolver::Optimize(
 
   eInvFaSparseT.set_size(n2bar, sdp.NumSparseConstraints());
   eInvFaDenseT.set_size(n2bar, sdp.NumDenseConstraints());
-  m.set_size(sdp.NumConstraints(), sdp.NumConstraints());
+  m.zeros(sdp.NumConstraints(), sdp.NumConstraints());
 
   // Controls early termination of the optimization process.
   bool terminate = false;

--- a/include/ensmallen_bits/sdp/primal_dual_impl.hpp
+++ b/include/ensmallen_bits/sdp/primal_dual_impl.hpp
@@ -162,8 +162,8 @@ SolveKKTSystem(const SparseConstraintType& aSparse,
         "solve KKT system.");
   }
 
-  MatType subTerm(aSparse.n_cols, 1);
-  subTerm.zeros();
+  MatType subTerm(aSparse.n_cols, 1, arma::fill::zeros);
+  
   if (aSparse.n_rows)
   {
     dySparse = dy(arma::span(0, aSparse.n_rows - 1), 0);


### PR DESCRIPTION
Mainly to take into account changes in Armadillo 10.5, where matrices are by default constructed with all elements set to zero.
The changes in this PR are backwards compatible with earlier versions of Armadillo.

