### PR TITLE
Bump minimum Armadillo version to 10.8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  ARMADILLO_DOWNLOAD: "https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz"
+  ARMADILLO_DOWNLOAD: "https://sourceforge.net/projects/arma/files/armadillo-10.8.2.tar.xz"
   BLAS_LIBRARY: "%APPVEYOR_BUILD_FOLDER%/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a"
   BLAS_LIBRARY_DLL: "%APPVEYOR_BUILD_FOLDER%/OpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll"
 
@@ -26,7 +26,7 @@ build_script:
   - cd ..
   - appveyor DownloadFile %ARMADILLO_DOWNLOAD% -FileName armadillo.tar.xz
   - 7z x armadillo.tar.xz -so -txz | 7z x -si -ttar > nul
-  - cd armadillo-9.800.6 && mkdir build && cd build
+  - cd armadillo-10.8.2 && mkdir build && cd build
   - >
     cmake -G "%VSVER%"
     -DBLAS_LIBRARY:FILEPATH=%BLAS_LIBRARY%
@@ -43,7 +43,7 @@ build_script:
   - cd ensmallen && mkdir build && cd build
   - >
     cmake -G "%VSVER%"
-    -DARMADILLO_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/../armadillo-9.800.6/include/
+    -DARMADILLO_INCLUDE_DIR=%APPVEYOR_BUILD_FOLDER%/../armadillo-10.8.2/include/
     -DARMADILLO_LIBRARIES=%BLAS_LIBRARY%
     -DLAPACK_LIBRARY=%BLAS_LIBRARY%
     -DBLAS_LIBRARY=%BLAS_LIBRARY%

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - if [ $ARMADILLO == "latest" ]; then
       curl https://ftp.fau.de/macports/distfiles/armadillo/`curl https://ftp.fau.de/macports/distfiles/armadillo/ -- | grep '.tar.xz' | sed 's/^.*<a href="\(armadillo-[0-9]*.[0-9]*.[0-9]*.tar.xz\)".*$/\1/' | tail -1` | tar xvJ && cd armadillo*;
     else
-      curl -L https://sourceforge.net/projects/arma/files/armadillo-9.800.6.tar.xz | tar -xvJ && cd armadillo*;
+      curl -L https://sourceforge.net/projects/arma/files/armadillo-10.8.2.tar.xz | tar -xvJ && cd armadillo*;
     fi
   - cmake . && make && sudo make install && cd ..
   - mkdir build && cd build && cmake .. && make ensmallen_tests -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if(USE_OPENMP)
 endif()
 
 # Find Armadillo and link it.
-find_package(Armadillo 9.800.0 REQUIRED)
+find_package(Armadillo 10.8.2 REQUIRED)
 target_link_libraries(ensmallen INTERFACE Armadillo::Armadillo)
 
 # Set helper variables for creating the version, config and target files.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
  * Update to C++14 standard
    ([#400](https://github.com/mlpack/ensmallen/pull/400)).
 
+ * Bump minimum Armadillo version to 10.8
+   ([#404](https://github.com/mlpack/ensmallen/pull/404)).
+
 ### ensmallen 2.21.1: "Bent Antenna"
 ###### 2024-02-15
  * Fix numerical precision issues for small-gradient L-BFGS scaling factor

--- a/include/ensmallen.hpp
+++ b/include/ensmallen.hpp
@@ -34,8 +34,8 @@
 
 #include <armadillo>
 
-#if ((ARMA_VERSION_MAJOR < 9) || ((ARMA_VERSION_MAJOR == 9) && (ARMA_VERSION_MINOR < 800)))
-  #error "need Armadillo version 9.800 or later"
+#if ((ARMA_VERSION_MAJOR < 10) || ((ARMA_VERSION_MAJOR == 10) && (ARMA_VERSION_MINOR < 8)))
+  #error "need Armadillo version 10.8 or newer"
 #endif
 
 #include <cctype>

--- a/include/ensmallen_bits/function/arma_traits.hpp
+++ b/include/ensmallen_bits/function/arma_traits.hpp
@@ -77,11 +77,6 @@ struct MatTypeTraits<arma::SpSubview<eT>>
 };
 
 
-#if ((ARMA_VERSION_MAJOR >= 10) || \
-    ((ARMA_VERSION_MAJOR == 9) && (ARMA_VERSION_MINOR >= 869)))
-
-// Armadillo 9.869+ has SpSubview_col and SpSubview_row
-
 template<typename eT>
 struct MatTypeTraits<arma::SpSubview_col<eT>>
 {
@@ -97,9 +92,6 @@ struct MatTypeTraits<arma::SpSubview_row<eT>>
       "Armadillo subviews cannot be passed to Optimize()!  Create a matrix "
       "or a matrix alias instead!");
 };
-
-#endif
-
 
 template<typename eT>
 struct MatTypeTraits<arma::Cube<eT>>

--- a/include/ensmallen_bits/utility/arma_traits.hpp
+++ b/include/ensmallen_bits/utility/arma_traits.hpp
@@ -98,26 +98,17 @@ struct IsArmaType<arma::SpSubview<eT> >
   const static bool value = true;
 };
 
