### PR TITLE
Move `iteration` member into UpdatePolicy classes

### DIFF
--- a/include/ensmallen_bits/ada_belief/ada_belief_update.hpp
+++ b/include/ensmallen_bits/ada_belief/ada_belief_update.hpp
@@ -49,8 +49,7 @@ class AdaBeliefUpdate
                   const double beta2 = 0.999) :
     epsilon(epsilon),
     beta1(beta1),
-    beta2(beta2),
-    iteration(0)
+    beta2(beta2)
   {
     // Nothing to do.
   }
@@ -69,11 +68,6 @@ class AdaBeliefUpdate
   double Beta2() const { return beta2; }
   //! Modify the exponential decay rate for the 2nd moment estimates.
   double& Beta2() { return beta2; }
-
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
 
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
@@ -94,7 +88,8 @@ class AdaBeliefUpdate
      * @param cols Number of columns in the gradient matrix.
      */
     Policy(AdaBeliefUpdate& parent, const size_t rows, const size_t cols) :
-        parent(parent)
+        parent(parent),
+        iteration(0)
     {
       m.zeros(rows, cols);
       s.zeros(rows, cols);
@@ -112,7 +107,7 @@ class AdaBeliefUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       m *= parent.beta1;
       m += (1 - parent.beta1) * gradient;
@@ -120,10 +115,8 @@ class AdaBeliefUpdate
       s *= parent.beta2;
       s += (1 - parent.beta2) * arma::pow(gradient - m, 2.0) + parent.epsilon;
 
-      const double biasCorrection1 = 1.0 - std::pow(parent.beta1,
-          parent.iteration);
-      const double biasCorrection2 = 1.0 - std::pow(parent.beta2,
-          parent.iteration);
+      const double biasCorrection1 = 1.0 - std::pow(parent.beta1, iteration);
+      const double biasCorrection2 = 1.0 - std::pow(parent.beta2, iteration);
 
       // And update the iterate.
       iterate -= ((m / biasCorrection1) * stepSize) / (arma::sqrt(s /
@@ -139,6 +132,9 @@ class AdaBeliefUpdate
 
     // The exponential moving average of squared gradient values.
     GradType s;
+
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -150,9 +146,6 @@ class AdaBeliefUpdate
 
   // The exponential decay rate for the 2nd moment estimates.
   double beta2;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/ada_sqrt/ada_sqrt_update.hpp
+++ b/include/ensmallen_bits/ada_sqrt/ada_sqrt_update.hpp
@@ -39,7 +39,7 @@ class AdaSqrtUpdate
    * @param epsilon The epsilon value used to initialise the squared gradient
    *        parameter.
    */
-  AdaSqrtUpdate(const double epsilon = 1e-8) : epsilon(epsilon), iteration(0)
+  AdaSqrtUpdate(const double epsilon = 1e-8) : epsilon(epsilon)
   {
     // Nothing to do.
   }
@@ -48,11 +48,6 @@ class AdaSqrtUpdate
   double Epsilon() const { return epsilon; }
   //! Modify the value used to initialise the squared gradient parameter.
   double& Epsilon() { return epsilon; }
-
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
 
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
@@ -76,7 +71,8 @@ class AdaSqrtUpdate
      */
     Policy(AdaSqrtUpdate& parent, const size_t rows, const size_t cols) :
         parent(parent),
-        squaredGradient(rows, cols)
+        squaredGradient(rows, cols),
+        iteration(0)
     {
       // Initialize an empty matrix for sum of squares of parameter gradient.
       squaredGradient.zeros();
@@ -95,11 +91,11 @@ class AdaSqrtUpdate
                 const double stepSize,
                 const GradType& gradient)
     {
-      ++parent.iteration;
+      ++iteration;
 
       squaredGradient += arma::square(gradient);
 
-      iterate -= stepSize * std::sqrt(parent.iteration) * gradient /
+      iterate -= stepSize * std::sqrt(iteration) * gradient /
           (squaredGradient + parent.epsilon);
     }
 
@@ -108,14 +104,13 @@ class AdaSqrtUpdate
     AdaSqrtUpdate& parent;
     // The squared gradient matrix.
     GradType squaredGradient;
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
   // The epsilon value used to initialise the squared gradient parameter.
   double epsilon;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/adam/adam_update.hpp
+++ b/include/ensmallen_bits/adam/adam_update.hpp
@@ -52,8 +52,7 @@ class AdamUpdate
              const double beta2 = 0.999) :
     epsilon(epsilon),
     beta1(beta1),
-    beta2(beta2),
-    iteration(0)
+    beta2(beta2)
   {
     // Nothing to do.
   }
@@ -72,11 +71,6 @@ class AdamUpdate
   double Beta2() const { return beta2; }
   //! Modify the second moment coefficient.
   double& Beta2() { return beta2; }
-
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
 
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
@@ -97,7 +91,8 @@ class AdamUpdate
      * @param cols Number of columns in the gradient matrix.
      */
     Policy(AdamUpdate& parent, const size_t rows, const size_t cols) :
-        parent(parent)
+        parent(parent),
+        iteration(0)
     {
       m.zeros(rows, cols);
       v.zeros(rows, cols);
@@ -115,7 +110,7 @@ class AdamUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       // And update the iterate.
       m *= parent.beta1;
@@ -124,10 +119,8 @@ class AdamUpdate
       v *= parent.beta2;
       v += (1 - parent.beta2) * (gradient % gradient);
 
-      const double biasCorrection1 = 1.0 - std::pow(parent.beta1,
-          parent.iteration);
-      const double biasCorrection2 = 1.0 - std::pow(parent.beta2,
-          parent.iteration);
+      const double biasCorrection1 = 1.0 - std::pow(parent.beta1, iteration);
+      const double biasCorrection2 = 1.0 - std::pow(parent.beta2, iteration);
 
       /**
        * It should be noted that the term, m / (arma::sqrt(v) + eps), in the
@@ -147,6 +140,9 @@ class AdamUpdate
 
     // The exponential moving average of squared gradient values.
     GradType v;
+
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -158,9 +154,6 @@ class AdamUpdate
 
   // The second moment coefficient.
   double beta2;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/adam/adamax_update.hpp
+++ b/include/ensmallen_bits/adam/adamax_update.hpp
@@ -54,8 +54,7 @@ class AdaMaxUpdate
                const double beta2 = 0.999) :
     epsilon(epsilon),
     beta1(beta1),
-    beta2(beta2),
-    iteration(0)
+    beta2(beta2)
   {
     // Nothing to do.
   }
@@ -74,11 +73,6 @@ class AdaMaxUpdate
   double Beta2() const { return beta2; }
   //! Modify the second moment coefficient.
   double& Beta2() { return beta2; }
-
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
 
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
@@ -99,7 +93,8 @@ class AdaMaxUpdate
      * @param cols Number of columns in the gradient matrix.
      */
     Policy(AdaMaxUpdate& parent, const size_t rows, const size_t cols) :
-        parent(parent)
+        parent(parent),
+        iteration(0)
     {
       m.zeros(rows, cols);
       u.zeros(rows, cols);
@@ -117,7 +112,7 @@ class AdaMaxUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       // And update the iterate.
       m *= parent.beta1;
@@ -127,8 +122,7 @@ class AdaMaxUpdate
       u *= parent.beta2;
       u = arma::max(u, arma::abs(gradient));
 
-      const double biasCorrection1 = 1.0 - std::pow(parent.beta1,
-          parent.iteration);
+      const double biasCorrection1 = 1.0 - std::pow(parent.beta1, iteration);
 
       if (biasCorrection1 != 0)
         iterate -= (stepSize / biasCorrection1 * m / (u + parent.epsilon));
@@ -141,6 +135,8 @@ class AdaMaxUpdate
     GradType m;
     // The exponentially weighted infinity norm.
     GradType u;
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -152,9 +148,6 @@ class AdaMaxUpdate
 
   // The second moment coefficient.
   double beta2;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/adam/amsgrad_update.hpp
+++ b/include/ensmallen_bits/adam/amsgrad_update.hpp
@@ -47,8 +47,7 @@ class AMSGradUpdate
                 const double beta2 = 0.999) :
     epsilon(epsilon),
     beta1(beta1),
-    beta2(beta2),
-    iteration(0)
+    beta2(beta2)
   {
     // Nothing to do.
   }
@@ -67,11 +66,6 @@ class AMSGradUpdate
   double Beta2() const { return beta2; }
   //! Modify the second moment coefficient.
   double& Beta2() { return beta2; }
-
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
 
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
@@ -92,7 +86,8 @@ class AMSGradUpdate
      * @param cols Number of columns in the gradient matrix.
      */
     Policy(AMSGradUpdate& parent, const size_t rows, const size_t cols) :
-        parent(parent)
+        parent(parent),
+        iteration(0)
     {
       m.zeros(rows, cols);
       v.zeros(rows, cols);
@@ -111,7 +106,7 @@ class AMSGradUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       // And update the iterate.
       m *= parent.beta1;
@@ -120,10 +115,8 @@ class AMSGradUpdate
       v *= parent.beta2;
       v += (1 - parent.beta2) * (gradient % gradient);
 
-      const double biasCorrection1 = 1.0 - std::pow(parent.beta1,
-          parent.iteration);
-      const double biasCorrection2 = 1.0 - std::pow(parent.beta2,
-          parent.iteration);
+      const double biasCorrection1 = 1.0 - std::pow(parent.beta1, iteration);
+      const double biasCorrection2 = 1.0 - std::pow(parent.beta2, iteration);
 
       // Element wise maximum of past and present squared gradients.
       vImproved = arma::max(vImproved, v);
@@ -144,6 +137,9 @@ class AMSGradUpdate
 
     // The optimal squared gradient value.
     GradType vImproved;
+
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -155,9 +151,6 @@ class AMSGradUpdate
 
   // The second moment coefficient.
   double beta2;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/adam/nadam_update.hpp
+++ b/include/ensmallen_bits/adam/nadam_update.hpp
@@ -50,8 +50,7 @@ class NadamUpdate
       epsilon(epsilon),
       beta1(beta1),
       beta2(beta2),
-      scheduleDecay(scheduleDecay),
-      iteration(0)
+      scheduleDecay(scheduleDecay)
   {
     // Nothing to do.
   }
@@ -76,11 +75,6 @@ class NadamUpdate
   //! Modify the decay parameter for decay coefficients
   double& ScheduleDecay() { return scheduleDecay; }
 
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
-
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
    * template class with two template arguments: MatType and GradType.  This is
@@ -101,7 +95,8 @@ class NadamUpdate
      */
     Policy(NadamUpdate& parent, const size_t rows, const size_t cols) :
         parent(parent),
-        cumBeta1(1)
+        cumBeta1(1),
+        iteration(0)
     {
       m.zeros(rows, cols);
       v.zeros(rows, cols);
@@ -119,7 +114,7 @@ class NadamUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       // And update the iterate.
       m *= parent.beta1;
@@ -129,18 +124,15 @@ class NadamUpdate
       v += (1 - parent.beta2) * gradient % gradient;
 
       double beta1T = parent.beta1 * (1 - (0.5 *
-          std::pow(0.96, parent.iteration * parent.scheduleDecay)));
+          std::pow(0.96, iteration * parent.scheduleDecay)));
 
       double beta1T1 = parent.beta1 * (1 - (0.5 *
-          std::pow(0.96, (parent.iteration + 1) * parent.scheduleDecay)));
+          std::pow(0.96, (iteration + 1) * parent.scheduleDecay)));
 
       cumBeta1 *= beta1T;
 
       const double biasCorrection1 = 1.0 - cumBeta1;
-
-      const double biasCorrection2 = 1.0 - std::pow(parent.beta2,
-          parent.iteration);
-
+      const double biasCorrection2 = 1.0 - std::pow(parent.beta2, iteration);
       const double biasCorrection3 = 1.0 - (cumBeta1 * beta1T1);
 
       /* Note :- arma::sqrt(v) + epsilon * sqrt(biasCorrection2) is approximated
@@ -163,6 +155,9 @@ class NadamUpdate
 
     // The cumulative product of decay coefficients.
     double cumBeta1;
+
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -177,9 +172,6 @@ class NadamUpdate
 
   // The decay parameter for decay coefficients.
   double scheduleDecay;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/adam/nadamax_update.hpp
+++ b/include/ensmallen_bits/adam/nadamax_update.hpp
@@ -50,8 +50,7 @@ class NadaMaxUpdate
       epsilon(epsilon),
       beta1(beta1),
       beta2(beta2),
-      scheduleDecay(scheduleDecay),
-      iteration(0)
+      scheduleDecay(scheduleDecay)
   {
     // Nothing to do.
   }
@@ -76,11 +75,6 @@ class NadaMaxUpdate
   //! Modify the decay parameter for decay coefficients
   double& ScheduleDecay() { return scheduleDecay; }
 
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
-
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
    * template class with two template arguments: MatType and GradType.  This is
@@ -101,7 +95,8 @@ class NadaMaxUpdate
      */
     Policy(NadaMaxUpdate& parent, const size_t rows, const size_t cols) :
         parent(parent),
-        cumBeta1(1)
+        cumBeta1(1),
+        iteration(0)
     {
       m.zeros(rows, cols);
       u.zeros(rows, cols);
@@ -119,7 +114,7 @@ class NadaMaxUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       // And update the iterate.
       m *= parent.beta1;
@@ -128,10 +123,10 @@ class NadaMaxUpdate
       u = arma::max(u * parent.beta2, arma::abs(gradient));
 
       double beta1T = parent.beta1 * (1 - (0.5 *
-          std::pow(0.96, parent.iteration * parent.scheduleDecay)));
+          std::pow(0.96, iteration * parent.scheduleDecay)));
 
       double beta1T1 = parent.beta1 * (1 - (0.5 *
-          std::pow(0.96, (parent.iteration + 1) * parent.scheduleDecay)));
+          std::pow(0.96, (iteration + 1) * parent.scheduleDecay)));
 
       cumBeta1 *= beta1T;
 
