### PR TITLE
Fix callback return values and clarify docs

### DIFF
--- a/doc/callbacks.md
+++ b/doc/callbacks.md
@@ -424,18 +424,18 @@ std::cout << "The optimized model found by AdaDelta has the "
 Callbacks are called at several states during the optimization process:
 
 * At the beginning and end of the optimization process.
-* After any call to `Evaluate()` and `EvaluateConstraint`.
-* After any call to `Gradient()` and `GradientConstraint`.
+* After any call to `Evaluate()` and `EvaluateConstraint()`.
+* After any call to `Gradient()` and `GradientConstraint()`.
 * At the start and end of an epoch.
 
-Each callback provides optimization relevant information that can be accessed or
+Each callback provides optimization-relevant information that can be accessed or
 modified.
 
 ### BeginOptimization
 
 Called at the beginning of the optimization process.
 
- * `BeginOptimization(`_`optimizer, function, coordinates`_`)`
+ * `void BeginOptimization(`_`optimizer, function, coordinates`_`)`
 
 #### Attributes
 
@@ -449,7 +449,7 @@ Called at the beginning of the optimization process.
 
 Called at the end of the optimization process.
 
- * `EndOptimization(`_`optimizer, function, coordinates`_`)`
+ * `void EndOptimization(`_`optimizer, function, coordinates`_`)`
 
 #### Attributes
 
@@ -463,7 +463,9 @@ Called at the end of the optimization process.
 
 Called after any call to `Evaluate()`.
 
- * `Evaluate(`_`optimizer, function, coordinates, objective`_`)`
+ * `bool Evaluate(`_`optimizer, function, coordinates, objective`_`)`
+
+If the callback returns `true`, the optimization will be terminated.
 
 #### Attributes
 
@@ -476,9 +478,11 @@ Called after any call to `Evaluate()`.
 
 ### EvaluateConstraint
 
- Called after any call to `EvaluateConstraint()`.
+Called after any call to `EvaluateConstraint()`.
 
- * `EvaluateConstraint(`_`optimizer, function, coordinates, constraint, constraintValue`_`)`
+ * `bool EvaluateConstraint(`_`optimizer, function, coordinates, constraint, constraintValue`_`)`
+
+If the callback returns `true`, the optimization will be terminated.
 
 #### Attributes
 
@@ -492,9 +496,11 @@ Called after any call to `Evaluate()`.
 
 ### Gradient
 
- Called after any call to `Gradient()`.
+Called after any call to `Gradient()`.
 
- * `Gradient(`_`optimizer, function, coordinates, gradient`_`)`
+ * `bool Gradient(`_`optimizer, function, coordinates, gradient`_`)`
+
+If the callback returns `true`, the optimization will be terminated.
 
 #### Attributes
 
@@ -507,9 +513,11 @@ Called after any call to `Evaluate()`.
 
 ### GradientConstraint
 
- Called after any call to `GradientConstraint()`.
+Called after any call to `GradientConstraint()`.
 
- * `GradientConstraint(`_`optimizer, function, coordinates, constraint, gradient`_`)`
+ * `bool GradientConstraint(`_`optimizer, function, coordinates, constraint, gradient`_`)`
+
+If the callback returns `true`, the optimization will be terminated.
 
 #### Attributes
 
@@ -526,7 +534,9 @@ Called after any call to `Evaluate()`.
 Called at the beginning of a pass over the data. The objective may be exact or
 an estimate depending on `exactObjective` value.
 
- * `BeginEpoch(`_`optimizer, function, coordinates, epoch, objective`_`)`
+ * `bool BeginEpoch(`_`optimizer, function, coordinates, epoch, objective`_`)`
+
+If the callback returns `true`, the optimization will be terminated.
 
 #### Attributes
 
@@ -543,7 +553,9 @@ an estimate depending on `exactObjective` value.
 Called at the end of a pass over the data. The objective may be exact or
 an estimate depending on `exactObjective` value.
 
- * `EndEpoch(`_`optimizer, function, coordinates, epoch, objective`_`)`
+ * `bool EndEpoch(`_`optimizer, function, coordinates, epoch, objective`_`)`
+
+If the callback returns `true`, the optimization will be terminated.
 
 #### Attributes
 
