### PR TITLE
Fix for C++20 constructor template argument deprecation

### DIFF
--- a/include/ensmallen_bits/callbacks/early_stop_at_min_loss.hpp
+++ b/include/ensmallen_bits/callbacks/early_stop_at_min_loss.hpp
@@ -32,7 +32,7 @@ class EarlyStopAtMinLossType
    * @param patienceIn The number of epochs to wait after the minimum loss has
    *    been reached or no improvement has been made (Default: 10).
    */
-  EarlyStopAtMinLossType<MatType>(const size_t patienceIn = 10) :
+  EarlyStopAtMinLossType(const size_t patienceIn = 10) :
       callbackUsed(false), 
       patience(patienceIn), 
       bestObjective(std::numeric_limits<double>::max()),
@@ -47,7 +47,7 @@ class EarlyStopAtMinLossType
    * @param patienceIn The number of epochs to wait after the minimum loss has
    *    been reached or no improvement has been made (Default: 10).
    */
-  EarlyStopAtMinLossType<MatType>(
+  EarlyStopAtMinLossType(
       std::function<double(const MatType&)> func,
       const size_t patienceIn = 10)
     : callbackUsed(true), 


### PR DESCRIPTION
Removes the redundant template type parameter from the constructors of `EarlyStopAtMinLossType` to allow inclusion and compilation of `ensmallen.hpp` in programs using C++20.

This is due to [the following change in C++20](https://eel.is/c++draft/diff.cpp17.class#2) (compared to C++17 and earlier) that disallows such non-necessary repeat of the parameter in constructors and destructors.

This does not affect compilation using earlier C++ standard. All `ensmallen_tests` still pass. This does not necessitate any change in user code. Fixes #324 