@@ -158,6 +153,9 @@ class NadaMaxUpdate
 
     // The cumulative product of decay coefficients.
     double cumBeta1;
+
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -172,9 +170,6 @@ class NadaMaxUpdate
 
   // The decay parameter for decay coefficients.
   double scheduleDecay;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/adam/optimisticadam_update.hpp
+++ b/include/ensmallen_bits/adam/optimisticadam_update.hpp
@@ -51,8 +51,7 @@ class OptimisticAdamUpdate
                        const double beta2 = 0.999) :
     epsilon(epsilon),
     beta1(beta1),
-    beta2(beta2),
-    iteration(0)
+    beta2(beta2)
   {
     // Nothing to do.
   }
@@ -71,11 +70,6 @@ class OptimisticAdamUpdate
   double Beta2() const { return beta2; }
   //! Modify the second moment coefficient.
   double& Beta2() { return beta2; }
-
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
 
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
@@ -96,7 +90,8 @@ class OptimisticAdamUpdate
      * @param cols Number of columns in the gradient matrix.
      */
     Policy(OptimisticAdamUpdate& parent, const size_t rows, const size_t cols) :
-        parent(parent)
+        parent(parent),
+        iteration(0)
     {
       m.zeros(rows, cols);
       v.zeros(rows, cols);
@@ -115,7 +110,7 @@ class OptimisticAdamUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       // And update the iterate.
       m *= parent.beta1;
@@ -124,13 +119,10 @@ class OptimisticAdamUpdate
       v *= parent.beta2;
       v += (1 - parent.beta2) * arma::square(gradient);
 
-      GradType mCorrected = m / (1.0 - std::pow(parent.beta1,
-          parent.iteration));
-      GradType vCorrected = v / (1.0 - std::pow(parent.beta2,
-          parent.iteration));
+      GradType mCorrected = m / (1.0 - std::pow(parent.beta1, iteration));
+      GradType vCorrected = v / (1.0 - std::pow(parent.beta2, iteration));
 
-      GradType update = mCorrected /
-          (arma::sqrt(vCorrected) + parent.epsilon);
+      GradType update = mCorrected / (arma::sqrt(vCorrected) + parent.epsilon);
 
       iterate -= (2 * stepSize * update - stepSize * g);
 
@@ -149,6 +141,9 @@ class OptimisticAdamUpdate
 
     // The previous update.
     GradType g;
+
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -160,9 +155,6 @@ class OptimisticAdamUpdate
 
   // The second moment coefficient.
   double beta2;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/ftml/ftml_update.hpp
+++ b/include/ensmallen_bits/ftml/ftml_update.hpp
@@ -50,8 +50,7 @@ class FTMLUpdate
              const double beta2 = 0.999) :
       epsilon(epsilon),
       beta1(beta1),
