### PR TITLE
Add an entry in the HISTORY for #413

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(ensmallen INTERFACE
 if(MSVC)
   target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:/Wall>)
 else()
-  target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:-Wall -Wpedantic -Wunused-parameter -Wunused-variable -Wunused-private-field>)
+  target_compile_options(ensmallen INTERFACE $<BUILD_INTERFACE:-Wall -Wpedantic -Wunused>)
 endif()
 
 # Find OpenMP and link it.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Remove unused variables to fix compiler warnings
+   ([#413](https://github.com/mlpack/ensmallen/pull/413)).
 
 ### ensmallen 2.22.0: "E-Bike Excitement"
 ###### 2024-11-29


### PR DESCRIPTION
I noticed that there was not a line in HISTORY.md for #413, so I added one.  (This will mean that the changelog won't be empty when I open a PR to release 2.22.1 with that fix.)