### PR TITLE
add short list of example optimisers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ ensmallen provides many types of optimizers that can be used
 for virtually any numerical optimization task.
 This includes gradient descent techniques, gradient-free optimizers,
 and constrained optimization.
+Examples include L-BFGS, SGD, CMAES and Simulated Annealing.
 ensmallen also allows optional callbacks to customize the optimization process.
 
 Documentation and downloads: http://ensmallen.org


### PR DESCRIPTION
Add example optimisers to increase relevant keywords.

This increases the likelihood of ensmallen being found via web search (eg. users typing specific keywords into google).

The corresponding PR for ensmallen.org is at https://github.com/mlpack/ensmallen.org/pull/15