-      beta2(beta2),
-      iteration(0)
+      beta2(beta2)
   { /* Do nothing. */ }
 
   //! Get the value used to initialise the squared gradient parameter.
@@ -68,11 +67,6 @@ class FTMLUpdate
   double Beta2() const { return beta2; }
   //! Modify the second moment coefficient.
   double& Beta2() { return beta2; }
-
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
 
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
@@ -112,16 +106,14 @@ class FTMLUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       // And update the iterate.
       v *= parent.beta2;
       v += (1 - parent.beta2) * (gradient % gradient);
 
-      const double biasCorrection1 = 1.0 - std::pow(parent.beta1,
-          parent.iteration);
-      const double biasCorrection2 = 1.0 - std::pow(parent.beta2,
-          parent.iteration);
+      const double biasCorrection1 = 1.0 - std::pow(parent.beta1, iteration);
+      const double biasCorrection2 = 1.0 - std::pow(parent.beta2, iteration);
 
       MatType sigma = -parent.beta1 * d;
       d = biasCorrection1 / stepSize *
@@ -145,6 +137,9 @@ class FTMLUpdate
 
     // Parameter update term.
     MatType d;
+
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -156,9 +151,6 @@ class FTMLUpdate
 
   // The second moment coefficient.
   double beta2;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/padam/padam_update.hpp
