### PR TITLE
The BUILD_TESTS option was replaced with 'make ensmallen_tests'.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,11 @@
 # just installs the headers to the install location, and optionally builds the
 # test program.
 cmake_minimum_required(VERSION 3.3.2)
-project(ensmallen 
+project(ensmallen
         LANGUAGES C CXX)
 
 # Configurable options for CMake.
 option(USE_OPENMP "If available, use OpenMP for parallelization." ON)
-option(BUILD_TESTS "Build tests." ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
 
@@ -96,6 +95,4 @@ install(FILES ${CMAKE_SOURCE_DIR}/include/ensmallen.hpp
 
 # Enable testing and build tests.
 enable_testing()
-if (BUILD_TESTS)
-  add_subdirectory(tests)
-endif()
+add_subdirectory(tests)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Remove superfluous CMake option to build the tests
+   ([#313](https://github.com/mlpack/ensmallen/pull/313)).
 
 ### ensmallen 2.17.0: "Pachis Din Me Pesa Double"
 ###### 2021-07-06


### PR DESCRIPTION
Remove the `BUILD_TESTS` option in favor of `make ensmallen_tests` see https://github.com/mlpack/ensmallen/pull/303 for more details.