+template<typename eT>
+struct IsArmaType<arma::SpSubview_col<eT> >
+{
+  const static bool value = true;
+};
 
-#if ((ARMA_VERSION_MAJOR >= 10) || \
-    ((ARMA_VERSION_MAJOR == 9) && (ARMA_VERSION_MINOR >= 869)))
-
-  // Armadillo 9.869+ has SpSubview_col and SpSubview_row
-
-  template<typename eT>
-  struct IsArmaType<arma::SpSubview_col<eT> >
-  {
-    const static bool value = true;
-  };
-
-  template<typename eT>
-  struct IsArmaType<arma::SpSubview_row<eT> >
-  {
-    const static bool value = true;
-  };
-
-#endif
-
+template<typename eT>
+struct IsArmaType<arma::SpSubview_row<eT> >
+{
+  const static bool value = true;
+};
 
 // template<>
 template<typename eT>

--- a/tests/ada_bound_test.cpp
+++ b/tests/ada_bound_test.cpp
@@ -55,9 +55,6 @@ TEST_CASE("AMSBoundphereFunctionTestFMat", "[AdaBoundTest]")
   FunctionTest<SphereFunction, arma::fmat>(optimizer, 0.5, 0.1);
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Test the AdaBound optimizer on the Sphere function with arma::sp_mat.
  */
@@ -111,5 +108,3 @@ TEST_CASE("AMSBoundSphereFunctionTestSpMatDenseGradient", "[AdaBoundTest]")
   REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
   REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
 }
-
-#endif

--- a/tests/adam_test.cpp
+++ b/tests/adam_test.cpp
@@ -38,9 +38,6 @@ TEST_CASE("AdamSphereFunctionTestFMat", "[AdamTest]")
   FunctionTest<SphereFunction, arma::fmat>(optimizer, 0.5, 0.2);
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Test the AMSGrad optimizer on the Sphere function with arma::sp_mat.
  */
@@ -65,8 +62,6 @@ TEST_CASE("AdamSphereFunctionTestSpMatDenseGradient", "[AdamTest]")
   REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
   REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
 }
-
-#endif
 
 /**
  * Test the Adam optimizer on the Wood function.
@@ -123,9 +118,6 @@ TEST_CASE("AMSGradSphereFunctionTestFMat", "[AdamTest]")
   FunctionTest<SphereFunction, arma::fmat>(optimizer, 0.5, 0.1);
 }
 
-#if ARMA_VERSION_MAJOR > 9 || \
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Test the AMSGrad optimizer on the Sphere function with arma::sp_mat.
  */
