### PR TITLE
Armadillo 14.2.0 deprecation changes to (index) .min() and .max()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,9 @@
  * Bump minimum Armadillo version to 10.8
    ([#404](https://github.com/mlpack/ensmallen/pull/404)).
 
+ * For Armadillo 14.2.0 switch to `.index_min()` and `.index_max()`
+   ([#409](https://github.com/mlpack/ensmallen/pull/409).
+
 ### ensmallen 2.21.1: "Bent Antenna"
 ###### 2024-02-15
  * Fix numerical precision issues for small-gradient L-BFGS scaling factor

--- a/include/ensmallen_bits/fw/atoms.hpp
+++ b/include/ensmallen_bits/fw/atoms.hpp
@@ -96,8 +96,7 @@ class Atoms
       // Find possible atom to be deleted.
       arma::vec gap = sqTerm -
           currentCoeffs % trans(gradient.t() * currentAtoms);
-      arma::uword ind;
-      gap.min(ind);
+      arma::uword ind = gap.index_min();
 
       // Try deleting the atom.
       arma::mat newAtoms(currentAtoms.n_rows, currentAtoms.n_cols - 1);

--- a/include/ensmallen_bits/fw/constr_lpball.hpp
+++ b/include/ensmallen_bits/fw/constr_lpball.hpp
@@ -118,8 +118,8 @@ class ConstrLpBallSolver
       else
         s = arma::abs(v);
 
-      arma::uword k = 0;
-      s.max(k);  // k is the linear index of the largest element.
+      // k is the linear index of the largest element.
+      arma::uword k = s.index_max();
       s.zeros();
       // Take the sign of v(k).
       s(k) = -((0.0 < v(k)) - (v(k) < 0.0));


### PR DESCRIPTION
Building `mlpack` under R using (Rcpp)Armadillo 14.2.0-1 leads to deprecation warnings which e.g. CRAN nags about.  The warnings start with the index minimum call in `atoms.hpp`; the change addresses and `ensmallen` (or rather `RcppEnsmallen`) still tests fine with it.  The second change is only other case I found with a quick search, there may be more.