### PR TITLE
SCD partial gradient test fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
  * Fix potential infinite loop in CMAES
    ([#331](https://github.com/mlpack/ensmallen/pull/331)).
 
+ * Fix SCD partial gradient test
+   ([#332](https://github.com/mlpack/ensmallen/pull/332)).
 
 ### ensmallen 2.18.0: "Fairmount Bagel"
 ###### 2021-10-20

--- a/tests/scd_test.cpp
+++ b/tests/scd_test.cpp
@@ -196,7 +196,7 @@ TEST_CASE("SoftmaxRegressionFunctionPartialGradientTest", "[SCDTest]")
 
   // Create random class labels.
   arma::Row<size_t> labels = arma::randi<arma::Row<size_t> >(
-      points, arma::distr_param(0, numClasses));
+      points, arma::distr_param(0, numClasses - 1));
 
   // 2 objects for 2 terms in the cost function. Each term contributes towards
   // the gradient and thus need to be checked independently.


### PR DESCRIPTION
Use the correct number of classes to generate the label vector. This will fix the build issue reported in https://github.com/mlpack/ensmallen/issues/329.