### PR TITLE
undefine conflicting As macro

### DIFF
--- a/include/ensmallen_bits/config.hpp
+++ b/include/ensmallen_bits/config.hpp
@@ -71,3 +71,9 @@
 #else
   #define ens_deprecated
 #endif
+
+// undefine conflicting macros
+#if defined(As)
+  #pragma message ("WARNING: undefined conflicting 'As' macro")
+  #undef As
+#endif


### PR DESCRIPTION

TLDR; Undefine conflicting 'As' macro which interferes with ensmallen. This stems from https://github.com/mlpack/mlpack/issues/3501

Long story:  
Class Library for Numbers (CLN; https://www.ginac.de/CLN/) is used by several other projects for scientific computing.  With infinite wisdom, CLN defines a conflicting "As" macro.  This prevents ensmallen (and hence mlpack) from being used in conjunction with CLN or any other project that uses CLN.

The proper fix would be to correct the CLN source.  However, CLN has been around for a long while, and various old versions are vendored inside many projects and distributed in many linux distros.  Undefining the silly "As" macro handles old versions of CLN.

Offending code is on lines 269 and 274 in https://www.ginac.de/CLN/cln.git/?p=cln.git;a=blob;f=include/cln/number.h;h=67f68899a6926eca49722f012d0a20d159162c57;hb=HEAD#l269
