### PR TITLE
update to C++14 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ option(USE_OPENMP "If available, use OpenMP for parallelization." ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake")
 
-# Set required C++ standard to C++11.
-set(CMAKE_CXX_STANDARD 11)
+# Set required C++ standard to C++14.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Extract version from sources.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ensmallen CMake configuration.  This project has no configurable options---it
 # just installs the headers to the install location, and optionally builds the
 # test program.
-cmake_minimum_required(VERSION 3.3.2)
+cmake_minimum_required(VERSION 3.3.2...3.5)
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")  # ensure the tests are built with optimisation
 endif ()

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Update to C++14 standard
+   ([#400](https://github.com/mlpack/ensmallen/pull/400)).
 
 ### ensmallen 2.21.1: "Bent Antenna"
 ###### 2024-02-15

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ and constrained optimization.
 Examples include L-BFGS, SGD, CMAES and Simulated Annealing.
 ensmallen also allows optional callbacks to customize the optimization process.
 
-Documentation and downloads: http://ensmallen.org
+Documentation and downloads: https://ensmallen.org
 
 ### Requirements
 
-* C++ compiler with C++11 support
-* Armadillo: http://arma.sourceforge.net
+* C++ compiler with C++14 support
+* Armadillo: https://arma.sourceforge.net
 * OpenBLAS or Intel MKL or LAPACK (see Armadillo site for details)
 
 
@@ -28,9 +28,7 @@ with or without root access.
 The cmake based installation will check the requirements 
 and optionally build the tests. If cmake 3.3 (or a later version) 
 is not already available on your system, it can be obtained 
-from [cmake.org](https://cmake.org). If you are using an older 
-system such as RHEL 7 or CentOS 7, an updated version of cmake 
-is also available via the EPEL repository (see the `cmake3` package).
+from [cmake.org](https://cmake.org).
 
 Example cmake based installation with root access:
 
@@ -151,3 +149,4 @@ the library.
 * N Rajiv Vaidyanathan
 * Roberto Hueso
 * Sayan Goswami
+

--- a/include/ensmallen.hpp
+++ b/include/ensmallen.hpp
@@ -15,19 +15,24 @@
 #ifndef ENSMALLEN_HPP
 #define ENSMALLEN_HPP
 
-// certain compilers are way behind the curve
-#if (defined(_MSVC_LANG) && (_MSVC_LANG >= 201402L))
-  #undef  ARMA_USE_CXX11
-  #define ARMA_USE_CXX11
+#undef ENS_HAVE_CXX14
+
+#if (__cplusplus >= 201402L)
+  #define ENS_HAVE_CXX14
+#endif
+
+#if defined(_MSVC_LANG)
+  #if (_MSVC_LANG >= 201402L)
+    #undef  ENS_HAVE_CXX14
+    #define ENS_HAVE_CXX14
+  #endif
+#endif
+
+#if !defined(ENS_HAVE_CXX14)
+  #error "*** C++14 compiler required; enable C++14 mode in your compiler, or use an earlier version of ensmallen"
 #endif
 
 #include <armadillo>
-
-#if !defined(ARMA_USE_CXX11)
-  // armadillo automatically enables ARMA_USE_CXX11
-  // when a C++11/C++14/C++17/etc compiler is detected
-  #error "please enable C++11/C++14 mode in your compiler"
-#endif
 
 #if ((ARMA_VERSION_MAJOR < 9) || ((ARMA_VERSION_MAJOR == 9) && (ARMA_VERSION_MINOR < 800)))
   #error "need Armadillo version 9.800 or later"

--- a/include/ensmallen_bits/config.hpp
+++ b/include/ensmallen_bits/config.hpp
@@ -56,22 +56,6 @@
 #endif
 
 
-// Define ens_deprecated for deprecated functionality.
-// This is adapted from Armadillo's implementation.
-#if defined(_MSC_VER)
-  #define ens_deprecated __declspec(deprecated)
-#elif defined(__GNUG__) && (!defined(__clang__))
-  #define ens_deprecated __attribute__((__deprecated__))
-#elif defined(__clang__)
-  #if __has_attribute(__deprecated__)
-    #define ens_deprecated __attribute__((__deprecated__))
-  #else
-    #define ens_deprecated
-  #endif
-#else
-  #define ens_deprecated
-#endif
-
 // undefine conflicting macros
 #if defined(As)
   #pragma message ("WARNING: undefined conflicting 'As' macro")

--- a/include/ensmallen_bits/function/sfinae_utility.hpp
+++ b/include/ensmallen_bits/function/sfinae_utility.hpp
@@ -188,7 +188,7 @@ struct NAME                                                                    \
     template<typename>                                                         \
     static no& chk(...);                                                       \
                                                                                \
-    static const bool value = sizeof(chk<Class>(0)) == sizeof(yes);            \
+    static constexpr bool value = sizeof(chk<Class>(0)) == sizeof(yes);        \
   };                                                                           \
                                                                                \
   template<size_t N>                                                           \
@@ -201,10 +201,10 @@ struct NAME                                                                    \
             N < MAXN,                                                          \
             WithGreaterOrEqualNumberOfAdditionalArgs<N + 1>,                   \
             std::false_type>::type>::type;                                     \
-    static const bool value = type::value;                                     \
+    static constexpr bool value = type::value;                                 \
   };                                                                           \
                                                                                \
-  static const bool value =                                                    \
+  static constexpr bool value =                                                \
       WithGreaterOrEqualNumberOfAdditionalArgs<MinN>::value;                   \
 };
 
@@ -235,7 +235,7 @@ struct NAME                                                                  \
   template <typename Q = T>                                                  \
   static char f(char) { return 0; }                                        \
                                                                              \
-  static const bool value = sizeof(f<T>(0)) != sizeof(char);                 \
+  static constexpr bool value = sizeof(f<T>(0)) != sizeof(char);             \
 };
 /*
  * A macro that can be used for passing arguments containing commas to other

--- a/include/ensmallen_bits/nsga2/nsga2.hpp
+++ b/include/ensmallen_bits/nsga2/nsga2.hpp
@@ -184,7 +184,7 @@ class NSGA2
    * deprecated and will be removed in ensmallen 3.x!  Use `ParetoFront()`
    * instead.
    */
-  ens_deprecated const std::vector<arma::mat>& Front()
+  [[deprecated("use ParetoFront() instead")]] const std::vector<arma::mat>& Front()
   {
     if (rcFront.size() == 0)
     {


### PR DESCRIPTION
Update C++ standard to C++14.

mlpack 4.4 already requires C++17, and Armadillo 14.0 will use C++14.

The only OS that required C++11 is RHEL 7 / CentOS 7, which is EOL as of 30 June 2024:
* https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux
* https://www.redhat.com/en/topics/linux/centos-linux-eol
* https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/

Using "two most recent releases of long term Linux distros" as the yardstick for compiler support.  The Linux distros are: RHEL (+ clones like Rocky Linux and Alma Linux), Ubuntu LTS, and Debian.

The current two supported releases of RHEL (8 and 9), Ubuntu LTS (22.04 and 24.04), Debian (11 and 12) all provide GCC versions that support at least C++14.

RHEL 8 does not support C++17 properly, so not bumping the C++ standard to C++17.