@@ -150,8 +142,6 @@ TEST_CASE("AMSGradSphereFunctionTestSpMatDenseGradient", "[AdamTest]")
   REQUIRE(coordinates(0) == Approx(0.0).margin(0.1));
   REQUIRE(coordinates(1) == Approx(0.0).margin(0.1));
 }
-
-#endif
 
 /**
  * Run Adam on logistic regression and make sure the results are acceptable.
@@ -236,9 +226,6 @@ TEST_CASE("QHAdamLogisticRegressionFMatTest", "[AdamTest]")
   LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.03, 0.06);
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Run QHAdam on logistic regression and make sure the results are acceptable,
  * using arma::sp_mat.
@@ -248,8 +235,6 @@ TEST_CASE("QHAdamLogisticRegressionSpMatTest", "[AdamTest]")
   QHAdam optimizer;
   LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.003, 0.006);
 }
-
-#endif
 
 /**
  * Test the Adam optimizer on the Ackley function.

--- a/tests/bigbatch_sgd_test.cpp
+++ b/tests/bigbatch_sgd_test.cpp
@@ -72,9 +72,6 @@ TEST_CASE("BBSArmijoLogisticRegressionFMatTest", "[BigBatchSGDTest]")
   }
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Run big-batch SGD using BBS_BB on logistic regression and make sure the
  * results are acceptable.  Use arma::sp_mat as the objective type.
@@ -102,5 +99,3 @@ TEST_CASE("BBSArmijoLogisticRegressionSpMatTest", "[BigBatchSGDTest]")
     LogisticRegressionFunctionTest<arma::sp_mat>(bbsgd, 0.003, 0.006, 3);
   }
 }
-
-#endif

--- a/tests/eve_test.cpp
+++ b/tests/eve_test.cpp
@@ -54,9 +54,6 @@ TEST_CASE("EveStyblinskiTangFunctionFMatTest","[EveTest]")
   FunctionTest<StyblinskiTangFunction, arma::fmat>(optimizer, 0.5, 0.1);
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Test the Eve optimizer on the Styblinski-Tang function, using arma::sp_mat as
  * the objective type.
@@ -66,5 +63,3 @@ TEST_CASE("EveStyblinskiTangFunctionSpMatTest","[EveTest]")
   Eve optimizer(1e-3, 2, 0.9, 0.999, 0.999, 1e-8, 10000, 500000, 1e-9, true);
   FunctionTest<StyblinskiTangFunction, arma::sp_mat>(optimizer, 0.5, 0.1);
 }
-
-#endif

--- a/tests/katyusha_test.cpp
+++ b/tests/katyusha_test.cpp
@@ -71,9 +71,6 @@ TEST_CASE("KatyushaProximalLogisticRegressionFMatTest", "[KatyushaTest]")
   }
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Run Katyusha on logistic regression and make sure the results are acceptable.
  * Use arma::sp_mat.
@@ -101,5 +98,3 @@ TEST_CASE("KatyushaProximalLogisticRegressionSpMatTest", "[KatyushaTest]")
     LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.015, 0.015);
   }
 }
-
-#endif

--- a/tests/rmsprop_test.cpp
+++ b/tests/rmsprop_test.cpp
@@ -35,9 +35,6 @@ TEST_CASE("RMSPropLogisticRegressionFMatTest", "[rmsprop]")
   LogisticRegressionFunctionTest<arma::fmat>(optimizer, 0.003, 0.006);
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Run RMSProp on logistic regression and make sure the results are acceptable.
  * Use arma::sp_mat.
@@ -47,5 +44,3 @@ TEST_CASE("RMSPropLogisticRegressionSpMatTest", "[rmsprop]")
   RMSProp optimizer;
   LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.003, 0.006);
 }
-
-#endif

--- a/tests/sarah_test.cpp
+++ b/tests/sarah_test.cpp
@@ -72,9 +72,6 @@ TEST_CASE("SARAHPlusLogisticRegressionFMatTest","[SARAHTest]")
   }
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Run SARAH on logistic regression and make sure the results are
  * acceptable.  Use arma::sp_mat.
@@ -102,5 +99,3 @@ TEST_CASE("SARAHPlusLogisticRegressionSpMatTest","[SARAHTest]")
     LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.015, 0.015);
   }
 }
-
-#endif

--- a/tests/sgdr_test.cpp
+++ b/tests/sgdr_test.cpp
@@ -81,9 +81,6 @@ TEST_CASE("SGDRLogisticRegressionFMatTest","[SGDRTest]")
   }
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Run SGDR on logistic regression and make sure the results are acceptable.
  * Use arma::sp_mat.
@@ -97,5 +94,3 @@ TEST_CASE("SGDRLogisticRegressionSpMatTest","[SGDRTest]")
     LogisticRegressionFunctionTest<arma::sp_mat>(sgdr, 0.003, 0.006);
   }
 }
-
-#endif

--- a/tests/snapshot_ensembles.cpp
+++ b/tests/snapshot_ensembles.cpp
@@ -85,9 +85,6 @@ TEST_CASE("SnapshotEnsemblesLogisticRegressionFMatTest","[SnapshotEnsemblesTest]
   }
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Run SGDR with snapshot ensembles on logistic regression and make sure the
  * results are acceptable.  Use arma::sp_mat.
@@ -102,5 +99,3 @@ TEST_CASE("SnapshotEnsemblesLogisticRegressionSpMatTest",
     LogisticRegressionFunctionTest<arma::sp_mat>(sgdr, 0.003, 0.006);
   }
 }
-
-#endif

--- a/tests/svrg_test.cpp
+++ b/tests/svrg_test.cpp
@@ -72,9 +72,6 @@ TEST_CASE("SVRGBBLogisticRegressionFMatTest", "[SVRGTest]")
   }
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Run SVRG on logistic regression and make sure the results are acceptable.
  * Use arma::sp_mat.
@@ -103,5 +100,3 @@ TEST_CASE("SVRGBBLogisticRegressionSpMatTest", "[SVRGTest]")
     LogisticRegressionFunctionTest<arma::sp_mat>(optimizer, 0.015, 0.015);
   }
 }
-
-#endif

--- a/tests/swats_test.cpp
+++ b/tests/swats_test.cpp
@@ -54,9 +54,6 @@ TEST_CASE("SWATSStyblinskiTangFunctionFMatTest", "[SWATSTest]")
   FunctionTest<StyblinskiTangFunction, arma::fmat>(optimizer, 3.0, 0.3);
 }
 
-#if ARMA_VERSION_MAJOR > 9 ||\
-    (ARMA_VERSION_MAJOR == 9 && ARMA_VERSION_MINOR >= 400)
-
 /**
  * Test the SWATS optimizer on the Styblinski-Tang function.  Use arma::sp_mat.
  */
@@ -65,5 +62,3 @@ TEST_CASE("SWATSStyblinskiTangFunctionSpMatTest", "[SWATSTest]")
   SWATS optimizer(1e-3, 2, 0.9, 0.999, 1e-6, 500000, 1e-9, true);
   FunctionTest<StyblinskiTangFunction, arma::sp_mat>(optimizer, 0.3, 0.03);
 }
-
-#endif


### PR DESCRIPTION
Bump minimum Armadillo version to 10.8.2.

This allows using the numerous Armadillo API additions and enhancements since 9.800.  It also allows assuming throughout the ensmallen codebase that matrices are initialised to zero by default.

Current state of Armadillo versions in various distros:
- Ubuntu 22.04 LTS has Armadillo 10.8.2
- Ubuntu 24.04 LTS has Armadillo 12.6.7
- Debian 12 has Armadillo 11.4.2
- Debian 13 (testing) has Armadillo 12.8.2
- RHEL EPEL 8 & 9 has Armadillo 12.6.6 (subject to future upgrades)

Related: https://github.com/mlpack/mlpack/pull/3760
