### PR TITLE
Bump minimum Armadillo version to 9.800.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  ARMADILLO_DOWNLOAD: "http://ftp.fau.de/macports/distfiles/armadillo/armadillo-8.400.0.tar.xz"
+  ARMADILLO_DOWNLOAD: "https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz"
   BLAS_LIBRARY: "%APPVEYOR_BUILD_FOLDER%/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a"
   BLAS_LIBRARY_DLL: "%APPVEYOR_BUILD_FOLDER%/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll"
 
@@ -26,7 +26,7 @@ build_script:
   - cd ..
   - appveyor DownloadFile %ARMADILLO_DOWNLOAD% -FileName armadillo.tar.xz
   - 7z x armadillo.tar.xz -so -txz | 7z x -si -ttar > nul
-  - cd armadillo-8.400.0 && mkdir build && cd build
+  - cd armadillo-9.800.6 && mkdir build && cd build
   - >
     cmake -G "%VSVER%"
     -DBLAS_LIBRARY:FILEPATH=%BLAS_LIBRARY%
@@ -43,7 +43,7 @@ build_script:
   - cd ensmallen && mkdir build && cd build
   - >
     cmake -G "%VSVER%"
-    -DARMADILLO_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/../armadillo-8.400.0/include/
+    -DARMADILLO_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/../armadillo-9.800.6/include/
     -DARMADILLO_LIBRARIES=%BLAS_LIBRARY%
     -DLAPACK_LIBRARY=%BLAS_LIBRARY%
     -DBLAS_LIBRARY=%BLAS_LIBRARY%

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - if [ $ARMADILLO == "latest" ]; then
       curl https://ftp.fau.de/macports/distfiles/armadillo/`curl https://ftp.fau.de/macports/distfiles/armadillo/ -- | grep '.tar.xz' | sed 's/^.*<a href="\(armadillo-[0-9]*.[0-9]*.[0-9]*.tar.xz\)".*$/\1/' | tail -1` | tar xvJ && cd armadillo*;
     else
-      curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-8.400.0.tar.xz | tar -xvJ && cd armadillo*;
+      curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-9.800.1.tar.xz | tar -xvJ && cd armadillo*;
     fi
   - cmake . && make && sudo make install && cd ..
   - mkdir build && cd build && cmake .. && make ensmallen_tests -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - if [ $ARMADILLO == "latest" ]; then
       curl https://ftp.fau.de/macports/distfiles/armadillo/`curl https://ftp.fau.de/macports/distfiles/armadillo/ -- | grep '.tar.xz' | sed 's/^.*<a href="\(armadillo-[0-9]*.[0-9]*.[0-9]*.tar.xz\)".*$/\1/' | tail -1` | tar xvJ && cd armadillo*;
     else
-      curl https://ftp.fau.de/macports/distfiles/armadillo/armadillo-9.800.1.tar.xz | tar -xvJ && cd armadillo*;
+      curl -L https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz | tar -xvJ && cd armadillo*;
     fi
   - cmake . && make && sudo make install && cd ..
   - mkdir build && cd build && cmake .. && make ensmallen_tests -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if(USE_OPENMP)
 endif()
 
 # Find Armadillo and link it.
