### PR TITLE
Report the correct epoch time in seconds.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
  * Update Catch2 to 2.13.8
   ([#336](https://github.com/mlpack/ensmallen/pull/336)).
 
+ * Fix epoch timing output
+  ([#337](https://github.com/mlpack/ensmallen/pull/337)).
+
 ### ensmallen 2.18.1: "Fairmount Bagel"
 ###### 2021-11-19
  * Accelerate SGD test time

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -216,9 +216,8 @@ class ProgressBar
         output << ".";
       }
     }
-
     const size_t stepTime = epochTimer.toc() / (double) epochSize * 1000;
-    output << "] " << progress << "% - " << (size_t) epochTimer.toc() % 60
+    output << "] " << progress << "% - " << epochTimer.toc()
         << "s " << stepTime << "ms/step " << "- loss: " << objective  <<  "\n";
     output.flush();
   }

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -218,7 +218,7 @@ class ProgressBar
     }
     const size_t stepTime = epochTimer.toc() / (double) epochSize * 1000;
     output << "] " << progress << "% - " << epochTimer.toc()
-        << "s/epoch; " << stepTime << "ms/step; " << " loss: "
+        << "s/epoch; " << stepTime << "ms/step; " << "loss: "
         << objective  <<  "\n";
     output.flush();
   }

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -218,7 +218,8 @@ class ProgressBar
     }
     const size_t stepTime = epochTimer.toc() / (double) epochSize * 1000;
     output << "] " << progress << "% - " << epochTimer.toc()
-        << "s " << stepTime << "ms/step " << "- loss: " << objective  <<  "\n";
+        << "s/epoch; " << stepTime << "ms/step; " << " loss: "
+        << objective  <<  "\n";
     output.flush();
   }
 

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -216,10 +216,10 @@ class ProgressBar
         output << ".";
       }
     }
-    const size_t stepTime = epochTimer.toc() / (double) epochSize * 1000;
-    output << "] " << progress << "% - " << epochTimer.toc()
-        << "s/epoch; " << stepTime << "ms/step; " << "loss: "
-        << objective  <<  "\n";
+    const double epochTimerElapsed = epochTimer.toc();
+    const size_t stepTime = epochTimerElapsed / (double) epochSize * 1000;
+    output << "] " << progress << "% - " << epochTimerElapsed
+        << "s/epoch; " << stepTime << "ms/step; loss: " << objective  <<  "\n";
     output.flush();
   }
 


### PR DESCRIPTION
Fix for https://github.com/mlpack/ensmallen/issues/244 now it shows the correct time in seconds:

```
Epoch 1/2
3/3 [====================================================================================================] 100% - 210s 70000ms/step - loss: 1224.1
Epoch 2/2
2/3 [==================================================================>.................................] 66% - ETA: 10s - loss: 439.535
```

See the `210s` at the end of the first epoch, which is the sum of each step.