### PR TITLE
Fix CNE test tolerances

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,14 +1,16 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Fix CNE test tolerances
+   ([#360](https://github.com/mlpack/ensmallen/pull/360)).
 
 ### ensmallen 2.19.1: "Eight Ball Deluxe"
 ###### 2023-01-30
-* Avoid deprecation warnings in Armadillo 11.2+
+ * Avoid deprecation warnings in Armadillo 11.2+
    ([#347](https://github.com/mlpack/ensmallen/pull/347)).
 
 ### ensmallen 2.19.0: "Eight Ball Deluxe"
 ###### 2022-04-06
-* Added DemonSGD and DemonAdam optimizers
+ * Added DemonSGD and DemonAdam optimizers
    ([#211](https://github.com/mlpack/ensmallen/pull/211)).
 
  * Fix bug with Adam-like optimizers not resetting when `resetPolicy` is `true`.

--- a/tests/cne_test.cpp
+++ b/tests/cne_test.cpp
@@ -96,11 +96,20 @@ TEST_CASE("CNEHimmelblauFunctionTest", "[CNETest]")
   HimmelblauFunction f;
   CNE optimizer(650, 3000, 0.3, 0.3, 0.3, 1e-7);
 
-  arma::mat coordinates = arma::mat("2; 1");
-  optimizer.Optimize(f, coordinates);
+  // Allow multiple trials.
+  arma::mat coordinates;
+  for (size_t trial = 0; trial < 3; ++trial)
+  {
+    coordinates = arma::mat("2; 1");
+    optimizer.Optimize(f, coordinates);
 
-  REQUIRE(coordinates(0) == Approx(3.0).margin(0.1));
-  REQUIRE(coordinates(1) == Approx(2.0).margin(0.1));
+    if (coordinates(0) == Approx(3.0).margin(0.6) &&
+        coordinates(1) == Approx(2.0).margin(0.2))
+      break;
+  }
+
+  REQUIRE(coordinates(0) == Approx(3.0).margin(0.6));
+  REQUIRE(coordinates(1) == Approx(2.0).margin(0.2));
 }
 
 /**

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -32,6 +32,7 @@ int main(int argc, char** argv)
   // if the keyword 'time' is provided then the result of calling std::time(0)
   // is used.
   const size_t seed = session.config().rngSeed();
+  std::cout << "random seed: " << seed << std::endl;
   srand((unsigned int) seed);
   arma::arma_rng::set_seed(seed);
 


### PR DESCRIPTION
In #359 it was pointed out that the `CNEHimmelblauFunctionTest` was failing on i386.  I investigated by running it (on x86_64) with tons of different random seeds, and found it failed about once every 80 or 90 runs.  So I adjusted the tolerances accordingly.

I also followed @conradsnicta's suggestion to print the random seed when running the tests.  (It can be set from the command-line with the `--rng-seed` option.)