### PR TITLE
Release version 2.20.1: "Stripped Bolt Head"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,8 @@ $ cd ensmallen
 
 # - or -
 
-$ wget http://ensmallen.org/files/ensmallen-2.20.0.tar.gz
-$ tar -xvzpf ensmallen-2.20.0.tar.gz
+$ wget http://ensmallen.org/files/ensmallen-2.20.1.tar.gz
+$ tar -xvzpf ensmallen-2.20.1.tar.gz
 $ cd ensmallen-latest
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### ensmallen ?.??.?: "???"
+###### ????-??-??
+
 ### ensmallen 2.20.1: "Stripped Bolt Head"
 ###### 2023-11-26
  * Clarify return values for different callback types

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-### ensmallen ?.??.?: "???"
-###### ????-??-??
+### ensmallen 2.20.1: "Stripped Bolt Head"
+###### 2023-11-26
  * Clarify return values for different callback types
    ([#383](https://github.com/mlpack/ensmallen/pull/383)).
 

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -16,7 +16,7 @@
 // The minor version is two digits so regular numerical comparisons of versions
 // work right.  The first minor version of a release is always 10.
 #define ENS_VERSION_MINOR 20
-#define ENS_VERSION_PATCH 0
+#define ENS_VERSION_PATCH 1
 // If this is a release candidate, it will be reflected in the version name
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not
@@ -24,8 +24,8 @@
 #define ENS_VERSION_NAME "Stripped Bolt Head"
 // Incorporate the date the version was released.
 #define ENS_VERSION_YEAR "2023"
-#define ENS_VERSION_MONTH "10"
-#define ENS_VERSION_DAY "02"
+#define ENS_VERSION_MONTH "11"
+#define ENS_VERSION_DAY "26"
 
 namespace ens {
 


### PR DESCRIPTION
This automatically-generated pull request adds the commits necessary to make the 2.20.1 release.

Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it.

Or, well, hopefully that will happen someday.

When you merge this PR, be sure to merge it using a *rebase*.

### Changelog

 * Clarify return values for different callback types ([#383](https://github.com/mlpack/ensmallen/pull/383)).

 * Fix return types of callbacks ([#382](https://github.com/mlpack/ensmallen/pull/382)).

 * Minor cleanup for printing optimization reports via `Report()` ([#385](https://github.com/mlpack/ensmallen/pull/385)).