### PR TITLE
Bugfix/unused variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(ensmallen INTERFACE
 if(MSVC)
   target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:/Wall>)
 else()
-  target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:-Wall -Wpedantic -Wunused-parameter>)
+  target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:-Wall -Wpedantic -Wunused-parameter -Wunused-variable>)
 endif()
 
 # Find OpenMP and link it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(ensmallen INTERFACE
 if(MSVC)
   target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:/Wall>)
 else()
-  target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:-Wall -Wpedantic -Wunused-parameter -Wunused-variable>)
+  target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:-Wall -Wpedantic -Wunused-parameter -Wunused-variable -Wunused-private-field>)
 endif()
 
 # Find OpenMP and link it.

--- a/include/ensmallen_bits/agemoea/agemoea.hpp
+++ b/include/ensmallen_bits/agemoea/agemoea.hpp
@@ -452,12 +452,6 @@ class AGEMOEA
   //! Probability that crossover will occur.
   double crossoverProb;
 
-  //! Probability that mutation will occur.
-  double mutationProb;
-
-  //! Strength of the mutation.
-  double mutationStrength;
-
   //! The crowding degree of the mutation. Higher value produces a mutant
   //! resembling its parent.
   double distributionIndex;

--- a/include/ensmallen_bits/problems/dtlz/dtlz2_function.hpp
+++ b/include/ensmallen_bits/problems/dtlz/dtlz2_function.hpp
@@ -110,7 +110,6 @@ namespace test {
        */
       arma::Row<typename MatType::elem_type> g(const MatType& coords)
       {
-        size_t k = numVariables - numObjectives + 1;
 
         // Convenience typedef.
         typedef typename MatType::elem_type ElemType;

--- a/include/ensmallen_bits/problems/dtlz/dtlz4_function.hpp
+++ b/include/ensmallen_bits/problems/dtlz/dtlz4_function.hpp
@@ -113,7 +113,6 @@ namespace test {
        */
       arma::Row<typename MatType::elem_type> g(const MatType& coords)
       {
-        size_t k = numVariables - numObjectives + 1;
 
         // Convenience typedef.
         typedef typename MatType::elem_type ElemType;

--- a/include/ensmallen_bits/problems/dtlz/dtlz5_function.hpp
+++ b/include/ensmallen_bits/problems/dtlz/dtlz5_function.hpp
@@ -110,7 +110,6 @@ namespace test {
        */
       arma::Row<typename MatType::elem_type> g(const MatType& coords)
       {
-        size_t k = numVariables - numObjectives + 1;
 
         // Convenience typedef.
         typedef typename MatType::elem_type ElemType;

--- a/include/ensmallen_bits/problems/dtlz/dtlz6_function.hpp
+++ b/include/ensmallen_bits/problems/dtlz/dtlz6_function.hpp
@@ -110,7 +110,6 @@ namespace test {
        */
       arma::Row<typename MatType::elem_type> g(const MatType& coords)
       {
-        size_t k = numVariables - numObjectives + 1;
 
         // Convenience typedef.
         typedef typename MatType::elem_type ElemType;

--- a/include/ensmallen_bits/problems/dtlz/dtlz7_function.hpp
+++ b/include/ensmallen_bits/problems/dtlz/dtlz7_function.hpp
@@ -110,7 +110,6 @@ namespace test {
        */
       arma::Row<typename MatType::elem_type> g(const MatType& coords)
       {
-        size_t k = numVariables - numObjectives + 1;
 
         // Convenience typedef.
         typedef typename MatType::elem_type ElemType;

--- a/include/ensmallen_bits/problems/dtlz/dtlz7_function.hpp
+++ b/include/ensmallen_bits/problems/dtlz/dtlz7_function.hpp
@@ -110,6 +110,7 @@ namespace test {
        */
       arma::Row<typename MatType::elem_type> g(const MatType& coords)
       {
+        size_t k = numVariables - numObjectives + 1;
 
         // Convenience typedef.
         typedef typename MatType::elem_type ElemType;
@@ -130,7 +131,6 @@ namespace test {
       arma::Row<typename MatType::elem_type> h(
           const MatType& coords, const arma::Row<typename MatType::elem_type>& G)
       {
-        size_t k = numVariables - numObjectives + 1;
 
         // Convenience typedef.
         typedef typename MatType::elem_type ElemType;

--- a/include/ensmallen_bits/problems/maf/maf5_function.hpp
+++ b/include/ensmallen_bits/problems/maf/maf5_function.hpp
@@ -131,7 +131,6 @@ namespace test {
        */
       arma::Row<typename MatType::elem_type> g(const MatType& coords)
       {
-        size_t k = numVariables - numObjectives + 1;
 
         // Convenience typedef.
         typedef typename MatType::elem_type ElemType;

--- a/include/ensmallen_bits/problems/maf/maf6_function.hpp
+++ b/include/ensmallen_bits/problems/maf/maf6_function.hpp
@@ -116,7 +116,6 @@ namespace test {
        */
       arma::Row<typename MatType::elem_type> g(const MatType& coords)
       {
-        size_t k = numVariables - numObjectives + 1;
 
         // Convenience typedef.
         typedef typename MatType::elem_type ElemType;


### PR DESCRIPTION
This PR tackles #412 by removing unused variables. 

I've also modified `CMakeLists.txt` to warn if it detects unused variables and private fields. (It's already warning on unused parameters!)