+++ b/include/ensmallen_bits/padam/padam_update.hpp
@@ -50,8 +50,7 @@ class PadamUpdate
       epsilon(epsilon),
       beta1(beta1),
       beta2(beta2),
-      partial(partial),
-      iteration(0)
+      partial(partial)
   {
     // Nothing to do.
   }
@@ -76,11 +75,6 @@ class PadamUpdate
   //! Modify the partial adaptive parameter.
   double& Partial() { return partial; }
 
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
-
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
    * template class with two template arguments: MatType and GradType.  This is
@@ -100,7 +94,8 @@ class PadamUpdate
      * @param cols Number of columns in the gradient matrix.
      */
     Policy(PadamUpdate& parent, const size_t rows, const size_t cols) :
-        parent(parent)
+        parent(parent),
+        iteration(0)
     {
       m.zeros(rows, cols);
       v.zeros(rows, cols);
@@ -119,7 +114,7 @@ class PadamUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       // And update the iterate.
       m *= parent.beta1;
@@ -128,10 +123,8 @@ class PadamUpdate
       v *= parent.beta2;
       v += (1 - parent.beta2) * (gradient % gradient);
 
-      const double biasCorrection1 = 1.0 - std::pow(parent.beta1,
-          parent.iteration);
-      const double biasCorrection2 = 1.0 - std::pow(parent.beta2,
-          parent.iteration);
+      const double biasCorrection1 = 1.0 - std::pow(parent.beta1, iteration);
+      const double biasCorrection2 = 1.0 - std::pow(parent.beta2, iteration);
 
       // Element wise maximum of past and present squared gradients.
       vImproved = arma::max(vImproved, v);
@@ -152,6 +145,9 @@ class PadamUpdate
 
     //! The optimal sqaured gradient value.
     GradType vImproved;
+
+    //! The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -166,9 +162,6 @@ class PadamUpdate
 
   //! Partial adaptive parameter.
   double partial;
-
-  //! The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/qhadam/qhadam_update.hpp
+++ b/include/ensmallen_bits/qhadam/qhadam_update.hpp
@@ -54,8 +54,7 @@ class QHAdamUpdate
     beta1(beta1),
     beta2(beta2),
     v1(v1),
-    v2(v2),
-    iteration(0)
+    v2(v2)
   {
     // Nothing to do.
   }
@@ -74,11 +73,6 @@ class QHAdamUpdate
   double Beta2() const { return beta2; }
   //! Modify the second moment coefficient.
   double& Beta2() { return beta2; }
-
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
 
   //! Get the first quasi-hyperbolic term.
   double V1() const { return v1; }
@@ -109,7 +103,8 @@ class QHAdamUpdate
      * @param cols Number of columns in the gradient matrix.
      */
     Policy(QHAdamUpdate& parent, const size_t rows, const size_t cols) :
-        parent(parent)
+        parent(parent),
+        iteration(0)
     {
       m.zeros(rows, cols);
       v.zeros(rows, cols);
@@ -127,7 +122,7 @@ class QHAdamUpdate
                 const GradType& gradient)
     {
       // Increment the iteration counter variable.
-      ++parent.iteration;
+      ++iteration;
 
       // And update the iterate.
       m *= parent.beta1;
@@ -136,10 +131,8 @@ class QHAdamUpdate
       v *= parent.beta2;
       v += (1 - parent.beta2) * (gradient % gradient);
 
-      const double biasCorrection1 = 1.0 - std::pow(parent.beta1,
-          parent.iteration);
-      const double biasCorrection2 = 1.0 - std::pow(parent.beta2,
-          parent.iteration);
+      const double biasCorrection1 = 1.0 - std::pow(parent.beta1, iteration);
+      const double biasCorrection2 = 1.0 - std::pow(parent.beta2, iteration);
 
       GradType mDash = m / biasCorrection1;
       GradType vDash = v / biasCorrection2;
@@ -160,6 +153,9 @@ class QHAdamUpdate
 
     // The exponential moving average of squared gradient values.
     GradType v;
+
+    // The number of iterations.
+    size_t iteration;
   };
 
  private:
@@ -177,9 +173,6 @@ class QHAdamUpdate
 
   // The second quasi-hyperbolic term.
   double v2;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/yogi/yogi_update.hpp
+++ b/include/ensmallen_bits/yogi/yogi_update.hpp
@@ -53,8 +53,7 @@ class YogiUpdate
              const double beta2 = 0.999) :
     epsilon(epsilon),
     beta1(beta1),
