### PR TITLE
Add a newline after printing coordinates to `Report` callback

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,9 @@
  * Fix return types of callbacks
    ([#382](https://github.com/mlpack/ensmallen/pull/382)).
 
+ * Minor cleanup for printing optimization reports via `Report()`
+   ([#385](https://github.com/mlpack/ensmallen/pull/385)).
+
 ### ensmallen 2.20.0: "Stripped Bolt Head"
 ###### 2023-10-02
  * Implementation of Active CMAES

--- a/include/ensmallen_bits/callbacks/report.hpp
+++ b/include/ensmallen_bits/callbacks/report.hpp
@@ -87,6 +87,7 @@ class Report
       TruncatePrint(initialCoordinates, outputMatrixSize);
       output << std::endl << "Final coordinates: " << std::endl;
       TruncatePrint(coordinates, outputMatrixSize);
+      output << std::endl;
     }
     else
     {


### PR DESCRIPTION
Pretty simple change... before:

```
Optimization Report
--------------------------------------------------------------------------------

Initial coordinates: 
 0.0000  0.0000  0.0000 ...
 0.0000 
Final coordinates: 
-2.3592 -0.0324 -0.0261 ...
-0.1400 iter          loss          loss change   |gradient|    step size     total time    
0             0.883         0.000         4.532         0.010         0.007         
10            0.762         0.121         0.000         0.010         0.078         
20            1.195         -0.433        867.404       0.010         0.136         
30            0.627         0.567         0.104         0.010         0.200         
40            0.660         -0.033        55.468        0.010         0.261         
50            0.733         -0.074        37.082        0.010         0.327         
60            0.561         0.172         4.335         0.010         0.389         
70            0.558         0.003         723.906       0.010         0.453         
80            0.696         -0.138        463.292       0.010         0.516         
90            0.654         0.043         451.552       0.010         0.581         

--------------------------------------------------------------------------------
```

After:

```
Optimization Report
--------------------------------------------------------------------------------

Initial coordinates: 
 0.0000  0.0000  0.0000 ...
 0.0000 
Final coordinates: 
-2.3592 -0.0324 -0.0261 ...
-0.1400 
iter          loss          loss change   |gradient|    step size     total time    
0             0.883         0.000         4.532         0.010         0.023         
10            0.762         0.121         0.000         0.010         0.097         
20            1.195         -0.433        867.404       0.010         0.154         
30            0.627         0.567         0.104         0.010         0.215         
40            0.660         -0.033        55.468        0.010         0.279         
50            0.733         -0.074        37.082        0.010         0.346         
60            0.561         0.172         4.335         0.010         0.411         
70            0.558         0.003         723.906       0.010         0.475         
80            0.696         -0.138        463.292       0.010         0.536         
90            0.654         0.043         451.552       0.010         0.601         

--------------------------------------------------------------------------------
```