### PR TITLE
Fix negative scaling factors for L-BFGS

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Fix numerical precision issues for small-gradient L-BFGS scaling factor
+   computations ([#392](https://github.com/mlpack/ensmallen/pull/392)).
 
 ### ensmallen 2.21.0: "Bent Antenna"
 ###### 2023-11-27

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
@@ -136,9 +136,8 @@ AugLagrangian::Optimize(
         << ", starting with objective "  << lastObjective << "." << std::endl;
 
     if (!lbfgs.Optimize(augfunc, coordinates, callbacks...))
-      Info << "L-BFGS reported an error during optimization."
-          << std::endl;
-    Info << "Done with L-BFGS: " << coordinates << "\n";
+      Info << "L-BFGS reported an error during optimization." << std::endl;
+    Info << "Done with L-BFGS." << std::endl;
 
     const ElemType objective = function.Evaluate(coordinates);
 

--- a/include/ensmallen_bits/callbacks/query_front.hpp
+++ b/include/ensmallen_bits/callbacks/query_front.hpp
@@ -48,7 +48,7 @@ class QueryFront
            typename MatType,
            typename ObjectivesVecType,
            typename IndicesType>
-  bool GenerationalStepTaken(OptimizerType& opt,
+  bool GenerationalStepTaken(OptimizerType& /* opt */,
                              FunctionType& /* function */,
                              const MatType& /* coordinates */,
                              const ObjectivesVecType& objectives,

--- a/include/ensmallen_bits/cmaes/not_empty_transformation.hpp
+++ b/include/ensmallen_bits/cmaes/not_empty_transformation.hpp
@@ -9,26 +9,32 @@
  * the 3-clause BSD license along with ensmallen.  If not, see
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
-#ifndef NOT_EMPTY_TRANSFORMATION
-#define NOT_EMPTY_TRANSFORMATION
+#ifndef ENSMALLEN_CMAES_NOT_EMPTY_TRANSFORMATION
+#define ENSMALLEN_CMAES_NOT_EMPTY_TRANSFORMATION
 
- /*
-  This partial specialization is used to throw an exception when the
-  TransformationPolicyType is EmptyTransformation and call a
-  constructor with parameters 'lowerBound' and 'upperBound' otherwise.
-  This shall be removed when the deprecated constructor is removed in
-  the next major version of ensmallen.
+/**
+ * This partial specialization is used to throw an exception when the
+ * TransformationPolicyType is EmptyTransformation and call a constructor with
+ * parameters 'lowerBound' and 'upperBound' otherwise.  This shall be removed
+ * when the deprecated constructor is removed in the next major version of
+ * ensmallen.
  */
 template<typename T1, typename T2>
-struct NotEmptyTransformation : std::true_type {
-  void Assign(T1& obj, double lowerBound, double upperBound) {
+struct NotEmptyTransformation : std::true_type
+{
+  void Assign(T1& obj, double lowerBound, double upperBound)
+  {
     obj = T1(lowerBound, upperBound);
   }
 };
 
 template<template<typename...> class T, typename... A, typename... B>
-struct NotEmptyTransformation<T<A...>, T<B...>> : std::false_type {
-  void Assign(T<A...>& obj, double lowerBound, double upperBound) {
+struct NotEmptyTransformation<T<A...>, T<B...>> : std::false_type
+{
+  void Assign(T<A...>& /* obj */,
+              double /* lowerBound */,
+              double /* upperBound */)
+  {
     throw std::logic_error("TransformationPolicyType is EmptyTransformation");
   }
 };


### PR DESCRIPTION
While investigating #390, I came across an interesting finding: L-BFGS was computing negative scaling values for the Hessian scaling step.  (These should not be negative!)  Specifically, the gradient norm was being computed as *negative* and this then snowballed into a convergence issue.  As it turns out, the convergence issue only seems to manifest on non-x86_64 architectures when using `arma::fmat` likely due to numerical precision specifics and other things along those lines.  Here's an example run of the `Johnson844LovaszThetaFMatSDP` test, printing negative gradient norms:

```
$ ./ensmallen_tests Johnson844LovaszThetaFMatSDP
ensmallen version: 2.21.0 (Bent Antenna)
armadillo version: 9.800.1 (Horizon Scraper)
random seed: 0
Filters: Johnson844LovaszThetaFMatSDP
Scaling factor less than zero! -0.0215062
Scaling factor less than zero! -2.41463e-09
===============================================================================
All tests passed (1122 assertions in 1 test case)
```

So, first question is: @conradsnicta do you consider it a responsibility of Armadillo to provide a nonnegative norm?  If so, I can add an extra `if (norm < 0) return 0` type check to the `norm()` function and open an MR.  If not, I'll just keep that in mind and check throughout ensmallen to make sure we don't depend on `norm()` returning nonnegative values.

Inside of ensmallen I chose to fix the issue by avoiding division by the gradient norm (or other quantities) when they are very small or negative.  On the M1 Macbook I have sitting around, this fixes the test failure and convergence succeeds.

I also fixed some compilation warnings, and made `AugLagrangian` not output the entire set of coordinates when `ENS_PRINT_INFO` is enabled (the coordinates could be huge!).