@@ -560,7 +572,9 @@ an estimate depending on `exactObjective` value.
 Called after the evolution of a single generation. Intended specifically for
 MultiObjective Optimizers.
 
- * `GenerationalStepTaken(`_`optimizer, function, coordinates, objectives, frontIndices`_`)`
+ * `bool GenerationalStepTaken(`_`optimizer, function, coordinates, objectives, frontIndices`_`)`
+
+If the callback returns `true`, the optimization will be terminated.
 
 #### Attributes
 
@@ -615,7 +629,7 @@ class ExponentialDecay
   // Callback function called at the end of a pass over the data. We are only
   // interested in the current epoch and the optimizer, we ignore the rest.
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void EndEpoch(OptimizerType& optimizer,
+  bool EndEpoch(OptimizerType& optimizer,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 const size_t epoch,
@@ -624,6 +638,9 @@ class ExponentialDecay
     // Update the learning rate.
     optimizer.StepSize() = learningRate * (1.0 - std::pow(decay,
         (double) epoch));
+
+    // Do not terminate the optimization.
+    return false;
   }
 
   double learningRate;
@@ -695,7 +712,7 @@ class EarlyStop
   // the current objective. We are only interested in the objective and ignore
   // the rest.
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void EndEpoch(OptimizerType& /* optimizer */,
+  bool EndEpoch(OptimizerType& /* optimizer */,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 const size_t /* epoch */,

--- a/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
+++ b/include/ensmallen_bits/bigbatch_sgd/bigbatch_sgd_impl.hpp
@@ -104,7 +104,7 @@ BigBatchSGD<UpdatePolicyType>::Optimize(
   BaseGradType functionGradient(iterate.n_rows, iterate.n_cols);
   const size_t actualMaxIterations = (maxIterations == 0) ?
       std::numeric_limits<size_t>::max() : maxIterations;
-  terminate |= Callback::BeginOptimization(*this, f, iterate, callbacks...);
+  Callback::BeginOptimization(*this, f, iterate, callbacks...);
   for (size_t i = 0; i < actualMaxIterations && !terminate;
       /* incrementing done manually */)
   {
@@ -191,6 +191,9 @@ BigBatchSGD<UpdatePolicyType>::Optimize(
       }
     }
 
+    if (terminate)
+      break;
+
     instUpdatePolicy.As<InstUpdatePolicyType>().Update(f, stepSize, iterate,
         gradient, gB, vB, currentFunction, batchSize, effectiveBatchSize,
         reset);
@@ -229,9 +232,7 @@ BigBatchSGD<UpdatePolicyType>::Optimize(
         return overallObjective;
       }
 
-      if (std::abs(lastObjective - overallObjective) < tolerance ||
-          Callback::BeginEpoch(*this, f, iterate, epoch, overallObjective,
-              callbacks...))
+      if (std::abs(lastObjective - overallObjective) < tolerance)
       {
         Info << "Big-batch SGD: minimized within tolerance " << tolerance
             << "; terminating optimization." << std::endl;
@@ -239,6 +240,9 @@ BigBatchSGD<UpdatePolicyType>::Optimize(
         Callback::EndOptimization(*this, f, iterate, callbacks...);
         return overallObjective;
       }
+
+      terminate |= Callback::BeginEpoch(*this, f, iterate, epoch,
+          overallObjective, callbacks...);
 
       // Reset the counter variables.
       lastObjective = overallObjective;
@@ -250,8 +254,11 @@ BigBatchSGD<UpdatePolicyType>::Optimize(
     }
   }
 
-  Info << "Big-batch SGD: maximum iterations (" << maxIterations << ") "
-      << "reached; terminating optimization." << std::endl;
+  if (!terminate)
+  {
+    Info << "Big-batch SGD: maximum iterations (" << maxIterations << ") "
+        << "reached; terminating optimization." << std::endl;
+  }
 
   // Calculate final objective if exactObjective is set to true.
   if (exactObjective)
@@ -263,7 +270,9 @@ BigBatchSGD<UpdatePolicyType>::Optimize(
       const ElemType objective = f.Evaluate(iterate, i, effectiveBatchSize);
       overallObjective += objective;
 
-      Callback::Evaluate(*this, f, iterate, objective, callbacks...);
+      // The optimization is finished, so we don't need to care what the
+      // callback returns.
+      (void) Callback::Evaluate(*this, f, iterate, objective, callbacks...);
     }
   }
 

--- a/include/ensmallen_bits/cd/cd_impl.hpp
+++ b/include/ensmallen_bits/cd/cd_impl.hpp
@@ -67,8 +67,7 @@ CD<DescentPolicyType>::Optimize(
   bool terminate = false;
 
   // Start iterating.
-  terminate |= Callback::BeginOptimization(*this, function, iterate,
-      callbacks...);
+  Callback::BeginOptimization(*this, function, iterate, callbacks...);
   for (size_t i = 1; i != maxIterations && !terminate; ++i)
   {
     // Get the coordinate to descend on.
@@ -81,6 +80,8 @@ CD<DescentPolicyType>::Optimize(
 
     terminate |= Callback::Gradient(*this, function, iterate, overallObjective,
         gradient, callbacks...);
+    if (terminate)
+      break;
 
     // Update the decision variable with the partial gradient.
     iterate.col(featureIdx) -= stepSize * gradient.col(featureIdx);
@@ -122,9 +123,10 @@ CD<DescentPolicyType>::Optimize(
   Info << "CD: maximum iterations (" << maxIterations << ") reached; "
       << "terminating optimization." << std::endl;
 
-  // Calculate and return final objective.
+  // Calculate and return final objective.  No need to pay attention to the
+  // result of the callback.
   const ElemType objective = function.Evaluate(iterate);
-  Callback::Evaluate(*this, function, iterate, objective, callbacks...);
+  (void) Callback::Evaluate(*this, function, iterate, objective, callbacks...);
 
   Callback::EndOptimization(*this, function, iterate, callbacks...);
   return objective;

--- a/include/ensmallen_bits/cmaes/active_cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/active_cmaes_impl.hpp
@@ -130,6 +130,9 @@ typename MatType::elem_type ActiveCMAES<SelectionPolicyType,
 
   BaseMatType transformedIterate = transformationPolicy.Transform(iterate);
 
+  // Controls early termination of the optimization process.
+  bool terminate = false;
+
   // Calculate the first objective function.
   ElemType currentObjective = 0;
   for (size_t f = 0; f < numFunctions; f += batchSize)
@@ -139,8 +142,8 @@ typename MatType::elem_type ActiveCMAES<SelectionPolicyType,
         effectiveBatchSize);
     currentObjective += objective;
 
-    Callback::Evaluate(*this, function, transformedIterate, objective,
-        callbacks...);
+    terminate |= Callback::Evaluate(*this, function, transformedIterate,
+        objective, callbacks...);
   }
 
   ElemType overallObjective = currentObjective;
@@ -168,12 +171,9 @@ typename MatType::elem_type ActiveCMAES<SelectionPolicyType,
   // The current visitation order (sorted by population objectives).
   arma::uvec idx = arma::linspace<arma::uvec>(0, lambda - 1, lambda);
 
-  // Controls early termination of the optimization process.
-  bool terminate = false;
-
   // Now iterate!
-  terminate |= Callback::BeginOptimization(*this, function, 
-      transformedIterate, callbacks...);
+  Callback::BeginOptimization(*this, function, transformedIterate,
+      callbacks...);
 
   size_t idx0, idx1;
 
@@ -213,7 +213,8 @@ typename MatType::elem_type ActiveCMAES<SelectionPolicyType,
 
       // Calculate the objective function.
       pObjective(idx(j)) = selectionPolicy.Select(function, batchSize,
-          transformationPolicy.Transform(pPosition[idx(j)]), callbacks...);
+          transformationPolicy.Transform(pPosition[idx(j)]), terminate,
+          callbacks...);
     }
 
     // Sort population.
@@ -227,7 +228,8 @@ typename MatType::elem_type ActiveCMAES<SelectionPolicyType,
 
     // Calculate the objective function.
     currentObjective = selectionPolicy.Select(function, batchSize,
-      transformationPolicy.Transform(mPosition[idx1]), callbacks...);
+        transformationPolicy.Transform(mPosition[idx1]), terminate,
+        callbacks...);
 
     // Update best parameters.
     if (currentObjective < overallObjective)

--- a/include/ensmallen_bits/cmaes/full_selection.hpp
+++ b/include/ensmallen_bits/cmaes/full_selection.hpp
@@ -26,6 +26,7 @@ class FullSelection
    * @tparam SeparableFunctionType Type of the function to be evaluated.
    * @param function Function to optimize.
    * @param batchSize Batch size to use for each step.
+   * @param terminate Whether optimization should be terminated after this call.
    * @param iterate starting point.
    */
   template<typename SeparableFunctionType,
@@ -34,6 +35,7 @@ class FullSelection
   double Select(SeparableFunctionType& function,
                 const size_t batchSize,
                 const MatType& iterate,
+                bool& terminate,
                 CallbackTypes&... callbacks)
   {
     // Find the number of functions to use.
@@ -45,7 +47,8 @@ class FullSelection
       const size_t effectiveBatchSize = std::min(batchSize, numFunctions - f);
       objective += function.Evaluate(iterate, f, effectiveBatchSize);
 
-      Callback::Evaluate(*this, f, iterate, objective, callbacks...);
+      terminate |= Callback::Evaluate(*this, f, iterate, objective,
+          callbacks...);
     }
 
     return objective;

--- a/include/ensmallen_bits/cmaes/random_selection.hpp
+++ b/include/ensmallen_bits/cmaes/random_selection.hpp
@@ -41,6 +41,7 @@ class RandomSelection
    * @tparam SeparableFunctionType Type of the function to be evaluated.
    * @param function Function to optimize.
    * @param batchSize Batch size to use for each step.
+   * @param terminate Whether optimization should be terminated after this call.
    * @param iterate starting point.
    */
   template<typename SeparableFunctionType,
@@ -49,6 +50,7 @@ class RandomSelection
   double Select(SeparableFunctionType& function,
                 const size_t batchSize,
                 const MatType& iterate,
+                bool& terminate,
                 CallbackTypes&... callbacks)
   {
     // Find the number of functions to use.
@@ -64,7 +66,8 @@ class RandomSelection
 
       objective += function.Evaluate(iterate, selection, effectiveBatchSize);
 
-      Callback::Evaluate(*this, f, iterate, objective, callbacks...);
+      terminate |= Callback::Evaluate(*this, f, iterate, objective,
+          callbacks...);
     }
 
     return objective;

--- a/include/ensmallen_bits/cne/cne_impl.hpp
+++ b/include/ensmallen_bits/cne/cne_impl.hpp
@@ -111,26 +111,26 @@ typename MatType::elem_type CNE::Optimize(ArbitraryFunctionType& function,
 
   // Find the fitness before optimization using given iterate parameters.
   ElemType lastBestFitness = function.Evaluate(iterate);
-  Callback::Evaluate(*this, function, iterate, lastBestFitness, callbacks...);
+  terminate |= Callback::Evaluate(*this, function, iterate, lastBestFitness,
+      callbacks...);
 
   // Iterate until maximum number of generations is obtained.
-  terminate |= Callback::BeginOptimization(*this, function, iterate,
-      callbacks...);
+  Callback::BeginOptimization(*this, function, iterate, callbacks...);
   for (size_t gen = 1; gen <= maxGenerations && !terminate; gen++)
   {
     // Calculating fitness values of all candidates.
     for (size_t i = 0; i < populationSize; i++)
     {
-       // Select a candidate and insert the parameters in the function.
-       iterate = population[i];
-       terminate |= Callback::StepTaken(*this, function, iterate,
-          callbacks...);
+        // Select a candidate and insert the parameters in the function.
+        iterate = population[i];
+        terminate |= Callback::StepTaken(*this, function, iterate,
+            callbacks...);
 
-       // Find fitness of candidate.
-       fitnessValues[i] = function.Evaluate(iterate);
+        // Find fitness of candidate.
+        fitnessValues[i] = function.Evaluate(iterate);
 
-       Callback::Evaluate(*this, function, iterate, fitnessValues[i],
-          callbacks...);
+        terminate |= Callback::Evaluate(*this, function, iterate,
+            fitnessValues[i], callbacks...);
     }
 
     Info << "Generation number: " << gen << " best fitness = "
@@ -154,8 +154,10 @@ typename MatType::elem_type CNE::Optimize(ArbitraryFunctionType& function,
   // Set the best candidate into the network parameters.
   iterateIn = population[index(0)];
 
+  // The output of the callback doesn't matter because the optimization is
+  // finished.
   const ElemType objective = function.Evaluate(iterate);
-  Callback::Evaluate(*this, function, iterate, objective, callbacks...);
+  (void) Callback::Evaluate(*this, function, iterate, objective, callbacks...);
 
   Callback::EndOptimization(*this, function, iterate, callbacks...);
   return objective;

--- a/include/ensmallen_bits/de/de_impl.hpp
+++ b/include/ensmallen_bits/de/de_impl.hpp
@@ -77,8 +77,8 @@ typename MatType::elem_type DE::Optimize(FunctionType& function,
     population[i] += iterate;
     fitnessValues[i] = function.Evaluate(population[i]);
 
-    Callback::Evaluate(*this, function, population[i], fitnessValues[i],
-        callbacks...);
+    terminate |= Callback::Evaluate(*this, function, population[i],
+        fitnessValues[i], callbacks...);
 
     if (fitnessValues[i] < lastBestFitness)
     {
@@ -88,8 +88,7 @@ typename MatType::elem_type DE::Optimize(FunctionType& function,
   }
 
   // Iterate until maximum number of generations are completed.
-  terminate |= Callback::BeginOptimization(*this, function, iterate,
-      callbacks...);
+  Callback::BeginOptimization(*this, function, iterate, callbacks...);
   for (size_t gen = 0; gen < maxGenerations && !terminate; gen++)
   {
     // Generate new population based on /best/1/bin strategy.
@@ -126,10 +125,15 @@ typename MatType::elem_type DE::Optimize(FunctionType& function,
       }
 
       ElemType iterateValue = function.Evaluate(iterate);
-      Callback::Evaluate(*this, function, iterate, iterateValue, callbacks...);
+      terminate |= Callback::Evaluate(*this, function, iterate, iterateValue,
+          callbacks...);
 
       const ElemType mutantValue = function.Evaluate(mutant);
-      Callback::Evaluate(*this, function, mutant, mutantValue, callbacks...);
+      terminate |= Callback::Evaluate(*this, function, mutant, mutantValue,
+          callbacks...);
+
+      if (terminate)
+        break;
 
       // Replace the current member if mutant is better.
       if (mutantValue < iterateValue)

--- a/include/ensmallen_bits/fw/frank_wolfe_impl.hpp
+++ b/include/ensmallen_bits/fw/frank_wolfe_impl.hpp
@@ -75,7 +75,7 @@ FrankWolfe<LinearConstrSolverType, UpdateRuleType>::Optimize(
   // Controls early termination of the optimization process.
   bool terminate = false;
 
-  terminate |= Callback::BeginOptimization(*this, f, iterate, callbacks...);
+  Callback::BeginOptimization(*this, f, iterate, callbacks...);
   for (size_t i = 1; i != maxIterations && !terminate; ++i)
   {
     currentObjective = f.EvaluateWithGradient(iterate, gradient);

--- a/include/ensmallen_bits/gradient_descent/gradient_descent_impl.hpp
+++ b/include/ensmallen_bits/gradient_descent/gradient_descent_impl.hpp
@@ -66,7 +66,7 @@ GradientDescent::Optimize(FunctionType& function,
   bool terminate = false;
 
   // Now iterate!
-  terminate |= Callback::BeginOptimization(*this, f, iterate, callbacks...);
+  Callback::BeginOptimization(*this, f, iterate, callbacks...);
   for (size_t i = 1; i != maxIterations && !terminate; ++i)
   {
     overallObjective = f.EvaluateWithGradient(iterate, gradient);

--- a/include/ensmallen_bits/iqn/iqn_impl.hpp
+++ b/include/ensmallen_bits/iqn/iqn_impl.hpp
@@ -112,8 +112,7 @@ IQN::Optimize(SeparableFunctionType& functionIn,
   BaseGradType gradient(iterate.n_rows, iterate.n_cols);
   BaseMatType u = t[0];
 
-  terminate |= Callback::BeginOptimization(*this, function, iterate,
-      callbacks...);
+  Callback::BeginOptimization(*this, function, iterate, callbacks...);
   for (size_t i = 1; i != maxIterations && !terminate; ++i)
   {
     for (size_t j = 0, f = 0; f < numFunctions; j++)
@@ -175,7 +174,7 @@ IQN::Optimize(SeparableFunctionType& functionIn,
           effectiveBatchSize);
       overallObjective += objective;
 
-      Callback::Evaluate(*this, function, iterate, objective,
+      terminate |= Callback::Evaluate(*this, function, iterate, objective,
           callbacks...);
     }
     overallObjective /= numFunctions;

--- a/include/ensmallen_bits/katyusha/katyusha_impl.hpp
+++ b/include/ensmallen_bits/katyusha/katyusha_impl.hpp
@@ -112,8 +112,7 @@ KatyushaType<Proximal>::Optimize(
 
   const size_t actualMaxIterations = (maxIterations == 0) ?
       std::numeric_limits<size_t>::max() : maxIterations;
-  terminate |= Callback::BeginOptimization(*this, function, iterate,
-      callbacks...);
+  Callback::BeginOptimization(*this, function, iterate, callbacks...);
   for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     // Calculate the objective function.
@@ -125,7 +124,8 @@ KatyushaType<Proximal>::Optimize(
           effectiveBatchSize);
       overallObjective += objective;
 
-      Callback::Evaluate(*this, function, iterate0, objective, callbacks...);
+      terminate |= Callback::Evaluate(*this, function, iterate0, objective,
+          callbacks...);
     }
 
     if (std::isnan(overallObjective) || std::isinf(overallObjective))
@@ -174,7 +174,7 @@ KatyushaType<Proximal>::Optimize(
     double cw = 1;
     w.zeros();
 
-    for (size_t f = 0, currentFunction = 0; f < innerIterations;
+    for (size_t f = 0, currentFunction = 0; (f < innerIterations) && !terminate;
         /* incrementing done manually */)
     {
       // Is this iteration the start of a sequence?
@@ -254,7 +254,10 @@ KatyushaType<Proximal>::Optimize(
           effectiveBatchSize);
       overallObjective += objective;
 
-      Callback::Evaluate(*this, function, iterate, objective, callbacks...);
+      // The optimization is finished, so we don't need to care about the
+      // callback result.
+      (void) Callback::Evaluate(*this, function, iterate, objective,
+          callbacks...);
     }
   }
 

--- a/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
+++ b/include/ensmallen_bits/lbfgs/lbfgs_impl.hpp
@@ -400,7 +400,7 @@ L_BFGS::Optimize(FunctionType& function,
   ElemType prevFunctionValue;
 
   // The main optimization loop.
-  terminate |= Callback::BeginOptimization(*this, f, iterate, callbacks...);
+  Callback::BeginOptimization(*this, f, iterate, callbacks...);
   for (size_t itNum = 0; (optimizeUntilConvergence || (itNum != maxIterations))
       && !terminate; ++itNum)
   {

--- a/include/ensmallen_bits/lookahead/lookahead_impl.hpp
+++ b/include/ensmallen_bits/lookahead/lookahead_impl.hpp
@@ -133,7 +133,7 @@ Lookahead<BaseOptimizerType, DecayPolicyType>::Optimize(
   }
 
   // Now iterate!
-  terminate |= Callback::BeginOptimization(*this, f, iterate, callbacks...);
+  Callback::BeginOptimization(*this, f, iterate, callbacks...);
   const size_t actualMaxIterations = (maxIterations == 0) ?
       std::numeric_limits<size_t>::max() : maxIterations;
   for (size_t i = 0; i < actualMaxIterations && !terminate; i++)
@@ -198,7 +198,9 @@ Lookahead<BaseOptimizerType, DecayPolicyType>::Optimize(
       const ElemType objective = f.Evaluate(iterate, i, effectiveBatchSize);
       overallObjective += objective;
 
-      Callback::Evaluate(*this, f, iterate, objective, callbacks...);
+      // The optimization is over, so we don't need to care about the result of
+      // the callback.
+      (void) Callback::Evaluate(*this, f, iterate, objective, callbacks...);
     }
   }
 

--- a/include/ensmallen_bits/moead/moead_impl.hpp
+++ b/include/ensmallen_bits/moead/moead_impl.hpp
@@ -188,7 +188,7 @@ Optimize(std::tuple<ArbitraryFunctionType...>& objectives,
   for (const arma::Col<ElemType>& individualFitness : populationFitness)
     idealPoint = arma::min(idealPoint, individualFitness);
 
-  terminate |= Callback::BeginOptimization(*this, objectives, iterate, callbacks...);
+  Callback::BeginOptimization(*this, objectives, iterate, callbacks...);
 
   // 2 The main loop.
   for (size_t generation = 1; generation <= maxGenerations && !terminate; ++generation)

--- a/include/ensmallen_bits/nsga2/nsga2_impl.hpp
+++ b/include/ensmallen_bits/nsga2/nsga2_impl.hpp
@@ -141,7 +141,7 @@ typename MatType::elem_type NSGA2::Optimize(
   Info << "NSGA2 initialized successfully. Optimization started." << std::endl;
 
   // Iterate until maximum number of generations is obtained.
-  terminate |= Callback::BeginOptimization(*this, objectives, iterate, callbacks...);
+  Callback::BeginOptimization(*this, objectives, iterate, callbacks...);
 
   for (size_t generation = 1; generation <= maxGenerations && !terminate; generation++)
   {

--- a/include/ensmallen_bits/parallel_sgd/parallel_sgd_impl.hpp
+++ b/include/ensmallen_bits/parallel_sgd/parallel_sgd_impl.hpp
@@ -98,8 +98,7 @@ typename MatType::elem_type>::type ParallelSGD<DecayPolicyType>::Optimize(
   // Iterate till the objective is within tolerance or the maximum number of
   // allowed iterations is reached. If maxIterations is 0, this will iterate
   // till convergence.
-  terminate |= Callback::BeginOptimization(*this, function, iterate,
-      callbacks...);
+  Callback::BeginOptimization(*this, function, iterate, callbacks...);
   for (size_t i = 1; i != maxIterations && !terminate; ++i)
   {
     // Calculate the overall objective.

--- a/include/ensmallen_bits/sa/sa.hpp
+++ b/include/ensmallen_bits/sa/sa.hpp
@@ -179,9 +179,10 @@ class SA
    * @param idx Current parameter to modify.
    * @param sweepCounter Current counter representing how many sweeps have been
    *      completed.
+   * @return Whether the optimization should be terminated.
    */
   template<typename FunctionType, typename MatType, typename... CallbackTypes>
-  void GenerateMove(FunctionType& function,
+  bool GenerateMove(FunctionType& function,
                     MatType& iterate,
                     MatType& accept,
                     MatType& moveSize,

--- a/include/ensmallen_bits/sdp/primal_dual_impl.hpp
+++ b/include/ensmallen_bits/sdp/primal_dual_impl.hpp
@@ -309,8 +309,7 @@ typename MatType::elem_type PrimalDualSolver::Optimize(
   bool terminate = false;
 
   typename SDPType::ElemType primalObj = 0., alpha, beta;
-  terminate |= Callback::BeginOptimization(*this, sdp, coordinates,
-      callbacks...);
+  Callback::BeginOptimization(*this, sdp, coordinates, callbacks...);
   for (size_t iteration = 1; iteration != maxIterations && !terminate;
       iteration++)
   {

--- a/include/ensmallen_bits/sgd/sgd_impl.hpp
+++ b/include/ensmallen_bits/sgd/sgd_impl.hpp
@@ -124,7 +124,7 @@ SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
   BaseGradType gradient(iterate.n_rows, iterate.n_cols);
   const size_t actualMaxIterations = (maxIterations == 0) ?
       std::numeric_limits<size_t>::max() : maxIterations;
-  terminate |= Callback::BeginOptimization(*this, f, iterate, callbacks...);
+  Callback::BeginOptimization(*this, f, iterate, callbacks...);
   terminate |= Callback::BeginEpoch(*this, f, iterate, epoch,
       overallObjective, callbacks...);
   for (size_t i = 0; i < actualMaxIterations && !terminate;
@@ -181,9 +181,7 @@ SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
         return overallObjective;
       }
 
-      if (std::abs(lastObjective - overallObjective) < tolerance ||
-          Callback::BeginEpoch(*this, f, iterate, epoch, overallObjective,
-              callbacks...))
+      if (std::abs(lastObjective - overallObjective) < tolerance)
       {
         Info << "SGD: minimized within tolerance " << tolerance << "; "
             << "terminating optimization." << std::endl;
@@ -191,6 +189,9 @@ SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
         Callback::EndOptimization(*this, f, iterate, callbacks...);
         return overallObjective;
       }
+
+      terminate |= Callback::BeginEpoch(*this, f, iterate, epoch,
+          overallObjective, callbacks...);
 
       // Reset the counter variables.
       lastObjective = overallObjective;
@@ -202,8 +203,11 @@ SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
     }
   }
 
-  Info << "SGD: maximum iterations (" << maxIterations << ") reached; "
-      << "terminating optimization." << std::endl;
+  if (!terminate)
+  {
+    Info << "SGD: maximum iterations (" << maxIterations << ") reached; "
+        << "terminating optimization." << std::endl;
+  }
 
   // Calculate final objective if exactObjective is set to true.
   if (exactObjective)
@@ -215,7 +219,9 @@ SGD<UpdatePolicyType, DecayPolicyType>::Optimize(
       const ElemType objective = f.Evaluate(iterate, i, effectiveBatchSize);
       overallObjective += objective;
 
-      Callback::Evaluate(*this, f, iterate, objective, callbacks...);
+      // The optimization is over, so it doesn't matter what the callback
+      // returns.
+      (void) Callback::Evaluate(*this, f, iterate, objective, callbacks...);
     }
   }
 

--- a/include/ensmallen_bits/svrg/svrg_impl.hpp
+++ b/include/ensmallen_bits/svrg/svrg_impl.hpp
@@ -129,8 +129,7 @@ SVRGType<UpdatePolicyType, DecayPolicyType>::Optimize(
 
   const size_t actualMaxIterations = (maxIterations == 0) ?
       std::numeric_limits<size_t>::max() : maxIterations;
-  terminate |= Callback::BeginOptimization(*this, function, iterate,
-      callbacks...);
+  Callback::BeginOptimization(*this, function, iterate, callbacks...);
   for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     // Calculate the objective function.
@@ -140,9 +139,13 @@ SVRGType<UpdatePolicyType, DecayPolicyType>::Optimize(
       const size_t effectiveBatchSize = std::min(batchSize, numFunctions - f);
       const ElemType objective = function.Evaluate(iterate, f,
           effectiveBatchSize);
-      Callback::Evaluate(*this, function, iterate, objective, callbacks...);
+      terminate |= Callback::Evaluate(*this, function, iterate, objective,
+          callbacks...);
       overallObjective += objective;
     }
+
+    if (terminate)
+      break;
 
     if (std::isnan(overallObjective) || std::isinf(overallObjective))
     {
@@ -187,6 +190,8 @@ SVRGType<UpdatePolicyType, DecayPolicyType>::Optimize(
       f += effectiveBatchSize;
     }
     fullGradient /= (double) numFunctions;
+    if (terminate)
+      break;
 
     // Store current parameter for the calculation of the variance reduced
     // gradient.
@@ -219,6 +224,9 @@ SVRGType<UpdatePolicyType, DecayPolicyType>::Optimize(
       terminate |= Callback::Gradient(*this, function, iterate0, gradient0,
         callbacks...);
 
+      if (terminate)
+        break;
+
       // Use the update policy to take a step.
       instUpdatePolicy.As<InstUpdatePolicyType>().Update(iterate, fullGradient,
           gradient, gradient0, effectiveBatchSize, stepSize);
@@ -248,7 +256,10 @@ SVRGType<UpdatePolicyType, DecayPolicyType>::Optimize(
           effectiveBatchSize);
       overallObjective += objective;
 
-      Callback::Evaluate(*this, function, iterate, objective, callbacks...);
+      // The optimization is finished, so it doesn't matter what the callback
+      // returns.
+      (void) Callback::Evaluate(*this, function, iterate, objective,
+          callbacks...);
     }
   }
 


### PR DESCRIPTION
This is a sibling PR to #382 and part of fixing #377.

I went through and audited the code to find places where the return values of callback functions were being ignored.  I modified optimizers as necessary to handle those return values, attempting to terminate optimization before any more steps were taken.

I also modified the documentation to clarify that `bool`s should be returned.  However, for `BeginOptimization()` and `EndOptimization()` returning a `bool` doesn't make sense---so I made those return `void`.

In a couple places there were various other cleanups that I did, but nothing that affected functionality in any real way unrelated to callbacks.

Once this is done/merged, I also plan to update the technical report's section on callbacks and re-upload to arXiv.