### PR TITLE
CMA stop conditions

### DIFF
--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -938,12 +938,12 @@ RosenbrockFunction f;
 arma::mat coordinates = f.GetInitialPoint();
 
 // CMAES with the FullSelection and BoundaryBoxConstraint policies.
-BoundaryBoxConstraint b(-1, 1);
+BoundaryBoxConstraint<> b(-1, 1);
 CMAES optimizer(0, b, 32, 200, 1e-4);
 optimizer.Optimize(f, coordinates);
 
 // CMAES with the RandomSelection and BoundaryBoxConstraint policies.
-ApproxCMAES<BoundaryBoxConstraint<>> cmaes(0, b, 32, 200, 1e-4);
+ApproxCMAES<BoundaryBoxConstraint<>> approxOptimizer(0, b, 32, 200, 1e-4);
 approxOptimizer.Optimize(f, coordinates);
 ```
 

--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -869,6 +869,12 @@ matrix within an iterative procedure using the covariance matrix.
  * `CMAES<`_`SelectionPolicyType, TransformationPolicyType`_`>(`_`lambda, transformationPolicy, batchSize`_`)`
  * `CMAES<`_`SelectionPolicyType, TransformationPolicyType`_`>(`_`lambda, transformationPolicy, batchSize, maxIterations, tolerance, selectionPolicy`_`)`
  * `CMAES<`_`SelectionPolicyType, TransformationPolicyType`_`>(`_`lambda, transformationPolicy, batchSize, maxIterations, tolerance, selectionPolicy, stepSize`_`)`
+ * `CMAES<`_`SelectionPolicyType, TransformationPolicyType`_`>(`_`lambda, transformationPolicy, batchSize, maxIterations, tolerance, selectionPolicy, stepSize, maxFunctionEvaluations`_`)`
+* `CMAES<SelectionPolicyType, TransformationPolicyType>(lambda, transformationPolicy, batchSize, maxIterations, tolerance, selectionPolicy, stepSize, maxFunctionEvaluations, minObjective)`
+* `CMAES<SelectionPolicyType, TransformationPolicyType>(lambda, transformationPolicy, batchSize, maxIterations, tolerance, selectionPolicy, stepSize, maxFunctionEvaluations, minObjective, toleranceConditionCov)`
+* `CMAES<SelectionPolicyType, TransformationPolicyType>(lambda, transformationPolicy, batchSize, maxIterations, tolerance, selectionPolicy, stepSize, maxFunctionEvaluations, minObjective, toleranceConditionCov, toleranceNoEffectAxis)`
+* `CMAES<SelectionPolicyType, TransformationPolicyType>(lambda, transformationPolicy, batchSize, maxIterations, tolerance, selectionPolicy, stepSize, maxFunctionEvaluations, minObjective, toleranceConditionCov, toleranceNoEffectAxis, toleranceNoEffectCoord)`
+* `CMAES<SelectionPolicyType, TransformationPolicyType>(lambda, transformationPolicy, batchSize, maxIterations, tolerance, selectionPolicy, stepSize, maxFunctionEvaluations, minObjective, toleranceConditionCov, toleranceNoEffectAxis, toleranceNoEffectCoord, toleranceRange, toleranceRangePatience)`
 
 The _`SelectionPolicyType`_ template parameter refers to the strategy used to
 compute the (approximate) objective function.  The `FullSelection` and
@@ -896,6 +902,13 @@ For convenience the following types can be used:
 | `double` | **`tolerance`** | Maximum absolute tolerance to terminate algorithm. | `1e-5` |
 | `SelectionPolicyType` | **`selectionPolicy`** | Instantiated selection policy used to calculate the objective. | `SelectionPolicyType()` |
 | `size_t` | **`stepSize`** | Initial step size | `0` |
+| `int` | **`maxFunctionEvaluations`** | Stop if the number of function evaluations reaches this limit. | `std::numeric_limits<int>::max()` |
+| `double` | **`minObjective`** | Stop if the best objective value is less than or equal to this target value. | `std::numeric_limits<double>::lowest()` |
+| `size_t` | **`toleranceConditionCov`** | Tolerance for stopping if the condition number of the covariance matrix exceeds this threshold. | `1e14` |
+| `double` | **`toleranceNoEffectAxis`** | Tolerance for stopping if adding a 0.1-standard deviation vector in a principal axis direction of mean vector. | `1e-12` |
+| `double` | **`toleranceNoEffectCoord`** | Tolerance for stopping if adding a 0.2-standard deviation in each coordinate does not change mean vector. | `1e-12` |
+| `double` | **`toleranceRange`** | Tolerance for stopping if the range of the fitness values is less than this value. | `1e-12` |
+| `int` | **`toleranceRangePatience`** | Patience for stopping if the range of the fitness values remains less than `toleranceRange` for a defined number of generations. | `1` |
 
 Attributes of the optimizer may also be changed via the member methods
 `Lambda()`, `TransformationPolicy()`, `BatchSize()`, `MaxIterations()`,

--- a/include/ensmallen_bits/cmaes/cmaes.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes.hpp
@@ -75,6 +75,13 @@ class CMAES
    * @param selectionPolicy Instantiated selection policy used to calculate the
    *     objective.
    * @param stepSize Starting sigma/step size (will be modified).
+   * @param maxFunctionEvaluations Maximum number of function evaluations allowed.
+   * @param minObjective Minimum objective value to terminate the optimization.
+   * @param toleranceConditionCov Tolerance condition for covariance matrix.
+   * @param toleranceNoEffectCoord Tolerance for stopping if there is no change when adding 0.2 std in each coordinate.
+   * @param toleranceNoEffectAxis Tolerance for stopping if there is no change when adding 0.1 std along each axis.
+   * @param toleranceRange Tolerance for stopping if range of the fitness values is less than this value.
+   * @param toleranceRangePatience Patience for stopping if range of the fitness values is less than toleranceRange.
    */
   CMAES(const size_t lambda = 0,
         const TransformationPolicyType& 
@@ -83,7 +90,15 @@ class CMAES
         const size_t maxIterations = 1000,
         const double tolerance = 1e-5,
         const SelectionPolicyType& selectionPolicy = SelectionPolicyType(),
-        double stepSize = 0);
+        double stepSize = 0,
+        const int maxFunctionEvaluations = std::numeric_limits<int>::max(),
+        const double minObjective = std::numeric_limits<double>::lowest(),
+        const size_t toleranceConditionCov = 1e14,
+        const double toleranceNoEffectCoord = 1e-12,
+        const double toleranceNoEffectAxis = 1e-12,
+        const double toleranceRange = 1e-12,
+        const size_t toleranceRangePatience = 1
+        );
 
   /**
    * Construct the CMA-ES optimizer with the given function and parameters 
@@ -103,6 +118,13 @@ class CMAES
    * @param selectionPolicy Instantiated selection policy used to calculate the
    * objective.
    * @param stepSize Starting sigma/step size (will be modified).
+   * @param maxFunctionEvaluations Maximum number of function evaluations allowed.
+   * @param minObjective Minimum objective value to terminate the optimization.
+   * @param toleranceConditionCov Tolerance condition for covariance matrix.
+   * @param toleranceNoEffectCoord Tolerance for stopping if there is no change when adding 0.2 std in each coordinate.
+   * @param toleranceNoEffectAxis Tolerance for stopping if there is no change when adding 0.1 std along each axis.
+   * @param toleranceRange Tolerance for stopping if range of the fitness values is less than this value.
+   * @param toleranceRangePatience Patience for stopping if range of the fitness values is less than toleranceRange. 
    */
   CMAES(const size_t lambda = 0,
         const double lowerBound = -10,
@@ -111,7 +133,15 @@ class CMAES
         const size_t maxIterations = 1000,
         const double tolerance = 1e-5,
         const SelectionPolicyType& selectionPolicy = SelectionPolicyType(),
-        double stepSize = 0);
+        double stepSize = 0,
+        const int maxFunctionEvaluations = std::numeric_limits<int>::max(),
+        const double minObjective = std::numeric_limits<double>::lowest(),
+        const size_t toleranceConditionCov = 1e14,
+        const double toleranceNoEffectCoord = 1e-12,
+        const double toleranceNoEffectAxis = 1e-12,
+        const double toleranceRange = 1e-12,
+        const size_t toleranceRangePatience = 1
+        );
 
   /**
    * Optimize the given function using CMA-ES. The given starting point will be
@@ -153,6 +183,21 @@ class CMAES
   //! Modify the tolerance for termination.
   double& Tolerance() { return tolerance; }
 
+  //! Get the maximum number of function evaluations.
+  size_t MaxFunctionEvaluations() const { return maxFunctionEvaluations; }
+  //! Modify the maximum number of function evaluations.
+  size_t& MaxFunctionEvaluations() { return maxFunctionEvaluations; }
+
+  //! Get the minimum objective value to terminate the optimization.
+  double MinObjective() const { return minObjective; }
+  //! Modify the minimum objective value to terminate the optimization.
+  double& MinObjective() { return minObjective; }
+
+  //! Get the tolerance condition for covariance matrix.
+  size_t ToleranceConditionCov() const { return toleranceConditionCov; }
+  //! Modify the tolerance condition for covariance matrix.
+  size_t& ToleranceConditionCov() { return toleranceConditionCov; }
+
   //! Get the selection policy.
   const SelectionPolicyType& SelectionPolicy() const { return selectionPolicy; }
   //! Modify the selection policy.
@@ -172,6 +217,38 @@ class CMAES
   double& StepSize()
   { return stepSize; }
 
+  //! Get the total number of function evaluations.
+  size_t FunctionEvaluations() const 
+  { return functionEvaluations; }
+
+  //! Get the tolerance for stopping if there is no change when adding 0.2 std in each coordinate.
+  double ToleranceNoEffectCoord() const 
+  { return toleranceNoEffectCoord; }
+  //! Modify the tolerance for stopping if there is no change when adding 0.2 std in each coordinate.
+  double& ToleranceNoEffectCoord() 
+  { return toleranceNoEffectCoord; }
+
+  //! Get the tolerance for stopping if there is no change when adding 0.1 std along each axis.
+  double ToleranceNoEffectAxis() const 
+  { return toleranceNoEffectAxis; }
+  //! Modify the tolerance for stopping if there is no change when adding 0.1 std along each axis.
+  double& ToleranceNoEffectAxis() 
+  { return toleranceNoEffectAxis; }
+
+  //! Get the tolerance for stopping if range of the fitness values is less than this value.
+  double ToleranceRange() const
+  { return toleranceRange; }
+  //! Modify the tolerance for stopping if range of the fitness values is less than this value.
+  double& ToleranceRange()
+  { return toleranceRange; }
+
+  //! Get the patience for stopping if range of the fitness values is less than toleranceRange.
+  size_t ToleranceRangePatience() const
+  { return toleranceRangePatience; }
+  //! Modify the patience for stopping if range of the fitness values is less than toleranceRange.
+  size_t& ToleranceRangePatience()
+  { return toleranceRangePatience; }
+
  private:
   //! Population size.
   size_t lambda;
@@ -185,6 +262,21 @@ class CMAES
   //! The tolerance for termination.
   double tolerance;
 
+  //! The tolerance for stopping if there is no change when adding 0.2 std in each coordinate.
+  double toleranceNoEffectCoord;
+
+  //! The tolerance for stopping if there is no change when adding 0.1 std along each axis.
+  double toleranceNoEffectAxis;
+
+  //! The maximum number of function evaluations.
+  size_t maxFunctionEvaluations;
+
+  //! The minimum objective value to terminate the optimization.
+  double minObjective;
+
+  //! The tolerance condition for covariance matrix.
+  size_t toleranceConditionCov;
+
   //! The selection policy used to calculate the objective.
   SelectionPolicyType selectionPolicy;
 
@@ -195,6 +287,15 @@ class CMAES
 
   //! The step size.
   double stepSize;
+
+  //! Counter for the number of function evaluations.
+  size_t functionEvaluations = 0;
+
+  //! The tolerance for stopping if range of the fitness values is less than this value.
+  double toleranceRange;
+
+  //! The patience for stopping if range of the fitness values is less than toleranceRange.
+  size_t toleranceRangePatience;
 };
 
 /**

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -417,7 +417,7 @@ typename MatType::elem_type CMAES<SelectionPolicyType,
     }
 
     // Check if the condition number of the covariance matrix is too high.
-    if (eigval(0) / eigval(eigval.n_elem - 1) > 1e14) // TODO: Probably put this into a parameter
+    if (eigval(eigval.n_elem - 1) / eigval(0) > 1e14) // TODO: Probably put this into a parameter
     {
       Info << "CMA-ES: covariance matrix condition number is too high; "
         << "terminating with failure." << std::endl;

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -291,6 +291,17 @@ typename MatType::elem_type CMAES<SelectionPolicyType,
       return overallObjective;
     }
 
+    // Terminate if sigma/sigma0 is above 10^4 * max(D)
+    if (sigma(idx1) / sigma(0) > 1e4 * std::max(eigvalZero, eigval))
+    {
+      Info << "The step size ratio is too large; "
+        << "terminating with failure." << std::endl;
+
+      iterate = transformationPolicy.Transform(iterate);
+      Callback::EndOptimization(*this, function, iterate, callbacks...);
+      return overallObjective;
+    }
+
     // Update covariance matrix.
     if ((psNorm / sqrt(1 - std::pow(1 - cs, 2 * i))) < h)
     {

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -453,7 +453,7 @@ typename MatType::elem_type CMAES<SelectionPolicyType,
       return overallObjective;
     }
 
-    // Terminate if adding 0.2 sigma_g in each coordinate does not change the m
+    // Terminate if adding 0.2 sigma_g in each coordinate does not change the m.
     for (size_t j = 0; j < iterate.n_elem; ++j)
     {
       if (std::abs(mPosition[idx0](j) - (mPosition[idx0](j) + 0.2 * sigma(idx0))) < 1e-12)


### PR DESCRIPTION
Hi,

I am currently enhancing the implementation of the CMA-ES algorithm by introducing additional stopping conditions. These modifications are intended to improve numerical stability and are advocated in [A Restart CMA Evolution Strategy With Increasing Population Size](http://www.cmap.polytechnique.fr/~nikolaus.hansen/cec2005ipopcmaes.pdf) and [The CMA Evolution Strategy: A Tutorial](https://arxiv.org/pdf/1604.00772). The changes are also in line with implementations found in [Python libraries](https://github.com/CMA-ES/pycma) maintained by the same author.

These are basically:
- [Implemented] **Maximum Generations (`maxiter`)**: Stop if the number of iterations reaches a predefined limit.
- [Implemented] **Target Objective Value (`ftarget`)**: Stop if the best objective value is less than or equal to a target value.
- [Implemented] **Maximum Function Evaluations (`maxfevals`)**: Stop if the number of function evaluations reaches a predefined limit.
- [Implemented] **Tolerance on Function Value (`tolfun`)**: Stop if the range of function values of the best solutions falls below a threshold over a certain number of iterations.
- [Implemented] **Tolerance on Fitness Stagnation (`tolflatfitness`)**: Stop if the best objective value does not change significantly over a number of generations.
- [Implemented] **Condition Number of Covariance Matrix (`tolconditioncov`)**: Stop if the condition number of the covariance matrix exceeds a certain threshold.
- **No Effect Axis (`noeffectaxis`)**: Stop if adding 0.1 times the standard deviation in the search space in a principal axis direction does not change the solution.
- **No Effect Coordinate (`noeffectcoord`)**: Stop if adding 0.2 times the standard deviation in the search space along one coordinate does not change the solution.
- **Tolerance on Variables (`tolx`)**: Stop if the change in the variables between generations falls below a threshold.
- **Tolerance on Upscaled Sigma (`tolfacupx`)**: Stop if any scaled step sizes exceed the product of the initial step sizes and a specified tolerance factor.
- **Historical Fitness Tolerance (`tolfunhist`)**: Stop if the range of fitness values in the historical best fitness list remains below a specified threshold.
- **Sigma Ratio Increase (`tolupsigma`)**: Stop if the ratio of the current step size to the maximum eigenvalue of the covariance matrix exceeds a specified multiple of the initial step size.
- **Stagnation (`tolstagnation`)**: Stop if there is no significant improvement over a large number of generations.
- **Relative Function Value (`tolfunrel`)**: Stop based on a relative condition involving the historical and current best function values.

These conditions are the ones currently present in the [Python repository](https://github.com/CMA-ES/pycma) I mentioned and align with the papers while adding a few other stopping criteria. These are what I plan to implement, but I'm open suggestions.

Additionally, I have made modifications in lines 94 and 112 to align with the initialization presented in [The CMA Evolution Strategy: A Comparing Review](http://www.cmap.polytechnique.fr/~nikolaus.hansen/hansenedacomparing.pdf) (page 26, equations 35 and 37). These initialization parameters are also supported by other papers I have reviewed.