-    beta2(beta2),
-    iteration(0)
+    beta2(beta2)
   {
     // Nothing to do.
   }
@@ -73,11 +72,6 @@ class YogiUpdate
   double Beta2() const { return beta2; }
   //! Modify the second moment coefficient.
   double& Beta2() { return beta2; }
-
-  //! Get the current iteration number.
-  size_t Iteration() const { return iteration; }
-  //! Modify the current iteration number.
-  size_t& Iteration() { return iteration; }
 
   /**
    * The UpdatePolicyType policy classes must contain an internal 'Policy'
@@ -115,16 +109,13 @@ class YogiUpdate
                 const double stepSize,
                 const GradType& gradient)
     {
-      // Increment the iteration counter variable.
-      ++parent.iteration;
-
       m *= parent.beta1;
       m += (1 - parent.beta1) * gradient;
 
       const MatType gSquared = arma::square(gradient);
       v -= (1 - parent.beta2) * arma::sign(v - gSquared) % gSquared;
 
-      // And update the iterate.
+      // Now update the iterate.
       iterate -= stepSize * m / (arma::sqrt(v) + parent.epsilon);
     }
 
@@ -148,9 +139,6 @@ class YogiUpdate
 
   // The second moment coefficient.
   double beta2;
-
-  // The number of iterations.
-  size_t iteration;
 };
 
 } // namespace ens


### PR DESCRIPTION
While testing some RNN support, I noticed that using `Adam` twice with `resetPolicy = true` did not produce the same results:

```
  ens::Adam optimizer(1e-5, 1, 0.9, 0.999, 1e-8, 200, 1e-8, false);

  ffn.Train(data.slice(0), responses.slice(0), optimizer);
  rnn.Train(data, responses, optimizer);
```

In this particular test case, that *should* produce the exact same results for `ffn` and `rnn`.  (It's easy to make an example that breaks in the same way.)

As it turns out, the issue is that even when `resetPolicy` is `true`, there is one member of `AdamUpdate` that doesn't get reset: the `iteration` counter.  Realistically, that should not be in the `AdamUpdate` class since it is specific to an optimization, but should instead be in the `AdamUpdate::Policy` class, which holds information specific to an individual optimization.

So, I went through all update policies with that pattern, and moved the `iteration` member into the child `Policy` class.