-find_package(Armadillo 8.400.0 REQUIRED)
+find_package(Armadillo 9.800.0 REQUIRED)
 target_link_libraries(ensmallen INTERFACE Armadillo::Armadillo)
 
 # Set helper variables for creating the version, config and target files.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
  * Remove superfluous CMake option to build the tests
    ([#313](https://github.com/mlpack/ensmallen/pull/313)).
 
+ * Bump minimum Armadillo version to 9.800
+   ([#318](https://github.com/mlpack/ensmallen/pull/318)).
+
 ### ensmallen 2.17.0: "Pachis Din Me Pesa Double"
 ###### 2021-07-06
  * CheckArbitraryFunctionTypeAPI extended for MOO support

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ gradient-free optimizers, and constrained optimization.
 
 ### Installation
 
-ensmallen can be installed in several ways: either manually or via cmake,
+ensmallen can be installed in several ways: either manually or via cmake, 
 with or without root access.
 
-The cmake based installation will check the requirements
-and optionally build the tests. If cmake 3.3 (or a later version)
-is not already available on your system, it can be obtained
-from [cmake.org](https://cmake.org). If you are using an older
-system such as RHEL 7 or CentOS 7, an updated version of cmake
+The cmake based installation will check the requirements 
+and optionally build the tests. If cmake 3.3 (or a later version) 
+is not already available on your system, it can be obtained 
+from [cmake.org](https://cmake.org). If you are using an older 
+system such as RHEL 7 or CentOS 7, an updated version of cmake 
 is also available via the EPEL repository (see the `cmake3` package).
 
 Example cmake based installation with root access:
@@ -41,7 +41,7 @@ cmake ..
 sudo make install
 ```
 
-Example cmake based installation without root access,
+Example cmake based installation without root access, 
 installing into `/home/blah/` (adapt as required):
 
 ```
@@ -51,7 +51,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/home/blah/
 make install
 ```
 
-The above will create a directory named `/home/blah/include/`
+The above will create a directory named `/home/blah/include/` 
 and place all ensmallen headers there.
 
 To optionally build and run the tests
@@ -63,10 +63,10 @@ make ensmallen_tests
 ./ensmallen_tests --durations yes
 ```
 
-Manual installation involves simply copying the `include/ensmallen.hpp` header
-***and*** the associated `include/ensmallen_bits` directory to a location
+Manual installation involves simply copying the `include/ensmallen.hpp` header 
+***and*** the associated `include/ensmallen_bits` directory to a location 
 such as `/usr/include/` which is searched by your C++ compiler.
-If you can't use `sudo` or don't have write access to `/usr/include/`,
+If you can't use `sudo` or don't have write access to `/usr/include/`, 
 use a directory within your own home directory (eg. `/home/blah/include/`).
 
 
@@ -75,11 +75,11 @@ use a directory within your own home directory (eg. `/home/blah/include/`).
 If you have installed ensmallen in a standard location such as `/usr/include/`:
 
     g++ prog.cpp -o prog -O2 -larmadillo
-
-If you have installed ensmallen in a non-standard location,
-such as `/home/blah/include/`, you will need to make sure
-that your C++ compiler searches `/home/blah/include/`
-by explicitly specifying the directory as an argument/option.
+    
+If you have installed ensmallen in a non-standard location, 
+such as `/home/blah/include/`, you will need to make sure 
+that your C++ compiler searches `/home/blah/include/` 
+by explicitly specifying the directory as an argument/option. 
 For example, using the `-I` switch in gcc and clang:
 
     g++ prog.cpp -o prog -O2 -I /home/blah/include/ -larmadillo
@@ -87,7 +87,7 @@ For example, using the `-I` switch in gcc and clang:
 
 ### Example Optimization
 
-See [`example.cpp`](example.cpp) for example usage of the L-BFGS optimizer
+See [`example.cpp`](example.cpp) for example usage of the L-BFGS optimizer 
 in a linear regression setting.
 
 
@@ -105,8 +105,8 @@ Please cite the following paper if you use ensmallen in your research and/or
 software. Citations are useful for the continued development and maintenance of
 the library.
 
-* Ryan R. Curtin, Marcus Edel, Rahul Ganesh Prabhu, Suryoday Basak, Zhihao Lou, Conrad Sanderson.
-  [The ensmallen library for flexible numerical optimization](https://jmlr.org/papers/volume22/20-416/20-416.pdf).
+* Ryan R. Curtin, Marcus Edel, Rahul Ganesh Prabhu, Suryoday Basak, Zhihao Lou, Conrad Sanderson.  
+  [The ensmallen library for flexible numerical optimization](https://jmlr.org/papers/volume22/20-416/20-416.pdf).  
   Journal of Machine Learning Research, Vol. 22, No. 166, 2021.
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ gradient-free optimizers, and constrained optimization.
 
 ### Installation
 
-ensmallen can be installed in several ways: either manually or via cmake, 
+ensmallen can be installed in several ways: either manually or via cmake,
 with or without root access.
 
-The cmake based installation will check the requirements 
-and optionally build the tests. If cmake 3.3 (or a later version) 
-is not already available on your system, it can be obtained 
-from [cmake.org](https://cmake.org). If you are using an older 
-system such as RHEL 7 or CentOS 7, an updated version of cmake 
+The cmake based installation will check the requirements
+and optionally build the tests. If cmake 3.3 (or a later version)
+is not already available on your system, it can be obtained
+from [cmake.org](https://cmake.org). If you are using an older
+system such as RHEL 7 or CentOS 7, an updated version of cmake
 is also available via the EPEL repository (see the `cmake3` package).
 
 Example cmake based installation with root access:
@@ -41,7 +41,7 @@ cmake ..
 sudo make install
 ```
 
-Example cmake based installation without root access, 
+Example cmake based installation without root access,
 installing into `/home/blah/` (adapt as required):
 
 ```
@@ -51,7 +51,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/home/blah/
 make install
 ```
 
-The above will create a directory named `/home/blah/include/` 
+The above will create a directory named `/home/blah/include/`
 and place all ensmallen headers there.
 
 To optionally build and run the tests
@@ -63,10 +63,10 @@ make ensmallen_tests
 ./ensmallen_tests --durations yes
 ```
 
-Manual installation involves simply copying the `include/ensmallen.hpp` header 
-***and*** the associated `include/ensmallen_bits` directory to a location 
+Manual installation involves simply copying the `include/ensmallen.hpp` header
+***and*** the associated `include/ensmallen_bits` directory to a location
 such as `/usr/include/` which is searched by your C++ compiler.
-If you can't use `sudo` or don't have write access to `/usr/include/`, 
+If you can't use `sudo` or don't have write access to `/usr/include/`,
 use a directory within your own home directory (eg. `/home/blah/include/`).
 
 
@@ -75,11 +75,11 @@ use a directory within your own home directory (eg. `/home/blah/include/`).
 If you have installed ensmallen in a standard location such as `/usr/include/`:
 
     g++ prog.cpp -o prog -O2 -larmadillo
-    
-If you have installed ensmallen in a non-standard location, 
-such as `/home/blah/include/`, you will need to make sure 
-that your C++ compiler searches `/home/blah/include/` 
-by explicitly specifying the directory as an argument/option. 
+
+If you have installed ensmallen in a non-standard location,
+such as `/home/blah/include/`, you will need to make sure
+that your C++ compiler searches `/home/blah/include/`
+by explicitly specifying the directory as an argument/option.
 For example, using the `-I` switch in gcc and clang:
 
     g++ prog.cpp -o prog -O2 -I /home/blah/include/ -larmadillo
@@ -87,7 +87,7 @@ For example, using the `-I` switch in gcc and clang:
 
 ### Example Optimization
 
-See [`example.cpp`](example.cpp) for example usage of the L-BFGS optimizer 
+See [`example.cpp`](example.cpp) for example usage of the L-BFGS optimizer
 in a linear regression setting.
 
 
@@ -105,8 +105,8 @@ Please cite the following paper if you use ensmallen in your research and/or
 software. Citations are useful for the continued development and maintenance of
 the library.
 
-* Ryan R. Curtin, Marcus Edel, Rahul Ganesh Prabhu, Suryoday Basak, Zhihao Lou, Conrad Sanderson.  
-  [The ensmallen library for flexible numerical optimization](https://jmlr.org/papers/volume22/20-416/20-416.pdf).  
+* Ryan R. Curtin, Marcus Edel, Rahul Ganesh Prabhu, Suryoday Basak, Zhihao Lou, Conrad Sanderson.
+  [The ensmallen library for flexible numerical optimization](https://jmlr.org/papers/volume22/20-416/20-416.pdf).
   Journal of Machine Learning Research, Vol. 22, No. 166, 2021.
 
 ```


### PR DESCRIPTION
As discussed here https://github.com/mlpack/ensmallen/pull/315 we like to bump the minimum Armadillo version to 9.800. I think once merged we should do another release `2.18.0`.