### PR TITLE
Fix some callbacks that ignored return values

### DIFF
--- a/include/ensmallen_bits/callbacks/callbacks.hpp
+++ b/include/ensmallen_bits/callbacks/callbacks.hpp
@@ -67,9 +67,7 @@ class Callback
            typename MatType>
   static typename std::enable_if<
       callbacks::traits::HasBeginOptimizationSignature<
-      // Check for boolean return values anyway, for older ensmallen callbacks.
-      // (The return value is ignored.)
-      CallbackType, OptimizerType, FunctionType, MatType>::hasBool,
+      CallbackType, OptimizerType, FunctionType, MatType>::value,
       void>::type
   BeginOptimizationFunction(CallbackType& callback,
                             OptimizerType& optimizer,
@@ -85,25 +83,8 @@ class Callback
            typename FunctionType,
            typename MatType>
   static typename std::enable_if<
-      callbacks::traits::HasBeginOptimizationSignature<
-      CallbackType, OptimizerType, FunctionType, MatType>::hasVoid,
-      void>::type
-  BeginOptimizationFunction(CallbackType& callback,
-                            OptimizerType& optimizer,
-                            FunctionType& function,
-                            MatType& coordinates)
-  {
-    const_cast<CallbackType&>(callback).BeginOptimization(optimizer, function,
-        coordinates);
-  }
-
-  template<typename CallbackType,
-           typename OptimizerType,
-           typename FunctionType,
-           typename MatType>
-  static typename std::enable_if<
-      callbacks::traits::HasBeginOptimizationSignature<
-      CallbackType, OptimizerType, FunctionType, MatType>::hasNone,
+      !callbacks::traits::HasBeginOptimizationSignature<
+      CallbackType, OptimizerType, FunctionType, MatType>::value,
       void>::type
   BeginOptimizationFunction(CallbackType& /* callback */,
                             OptimizerType& /* optimizer */,
@@ -175,7 +156,8 @@ class Callback
            typename OptimizerType,
            typename FunctionType,
            typename MatType>
-  static typename std::enable_if<!callbacks::traits::HasEndOptimizationSignature<
+  static typename std::enable_if<
+      !callbacks::traits::HasEndOptimizationSignature<
       CallbackType, OptimizerType, FunctionType, MatType>::value,
       void>::type
   EndOptimizationFunction(CallbackType& /* callback */,
@@ -234,7 +216,7 @@ class Callback
            typename FunctionType,
            typename MatType>
   static typename std::enable_if<callbacks::traits::HasEvaluateSignature<
-      CallbackType, OptimizerType, FunctionType, MatType>::value,
+      CallbackType, OptimizerType, FunctionType, MatType>::hasBool,
       bool>::type
   EvaluateFunction(CallbackType& callback,
                    OptimizerType& optimizer,
@@ -242,16 +224,34 @@ class Callback
                    const MatType& coordinates,
                    const double objective)
   {
-    return (const_cast<CallbackType&>(callback).Evaluate(
-        optimizer, function, coordinates, objective), false);
+    return const_cast<CallbackType&>(callback).Evaluate(optimizer, function,
+        coordinates, objective);
   }
 
   template<typename CallbackType,
            typename OptimizerType,
            typename FunctionType,
            typename MatType>
-  static typename std::enable_if<!callbacks::traits::HasEvaluateSignature<
-      CallbackType, OptimizerType, FunctionType, MatType>::value,
+  static typename std::enable_if<callbacks::traits::HasEvaluateSignature<
+      CallbackType, OptimizerType, FunctionType, MatType>::hasVoid,
+      bool>::type
+  EvaluateFunction(CallbackType& callback,
+                   OptimizerType& optimizer,
+                   FunctionType& function,
+                   const MatType& coordinates,
+                   const double objective)
+  {
+    const_cast<CallbackType&>(callback).Evaluate(optimizer, function,
+        coordinates, objective);
+    return false;
+  }
+
+  template<typename CallbackType,
+           typename OptimizerType,
+           typename FunctionType,
+           typename MatType>
+  static typename std::enable_if<callbacks::traits::HasEvaluateSignature<
+      CallbackType, OptimizerType, FunctionType, MatType>::hasNone,
       bool>::type
   EvaluateFunction(CallbackType& /* callback */,
                    OptimizerType& /* optimizer */,
@@ -304,7 +304,7 @@ class Callback
            typename MatType>
   static typename std::enable_if<
       callbacks::traits::HasEvaluateConstraintSignature<
-      CallbackType, OptimizerType, FunctionType, MatType>::value,
+      CallbackType, OptimizerType, FunctionType, MatType>::hasBool,
       bool>::type
   EvaluateConstraintFunction(CallbackType& callback,
                              OptimizerType& optimizer,
@@ -313,8 +313,8 @@ class Callback
                              const size_t constraint,
                              const double constraintValue)
   {
-    return (const_cast<CallbackType&>(callback).EvaluateConstraint(
-        optimizer, function, coordinates, constraint, constraintValue), false);
+    return const_cast<CallbackType&>(callback).EvaluateConstraint(
+        optimizer, function, coordinates, constraint, constraintValue);
   }
 
   template<typename CallbackType,
@@ -322,8 +322,28 @@ class Callback
            typename FunctionType,
            typename MatType>
   static typename std::enable_if<
-      !callbacks::traits::HasEvaluateConstraintSignature<
-      CallbackType, OptimizerType, FunctionType, MatType>::value,
+      callbacks::traits::HasEvaluateConstraintSignature<
+      CallbackType, OptimizerType, FunctionType, MatType>::hasVoid,
+      bool>::type
+  EvaluateConstraintFunction(CallbackType& callback,
+                             OptimizerType& optimizer,
+                             FunctionType& function,
+                             const MatType& coordinates,
+                             const size_t constraint,
+                             const double constraintValue)
+  {
+    const_cast<CallbackType&>(callback).EvaluateConstraint(
+        optimizer, function, coordinates, constraint, constraintValue);
+    return false;
+  }
+
+  template<typename CallbackType,
+           typename OptimizerType,
+           typename FunctionType,
+           typename MatType>
+  static typename std::enable_if<
+      callbacks::traits::HasEvaluateConstraintSignature<
+      CallbackType, OptimizerType, FunctionType, MatType>::hasNone,
       bool>::type
   EvaluateConstraintFunction(CallbackType& /* callback */,
                              OptimizerType& /* optimizer */,
@@ -380,7 +400,7 @@ class Callback
            typename MatType,
            typename GradType>
   static typename std::enable_if<callbacks::traits::HasGradientSignature<
-      CallbackType, OptimizerType, FunctionType, MatType, GradType>::value,
+      CallbackType, OptimizerType, FunctionType, MatType, GradType>::hasBool,
       bool>::type
   GradientFunction(CallbackType& callback,
                    OptimizerType& optimizer,
@@ -388,8 +408,8 @@ class Callback
                    const MatType& coordinates,
                    GradType& gradient)
   {
-    return (const_cast<CallbackType&>(callback).Gradient(
-        optimizer, function, coordinates, gradient), false);
+    return const_cast<CallbackType&>(callback).Gradient(optimizer, function,
+        coordinates, gradient);
   }
 
   template<typename CallbackType,
@@ -397,8 +417,27 @@ class Callback
            typename FunctionType,
            typename MatType,
            typename GradType>
-  static typename std::enable_if<!callbacks::traits::HasGradientSignature<
-      CallbackType, OptimizerType, FunctionType, MatType, GradType>::value,
+  static typename std::enable_if<callbacks::traits::HasGradientSignature<
+      CallbackType, OptimizerType, FunctionType, MatType, GradType>::hasVoid,
+      bool>::type
+  GradientFunction(CallbackType& callback,
+                   OptimizerType& optimizer,
+                   FunctionType& function,
+                   const MatType& coordinates,
+                   GradType& gradient)
+  {
+    const_cast<CallbackType&>(callback).Gradient(
+        optimizer, function, coordinates, gradient);
+    return false;
+  }
+
+  template<typename CallbackType,
+           typename OptimizerType,
+           typename FunctionType,
+           typename MatType,
+           typename GradType>
+  static typename std::enable_if<callbacks::traits::HasGradientSignature<
+      CallbackType, OptimizerType, FunctionType, MatType, GradType>::hasNone,
       bool>::type
   GradientFunction(CallbackType& /* callback */,
                    OptimizerType& /* optimizer */,
@@ -451,7 +490,7 @@ class Callback
            typename GradType>
   static typename std::enable_if<
       callbacks::traits::HasGradientConstraintSignature<
-      CallbackType, OptimizerType, FunctionType, MatType, GradType>::value,
+      CallbackType, OptimizerType, FunctionType, MatType, GradType>::hasBool,
       bool>::type
   GradientConstraintFunction(CallbackType& callback,
                              OptimizerType& optimizer,
@@ -460,8 +499,8 @@ class Callback
                              const size_t constraint,
                              GradType& gradient)
   {
-    return (const_cast<CallbackType&>(callback).GradientConstraint(
-        optimizer, function, coordinates, constraint, gradient), false);
+    return const_cast<CallbackType&>(callback).GradientConstraint(optimizer,
+        function, coordinates, constraint, gradient);
   }
 
   template<typename CallbackType,
@@ -470,8 +509,29 @@ class Callback
            typename MatType,
            typename GradType>
   static typename std::enable_if<
-      !callbacks::traits::HasGradientConstraintSignature<
-      CallbackType, OptimizerType, FunctionType, MatType, GradType>::value,
+      callbacks::traits::HasGradientConstraintSignature<
+      CallbackType, OptimizerType, FunctionType, MatType, GradType>::hasVoid,
+      bool>::type
+  GradientConstraintFunction(CallbackType& callback,
+                             OptimizerType& optimizer,
+                             FunctionType& function,
+                             const MatType& coordinates,
+                             const size_t constraint,
+                             GradType& gradient)
+  {
+    const_cast<CallbackType&>(callback).GradientConstraint(
+        optimizer, function, coordinates, constraint, gradient);
+    return false;
+  }
+
+  template<typename CallbackType,
+           typename OptimizerType,
+           typename FunctionType,
+           typename MatType,
+           typename GradType>
+  static typename std::enable_if<
+      callbacks::traits::HasGradientConstraintSignature<
+      CallbackType, OptimizerType, FunctionType, MatType, GradType>::hasNone,
       bool>::type
   GradientConstraintFunction(CallbackType& /* callback */,
                              OptimizerType& /* optimizer */,
@@ -563,7 +623,7 @@ class Callback
            typename FunctionType,
            typename MatType>
   static typename std::enable_if<callbacks::traits::HasBeginEpochSignature<
-      CallbackType, OptimizerType, FunctionType, MatType>::value, bool>::type
+      CallbackType, OptimizerType, FunctionType, MatType>::hasBool, bool>::type
   BeginEpochFunction(CallbackType& callback,
                      OptimizerType& optimizer,
                      FunctionType& function,
@@ -571,16 +631,34 @@ class Callback
                      const size_t epoch,
                      const double objective)
   {
-    return (const_cast<CallbackType&>(callback).BeginEpoch(
-        optimizer, function, coordinates, epoch, objective), false);
+    return const_cast<CallbackType&>(callback).BeginEpoch(
+        optimizer, function, coordinates, epoch, objective);
   }
 
   template<typename CallbackType,
            typename OptimizerType,
            typename FunctionType,
            typename MatType>
-  static typename std::enable_if<!callbacks::traits::HasBeginEpochSignature<
-      CallbackType, OptimizerType, FunctionType, MatType>::value, bool>::type
+  static typename std::enable_if<callbacks::traits::HasBeginEpochSignature<
+      CallbackType, OptimizerType, FunctionType, MatType>::hasVoid, bool>::type
+  BeginEpochFunction(CallbackType& callback,
+                     OptimizerType& optimizer,
+                     FunctionType& function,
+                     const MatType& coordinates,
+                     const size_t epoch,
+                     const double objective)
+  {
+    const_cast<CallbackType&>(callback).BeginEpoch(
+        optimizer, function, coordinates, epoch, objective);
+    return false;
+  }
+
+  template<typename CallbackType,
+           typename OptimizerType,
+           typename FunctionType,
+           typename MatType>
+  static typename std::enable_if<callbacks::traits::HasBeginEpochSignature<
+      CallbackType, OptimizerType, FunctionType, MatType>::hasNone, bool>::type
   BeginEpochFunction(CallbackType& /* callback  */,
                      OptimizerType& /* optimizer */,
                      FunctionType& /* function  */,
@@ -768,6 +846,32 @@ class Callback
                     MatType& /* coordinates */)
   { return false; }
 
+  /**
+   * Iterate over the callbacks and invoke the StepTaken() callback if it
+   * exists.
+   *
+   * @param optimizer The optimizer used to update the function.
+   * @param function Function to optimize.
+   * @param coordinates Starting point.
+   * @param callbacks The callbacks container.
+   */
+  template<typename OptimizerType,
+           typename FunctionType,
+           typename MatType,
+           typename... CallbackTypes>
+  static bool StepTaken(OptimizerType& optimizer,
+                        FunctionType& function,
+                        MatType& coordinates,
+                        CallbackTypes&... callbacks)
+  {
+    // This will return immediately once a callback returns true.
+    bool result = false;
+    (void)std::initializer_list<bool>{ result =
+        result || Callback::StepTakenFunction(callbacks, optimizer,
+            function, coordinates)... };
+     return result;
+  }
+
  /**
   * Invoke the GenerationalStepTaken() callback if it exists.
   * Specialization for MultiObjective case.
@@ -819,7 +923,6 @@ class Callback
   {
     const_cast<CallbackType&>(callback).GenerationalStepTaken(
         optimizer, function, coordinates, objectives, frontIndices);
-
     return false;
   }
 
@@ -840,32 +943,6 @@ class Callback
                                 ObjectivesVecType& /* objectives */,
                                 IndicesType& /* frontIndices */)
   { return false; }
-
-  /**
-   * Iterate over the callbacks and invoke the StepTaken() callback if it
-   * exists.
-   *
-   * @param optimizer The optimizer used to update the function.
-   * @param function Function to optimize.
-   * @param coordinates Starting point.
-   * @param callbacks The callbacks container.
-   */
-  template<typename OptimizerType,
-           typename FunctionType,
-           typename MatType,
-           typename... CallbackTypes>
-  static bool StepTaken(OptimizerType& optimizer,
-                        FunctionType& function,
-                        MatType& coordinates,
-                        CallbackTypes&... callbacks)
-  {
-    // This will return immediately once a callback returns true.
-    bool result = false;
-    (void)std::initializer_list<bool>{ result =
-        result || Callback::StepTakenFunction(callbacks, optimizer,
-            function, coordinates)... };
-     return result;
-  }
 
   /**
    * Iterate over the callbacks and invoke the GenerationalStepTaken() callback if it

--- a/include/ensmallen_bits/callbacks/early_stop_at_min_loss.hpp
+++ b/include/ensmallen_bits/callbacks/early_stop_at_min_loss.hpp
@@ -33,8 +33,8 @@ class EarlyStopAtMinLossType
    *    been reached or no improvement has been made (Default: 10).
    */
   EarlyStopAtMinLossType(const size_t patienceIn = 10) :
-      callbackUsed(false), 
-      patience(patienceIn), 
+      callbackUsed(false),
+      patience(patienceIn),
       bestObjective(std::numeric_limits<double>::max()),
       steps(0)
   { /* Nothing to do here */ }
@@ -50,10 +50,10 @@ class EarlyStopAtMinLossType
   EarlyStopAtMinLossType(
       std::function<double(const MatType&)> func,
       const size_t patienceIn = 10)
-    : callbackUsed(true), 
-      patience(patienceIn), 
+    : callbackUsed(true),
+      patience(patienceIn),
       bestObjective(std::numeric_limits<double>::max()),
-      steps(0), 
+      steps(0),
       localFunc(func)
   {
     // Nothing to do here
@@ -78,7 +78,7 @@ class EarlyStopAtMinLossType
     if (callbackUsed)
     {
       objective = localFunc(coordinates);
-    } 
+    }
 
     if (objective < bestObjective)
     {
@@ -98,7 +98,8 @@ class EarlyStopAtMinLossType
   }
 
  private:
-  //! False if the first constructor is called, true if the user passed a lambda. 
+  //! False if the first constructor is called, true if the user passed a
+  //! lambda.
   bool callbackUsed;
 
   //! The number of epochs to wait before terminating the optimization process.

--- a/include/ensmallen_bits/callbacks/grad_clip_by_norm.hpp
+++ b/include/ensmallen_bits/callbacks/grad_clip_by_norm.hpp
@@ -40,7 +40,7 @@ class GradClipByNorm
    * @param gradient Matrix that holds the gradient.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void Gradient(OptimizerType& /* optimizer */,
+  bool Gradient(OptimizerType& /* optimizer */,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 MatType& gradient)
@@ -48,6 +48,7 @@ class GradClipByNorm
     const double gradientNorm = arma::norm(gradient);
     if (gradientNorm > maxNorm)
       gradient = maxNorm * gradient / gradientNorm;
+    return false;
   }
 
  private:

--- a/include/ensmallen_bits/callbacks/grad_clip_by_value.hpp
+++ b/include/ensmallen_bits/callbacks/grad_clip_by_value.hpp
@@ -39,12 +39,13 @@ class GradClipByValue
    * @param gradient Matrix that holds the gradient.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void Gradient(OptimizerType& /* optimizer */,
+  bool Gradient(OptimizerType& /* optimizer */,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 MatType& gradient)
   {
     gradient = arma::clamp(gradient, lower, upper);
+    return false;
   }
 
  private:

--- a/include/ensmallen_bits/callbacks/print_loss.hpp
+++ b/include/ensmallen_bits/callbacks/print_loss.hpp
@@ -38,13 +38,14 @@ class PrintLoss
    * @param objective Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void EndEpoch(OptimizerType& /* optimizer */,
+  bool EndEpoch(OptimizerType& /* optimizer */,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 const size_t /* epoch */,
                 const double objective)
   {
     output << objective << std::endl;
+    return false;
   }
 
  private:

--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -98,7 +98,7 @@ class ProgressBar
    * @param objective Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void BeginEpoch(OptimizerType& /* optimizer */,
+  bool BeginEpoch(OptimizerType& /* optimizer */,
                   FunctionType& /* function */,
                   const MatType& /* coordinates */,
                   const size_t epochIn,
@@ -113,6 +113,8 @@ class ProgressBar
 
     epoch = epochIn;
     newEpoch = true;
+
+    return false;
   }
 
   /**
@@ -124,7 +126,7 @@ class ProgressBar
    * @param objective Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void StepTaken(OptimizerType& /* optimizer */,
+  bool StepTaken(OptimizerType& /* optimizer */,
                  FunctionType& /* function */,
                  const MatType& /* coordinates */)
   {
@@ -163,6 +165,8 @@ class ProgressBar
     output.flush();
 
     stepTimer.tic();
+
+    return false;
   }
 
   /**
@@ -174,13 +178,14 @@ class ProgressBar
    * @param objectiveIn Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void Evaluate(OptimizerType& optimizer,
+  bool Evaluate(OptimizerType& optimizer,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 const double objectiveIn)
   {
     objective += objectiveIn / optimizer.BatchSize();
     steps++;
+    return false;
   }
 
   /**
@@ -193,7 +198,7 @@ class ProgressBar
    * @param objective Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void EndEpoch(OptimizerType& /* optimizer */,
+  bool EndEpoch(OptimizerType& /* optimizer */,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 const size_t /* epoch */,
@@ -221,6 +226,7 @@ class ProgressBar
     output << "] " << progress << "% - " << epochTimerElapsed
         << "s/epoch; " << stepTime << "ms/step; loss: " << objective  <<  "\n";
     output.flush();
+    return false;
   }
 
  private:

--- a/include/ensmallen_bits/callbacks/report.hpp
+++ b/include/ensmallen_bits/callbacks/report.hpp
@@ -239,13 +239,14 @@ class Report
    * @param objective Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void BeginEpoch(OptimizerType& /* optimizer */,
+  bool BeginEpoch(OptimizerType& /* optimizer */,
                   FunctionType& /* function */,
                   const MatType& /* coordinates */,
                   const size_t /* epoch */,
                   const double /* objective */)
   {
     epochCalls++;
+    return false;
   }
 
   /**
@@ -258,7 +259,7 @@ class Report
    * @param objective Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void EndEpoch(OptimizerType& optimizer,
+  bool EndEpoch(OptimizerType& optimizer,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 const size_t /* epoch */,
@@ -282,6 +283,7 @@ class Report
       gradientsNorm.push_back(gradientNorm);
 
     SaveStepSize(optimizer);
+    return false;
   }
 
   /**
@@ -293,7 +295,7 @@ class Report
    * @param objective Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void StepTaken(OptimizerType& optimizer,
+  bool StepTaken(OptimizerType& optimizer,
                  FunctionType& /* function */,
                  const MatType& /* coordinates */)
   {
@@ -307,6 +309,7 @@ class Report
 
       SaveStepSize(optimizer);
     }
+    return false;
   }
 
   /**
@@ -318,13 +321,14 @@ class Report
    * @param objectiveIn Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void Evaluate(OptimizerType& /* optimizer */,
+  bool Evaluate(OptimizerType& /* optimizer */,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 const double objectiveIn)
   {
     objective = objectiveIn;
     evaluateCalls++;
+    return false;
   }
 
   /**
@@ -337,7 +341,7 @@ class Report
     * @param objectiveIn Objective value of the current point.
     */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void EvaluateConstraint(OptimizerType& /* optimizer */,
+  bool EvaluateConstraint(OptimizerType& /* optimizer */,
                           FunctionType& /* function */,
                           const MatType& /* coordinates */,
                           const size_t /* constraint */,
@@ -345,6 +349,7 @@ class Report
   {
     objective += objectiveIn;
     evaluateCalls++;
+    return false;
   }
 
   /**
@@ -356,7 +361,7 @@ class Report
    * @param gradientIn Matrix that holds the gradient.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void Gradient(OptimizerType& /* optimizer */,
+  bool Gradient(OptimizerType& /* optimizer */,
                 FunctionType& /* function */,
                 const MatType& /* coordinates */,
                 const MatType& gradientIn)
@@ -364,6 +369,7 @@ class Report
     hasGradient = true;
     gradientNorm = arma::norm(gradientIn);
     gradientCalls++;
+    return false;
   }
 
   /**
@@ -376,13 +382,14 @@ class Report
    * @param gradient Matrix that holds the gradient;
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void GradientConstraint(OptimizerType& optimizer,
+  bool GradientConstraint(OptimizerType& optimizer,
                           FunctionType& function,
                           const MatType& coordinates,
                           const size_t /* constraint */,
                           const MatType& gradient)
   {
     Gradient(optimizer, function, coordinates, gradient);
+    return false;
   }
 
  private:

--- a/include/ensmallen_bits/callbacks/store_best_coordinates.hpp
+++ b/include/ensmallen_bits/callbacks/store_best_coordinates.hpp
@@ -40,7 +40,7 @@ class StoreBestCoordinates
    * @param objective Objective value of the current point.
    */
   template<typename OptimizerType, typename FunctionType, typename MatType>
-  void Evaluate(OptimizerType& /* optimizer */,
+  bool Evaluate(OptimizerType& /* optimizer */,
                 FunctionType& /* function */,
                 const MatType& coordinates,
                 const double objective)
@@ -50,6 +50,7 @@ class StoreBestCoordinates
       bestObjective = objective;
       bestCoordinates = coordinates;
     }
+    return false;
   }
 
   //! Get the best coordinates.

--- a/include/ensmallen_bits/callbacks/traits.hpp
+++ b/include/ensmallen_bits/callbacks/traits.hpp
@@ -239,23 +239,11 @@ template<typename CallbackType,
          typename MatType>
 struct HasBeginOptimizationSignature
 {
-  const static bool hasBool =
+  const static bool value =
       HasBeginOptimization<CallbackType, TypedForms<OptimizerType,
-          FunctionType, MatType>::template BeginOptimizationBoolForm>::value &&
-      !HasBeginOptimization<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template BeginOptimizationBoolForm>::value ||
+      HasBeginOptimization<CallbackType, TypedForms<OptimizerType,
           FunctionType, MatType>::template BeginOptimizationVoidForm>::value;
-
-  const static bool hasVoid =
-      !HasBeginOptimization<CallbackType, TypedForms<OptimizerType,
-          FunctionType, MatType>::template BeginOptimizationBoolForm>::value &&
-      HasBeginOptimization<CallbackType, TypedForms<OptimizerType,
-         FunctionType, MatType>::template BeginOptimizationVoidForm>::value;
-
-  const static bool hasNone =
-      !HasBeginOptimization<CallbackType, TypedForms<OptimizerType,
-          FunctionType, MatType>::template BeginOptimizationBoolForm>::value &&
-      !HasBeginOptimization<CallbackType, TypedForms<OptimizerType,
-         FunctionType, MatType>::template BeginOptimizationVoidForm>::value;
 };
 
 //! Utility struct, check if either void Evaluate() or bool Evaluate()
@@ -266,10 +254,22 @@ template<typename CallbackType,
          typename MatType>
 struct HasEvaluateSignature
 {
-  const static bool value =
+  const static bool hasBool =
       HasEvaluate<CallbackType, TypedForms<OptimizerType,
-          FunctionType, MatType>::template EvaluateBoolForm>::value ||
+          FunctionType, MatType>::template EvaluateBoolForm>::value &&
+      !HasEvaluate<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template EvaluateVoidForm>::value;
+
+  const static bool hasVoid =
+      !HasEvaluate<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template EvaluateBoolForm>::value &&
       HasEvaluate<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template EvaluateVoidForm>::value;
+
+  const static bool hasNone =
+      !HasEvaluate<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template EvaluateBoolForm>::value &&
+      !HasEvaluate<CallbackType, TypedForms<OptimizerType,
           FunctionType, MatType>::template EvaluateVoidForm>::value;
 };
 
@@ -281,10 +281,22 @@ template<typename CallbackType,
          typename MatType>
 struct HasEvaluateConstraintSignature
 {
-  const static bool value =
+  const static bool hasBool =
       HasEvaluateConstraint<CallbackType, TypedForms<OptimizerType,
-          FunctionType, MatType>::template EvaluateConstraintBoolForm>::value ||
+          FunctionType, MatType>::template EvaluateConstraintBoolForm>::value &&
+      !HasEvaluateConstraint<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template EvaluateConstraintVoidForm>::value;
+
+  const static bool hasVoid =
+      !HasEvaluateConstraint<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template EvaluateConstraintBoolForm>::value &&
       HasEvaluateConstraint<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template EvaluateConstraintVoidForm>::value;
+
+  const static bool hasNone =
+      !HasEvaluateConstraint<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template EvaluateConstraintBoolForm>::value &&
+      !HasEvaluateConstraint<CallbackType, TypedForms<OptimizerType,
           FunctionType, MatType>::template EvaluateConstraintVoidForm>::value;
 };
 
@@ -297,17 +309,41 @@ template<typename CallbackType,
          typename Gradient>
 struct HasGradientSignature
 {
-  const static bool value =
-      HasGradient<CallbackType, TypedForms<OptimizerType,
+  const static bool hasBool =
+      (HasGradient<CallbackType, TypedForms<OptimizerType,
           FunctionType, MatType, Gradient>::template GradientBoolForm>::value ||
       HasGradient<CallbackType, TypedForms<OptimizerType,
-          FunctionType, MatType,
-          Gradient>::template GradientBoolModifiableForm>::value ||
-      HasGradient<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template
+          GradientBoolModifiableForm>::value) &&
+      (!HasGradient<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template GradientVoidForm>::value ||
+      !HasGradient<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template
+          GradientVoidModifiableForm>::value);
+
+  const static bool hasVoid =
+      (!HasGradient<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template GradientBoolForm>::value ||
+      !HasGradient<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template
+          GradientBoolModifiableForm>::value) &&
+      (HasGradient<CallbackType, TypedForms<OptimizerType,
           FunctionType, MatType, Gradient>::template GradientVoidForm>::value ||
       HasGradient<CallbackType, TypedForms<OptimizerType,
-          FunctionType, MatType,
-          Gradient>::template GradientVoidModifiableForm>::value;
+          FunctionType, MatType, Gradient>::template
+          GradientVoidModifiableForm>::value);
+
+  const static bool hasNone =
+      !HasGradient<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template GradientBoolForm>::value &&
+      !HasGradient<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template
+          GradientBoolModifiableForm>::value &&
+      !HasGradient<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template GradientVoidForm>::value &&
+      !HasGradient<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template
+          GradientVoidModifiableForm>::value;
 };
 
 //! Utility struct, check if either void GradientConstraint() or
@@ -319,13 +355,29 @@ template<typename CallbackType,
          typename Gradient>
 struct HasGradientConstraintSignature
 {
-  const static bool value =
+  const static bool hasBool =
       HasGradientConstraint<CallbackType, TypedForms<OptimizerType,
-      FunctionType, MatType,
-          Gradient>::template GradientConstraintBoolForm>::value ||
+          FunctionType, MatType, Gradient>::template
+          GradientConstraintBoolForm>::value &&
+      !HasGradientConstraint<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template
+          GradientConstraintVoidForm>::value;
+
+  const static bool hasVoid =
+      !HasGradientConstraint<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template
+          GradientConstraintBoolForm>::value &&
       HasGradientConstraint<CallbackType, TypedForms<OptimizerType,
-      FunctionType, MatType,
-          Gradient>::template GradientConstraintVoidForm>::value;
+          FunctionType, MatType, Gradient>::template
+          GradientConstraintVoidForm>::value;
+
+  const static bool hasNone =
+      !HasGradientConstraint<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template
+          GradientConstraintBoolForm>::value &&
+      !HasGradientConstraint<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType, Gradient>::template
+          GradientConstraintVoidForm>::value;
 };
 
 //! Utility struct, check if either void EndOptimization() or
@@ -338,9 +390,9 @@ struct HasEndOptimizationSignature
 {
   const static bool value =
       HasEndOptimization<CallbackType, TypedForms<OptimizerType,
-      FunctionType, MatType>::template EndOptimizationBoolForm>::value ||
+          FunctionType, MatType>::template EndOptimizationBoolForm>::value ||
       HasEndOptimization<CallbackType, TypedForms<OptimizerType,
-      FunctionType, MatType>::template EndOptimizationVoidForm>::value;
+          FunctionType, MatType>::template EndOptimizationVoidForm>::value;
 };
 
 //! Utility struct, check if either void BeginEpoch() or bool BeginEpoch()
@@ -351,11 +403,23 @@ template<typename CallbackType,
          typename MatType>
 struct HasBeginEpochSignature
 {
-  const static bool value =
+  const static bool hasBool =
       HasBeginEpoch<CallbackType, TypedForms<OptimizerType,
-      FunctionType, MatType>::template BeginEpochBoolForm>::value ||
+          FunctionType, MatType>::template BeginEpochBoolForm>::value &&
+      !HasBeginEpoch<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template BeginEpochVoidForm>::value;
+
+  const static bool hasVoid =
+      !HasBeginEpoch<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template BeginEpochBoolForm>::value &&
       HasBeginEpoch<CallbackType, TypedForms<OptimizerType,
-      FunctionType, MatType>::template BeginEpochVoidForm>::value;
+          FunctionType, MatType>::template BeginEpochVoidForm>::value;
+
+  const static bool hasNone =
+      !HasBeginEpoch<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template BeginEpochBoolForm>::value &&
+      !HasBeginEpoch<CallbackType, TypedForms<OptimizerType,
+          FunctionType, MatType>::template BeginEpochVoidForm>::value;
 };
 
 //! Utility struct, check if either void EndEpoch() or bool EndEpoch()
@@ -402,13 +466,13 @@ struct HasStepTakenSignature
       !HasStepTaken<CallbackType, TypedForms<OptimizerType,
           FunctionType, MatType>::template StepTakenBoolForm>::value &&
       HasStepTaken<CallbackType, TypedForms<OptimizerType,
-         FunctionType, MatType>::template StepTakenVoidForm>::value;
+          FunctionType, MatType>::template StepTakenVoidForm>::value;
 
   const static bool hasNone =
       !HasStepTaken<CallbackType, TypedForms<OptimizerType,
           FunctionType, MatType>::template StepTakenBoolForm>::value &&
       !HasStepTaken<CallbackType, TypedForms<OptimizerType,
-         FunctionType, MatType>::template StepTakenVoidForm>::value;
+          FunctionType, MatType>::template StepTakenVoidForm>::value;
 };
 
 //! A utility struct for Typed Forms required in


### PR DESCRIPTION
I was debugging #377 further when I noticed that several of the callback functions (`Evaluate()`, `Gradient()`, `EvaluateConstraint()`, and others) actually don't use the return value of the callback.

Any overload of those callbacks would call:

```
    return (const_cast<CallbackType&>(callback).Evaluate(
        optimizer, function, coordinates, objective), false);
```

which always returns `false`.  The fix for this was to adjust the traits for each callback type to provide `::hasBool` and `::hasVoid` members, and then use the return value for the `::hasBool` version, just like `StepTaken()` does (and a couple other callbacks).

I also modified all our existing callbacks to return `bool` instead of `void`.

Once this PR is merged, the example in #377 works, and we should do a release.