### PR TITLE
avoid infinite loop for single-precision matrices

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,10 @@
  * Accelerate SGD test time
    ([#330](https://github.com/mlpack/ensmallen/pull/300)).
 
+ * Fix potential infinite loop in CMAES
+   ([#331](https://github.com/mlpack/ensmallen/pull/331)).
+
+
 ### ensmallen 2.18.0: "Fairmount Bagel"
 ###### 2021-10-20
  * Add gradient value clipping and gradient norm scaling callback

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -159,7 +159,7 @@ typename MatType::elem_type CMAES<SelectionPolicyType>::Optimize(
     // add a small value and try again.
     BaseMatType covLower;
     while (!arma::chol(covLower, C[idx0], "lower"))
-      C[idx0].diag() += 1e-16;
+      C[idx0].diag() += std::numeric_limits<ElemType>::epsilon();
 
     for (size_t j = 0; j < lambda; ++j)
     {


### PR DESCRIPTION
if `BaseMatType` is `fmat` (ie. matrix with single precision elements), 1e-16 is effectively zero, leading to an infinite loop if `chol()` fails on the `C[idx0]` matrix.
The solution is to use type dependent epsilon.