### PR TITLE
Release version 2.17.0: "Pachis Din Me Pesa Double"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ $ cd ensmallen
 
 # - or -
 
-$ wget http://ensmallen.org/files/ensmallen-2.16.2.tar.gz
-$ tar -xvzpf ensmallen-2.16.2.tar.gz
+$ wget http://ensmallen.org/files/ensmallen-2.17.0.tar.gz
+$ tar -xvzpf ensmallen-2.17.0.tar.gz
 $ cd ensmallen-latest
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### ensmallen ?.??.?: "???"
+###### ????-??-??
+
 ### ensmallen 2.17.0: "Pachis Din Me Pesa Double"
 ###### 2021-07-06
  * CheckArbitraryFunctionTypeAPI extended for MOO support

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,15 +1,5 @@
-### ensmallen ?.??.?: "???"
-###### ????-??-??
- * Modify matrix initialisation to take into account
-   default element zeroing in Armadillo 10.5
-   ([#305](https://github.com/mlpack/ensmallen/pull/305)).
-
- * Disable building the tests by default for faster installation
-   ([#303](https://github.com/mlpack/ensmallen/pull/303)).
-
- * Improved installation and compilation instructions
-   ([#300](https://github.com/mlpack/ensmallen/pull/300)).
-
+### ensmallen 2.17.0: "Pachis Din Me Pesa Double"
+###### 2021-07-06
  * CheckArbitraryFunctionTypeAPI extended for MOO support
    ([#283](https://github.com/mlpack/ensmallen/pull/283)).
 
@@ -37,6 +27,16 @@
 
  * Add Dirichlet Weight Initialization
    ([#296](https://github.com/mlpack/ensmallen/pull/296)).
+
+ * Improved installation and compilation instructions
+   ([#300](https://github.com/mlpack/ensmallen/pull/300)).
+
+ * Disable building the tests by default for faster installation
+   ([#303](https://github.com/mlpack/ensmallen/pull/303)).
+
+ * Modify matrix initialisation to take into account
+   default element zeroing in Armadillo 10.5
+   ([#305](https://github.com/mlpack/ensmallen/pull/305)).
 
 ### ensmallen 2.16.2: "Severely Dented Can Of Polyurethane"
 ###### 2021-03-24

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -15,17 +15,17 @@
 #define ENS_VERSION_MAJOR 2
 // The minor version is two digits so regular numerical comparisons of versions
 // work right.  The first minor version of a release is always 10.
-#define ENS_VERSION_MINOR 16
-#define ENS_VERSION_PATCH 2
+#define ENS_VERSION_MINOR 17
+#define ENS_VERSION_PATCH 0
 // If this is a release candidate, it will be reflected in the version name
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not
 // contain the capitalized string "RC".
-#define ENS_VERSION_NAME "Severely Dented Can Of Polyurethane"
+#define ENS_VERSION_NAME "Pachis Din Me Pesa Double"
 // Incorporate the date the version was released.
 #define ENS_VERSION_YEAR "2021"
-#define ENS_VERSION_MONTH "03"
-#define ENS_VERSION_DAY "24"
+#define ENS_VERSION_MONTH "07"
+#define ENS_VERSION_DAY "06"
 
 namespace ens {
 


### PR DESCRIPTION
This automatically-generated pull request adds the commits necessary to make the 2.17.0 release.

Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it.

Or, well, hopefully that will happen someday.

When you merge this PR, be sure to merge it using a *rebase*.

### Changelog

 * CheckArbitraryFunctionTypeAPI extended for MOO support ([#283](https://github.com/mlpack/ensmallen/pull/283)).

 * Refactor NSGA2 ([#263](https://github.com/mlpack/ensmallen/pull/263), [#304](https://github.com/mlpack/ensmallen/pull/304)).

 * Add Indicators for Multiobjective optimizers ([#285](https://github.com/mlpack/ensmallen/pull/285)).

 * Make Callback flexible for MultiObjective Optimizers ([#289](https://github.com/mlpack/ensmallen/pull/289)).

 * Add ZDT Test Suite ([#273](https://github.com/mlpack/ensmallen/pull/273)).

 * Add MOEA-D/DE Optimizer ([#269](https://github.com/mlpack/ensmallen/pull/269)).

 * Introduce Policy Methods for MOEA/D-DE ([#293](https://github.com/mlpack/ensmallen/pull/293)).

 * Add Das-Dennis weight initialization method ([#295](https://github.com/mlpack/ensmallen/pull/295)).

 * Add Dirichlet Weight Initialization ([#296](https://github.com/mlpack/ensmallen/pull/296)).

 * Improved installation and compilation instructions ([#300](https://github.com/mlpack/ensmallen/pull/300)).

 * Disable building the tests by default for faster installation ([#303](https://github.com/mlpack/ensmallen/pull/303)).

 * Modify matrix initialisation to take into account default element zeroing in Armadillo 10.5 ([#305](https://github.com/mlpack/ensmallen/pull/305)).