### PR TITLE
Release 2.18.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ $ cd ensmallen
 
 # - or -
 
-$ wget http://ensmallen.org/files/ensmallen-2.18.0.tar.gz
-$ tar -xvzpf ensmallen-2.18.0.tar.gz
+$ wget http://ensmallen.org/files/ensmallen-2.18.1.tar.gz
+$ tar -xvzpf ensmallen-2.18.1.tar.gz
 $ cd ensmallen-latest
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-### ensmallen ?.??.?: "???"
-###### ????-??-??
+### ensmallen 2.18.1: "Fairmount Bagel"
+###### 2021-11-19
  * Accelerate SGD test time
    ([#330](https://github.com/mlpack/ensmallen/pull/300)).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### ensmallen ?.??.?: "???"
+###### ????-??-??
+
 ### ensmallen 2.18.1: "Fairmount Bagel"
 ###### 2021-11-19
  * Accelerate SGD test time

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -16,7 +16,7 @@
 // The minor version is two digits so regular numerical comparisons of versions
 // work right.  The first minor version of a release is always 10.
 #define ENS_VERSION_MINOR 18
-#define ENS_VERSION_PATCH 0
+#define ENS_VERSION_PATCH 1
 // If this is a release candidate, it will be reflected in the version name
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not
@@ -24,8 +24,8 @@
 #define ENS_VERSION_NAME "Fairmount Bagel"
 // Incorporate the date the version was released.
 #define ENS_VERSION_YEAR "2021"
-#define ENS_VERSION_MONTH "10"
-#define ENS_VERSION_DAY "20"
+#define ENS_VERSION_MONTH "11"
+#define ENS_VERSION_DAY "19"
 
 namespace ens {
 


### PR DESCRIPTION
This automatically-generated pull request adds the commits necessary to make the 2.18.1 release.

Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it.

Or, well, hopefully that will happen someday.

When you merge this PR, be sure to merge it using a *rebase*.

### Changelog

 * Accelerate SGD test time ([#330](https://github.com/mlpack/ensmallen/pull/300)).

 * Fix potential infinite loop in CMAES ([#331](https://github.com/mlpack/ensmallen/pull/331)).

 * Fix SCD partial gradient test ([#332](https://github.com/mlpack/ensmallen/pull/332)).