### PR TITLE
avoid deprecation warnings in armadillo 11.2+

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+* Avoid deprecation warning in Armadillo 11.2+
+   ([#347](https://github.com/mlpack/ensmallen/pull/347)).
 
 ### ensmallen 2.19.0: "Eight Ball Deluxe"
 ###### 2022-04-06

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
-* Avoid deprecation warning in Armadillo 11.2+
+* Avoid deprecation warnings in Armadillo 11.2+
    ([#347](https://github.com/mlpack/ensmallen/pull/347)).
 
 ### ensmallen 2.19.0: "Eight Ball Deluxe"

--- a/tests/frankwolfe_test.cpp
+++ b/tests/frankwolfe_test.cpp
@@ -28,8 +28,7 @@ TEST_CASE("FWOMPTest", "[FrankWolfeTest]")
   mat B1 = eye(3, 3);
   mat B2 = 0.1 * randn(3, k);
   mat A = join_horiz(B1, B2); // The dictionary is input as columns of A.
-  vec b;
-  b << 1 << 1 << 0; // Vector to be sparsely approximated.
+  vec b = {1.0, 1.0, 0.0}; // Vector to be sparsely approximated.
 
   FuncSq f(A, b);
   ConstrLpBallSolver linearConstrSolver(1);
@@ -85,14 +84,12 @@ TEST_CASE("FWPruneSupportOMP", "[FrankWolfeTest]")
 {
   // The dictionary is input as columns of A.
   const int k = 3;
-  mat B1;
-  B1 << 1 << 0 << 1 << endr
-     << 0 << 1 << 1 << endr
-     << 0 << 0 << 1 << endr;
+  mat B1 = { { 1.0, 0.0, 1.0 },
+             { 0.0, 1.0, 1.0 },
+             { 0.0, 0.0, 1.0 } };
   mat B2 = randu(k, k);
   mat A = join_horiz(B1, B2); // The dictionary is input as columns of A.
-  vec b;
-  b << 1 << 1 << 0; // Vector to be sparsely approximated.
+  vec b = { 1.0, 1.0, 0.0 }; // Vector to be sparsely approximated.
 
   FuncSq f(A, b);
   ConstrLpBallSolver linearConstrSolver(1);
@@ -115,8 +112,7 @@ TEST_CASE("FWAtomNormConstraint", "[FrankWolfeTest]")
   mat B1 = eye(3, 3);
   mat B2 = 0.1 * randn(3, k);
   mat A = join_horiz(B1, B2); // The dictionary is input as columns of A.
-  vec b;
-  b << 1 << 1 << 0; // Vector to be sparsely approximated.
+  vec b = { 1.0, 1.0, 0.0 }; // Vector to be sparsely approximated.
 
   FuncSq f(A, b);
   ConstrLpBallSolver linearConstrSolver(1);

--- a/tests/line_search_test.cpp
+++ b/tests/line_search_test.cpp
@@ -23,8 +23,7 @@ using namespace ens::test;
 TEST_CASE("FuncFWTest", "[LineSearchTest]")
 {
   mat x1 = zeros<mat>(3, 1);
-  mat x2;
-  x2 << 0.2 << 0.4 << 0.6;
+  mat x2 = { 0.2, 0.4, 0.6 };
   x2 = x2.t();
 
   TestFuncFW<> f;
@@ -44,8 +43,7 @@ TEST_CASE("FuncFWTest", "[LineSearchTest]")
 TEST_CASE("FuncFWFMatTest", "[LineSearchTest]")
 {
   fmat x1 = zeros<fmat>(3, 1);
-  fmat x2;
-  x2 << 0.2 << 0.4 << 0.6;
+  fmat x2 = { 0.2, 0.4, 0.6 };
   x2 = x2.t();
 
   TestFuncFW<arma::fmat> f;

--- a/tests/sdp_primal_dual_test.cpp
+++ b/tests/sdp_primal_dual_test.cpp
@@ -10,7 +10,10 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 
-#define ARMA_DONT_PRINT_ERRORS
+#if (ARMA_VERSION_MAJOR < 11)
+  #define ARMA_DONT_PRINT_ERRORS
+#endif
+
 #include <ensmallen.hpp>
 #include "catch.hpp"
 


### PR DESCRIPTION
`ARMA_DONT_PRINT_ERRORS` was originally added to prevent runtime warnings coming from `arma::eig_sym()` within the `CheckPositiveSemiDefinite()` function within tests/sdp_primal_dual_test.cpp.

Since Armadillo 10.4, `ARMA_DONT_PRINT_ERRORS` doesn't do anything, as failed decompositions no longer emit warnings by default.  (The warning level can be adjusted via `ARMA_WARN_LEVEL`.)

Since Armadillo 11.2+, a compile-time deprecation notice is emitted if `ARMA_DONT_PRINT_ERRORS` is defined.

Since Armadillo 11.2+, a compile-time deprecation notice is emitted if `operator<<` is used for matrix and vector initialisation.  The much more efficient C++11 initializer_lists can be used instead.
