### PR TITLE
List minimum Armadillo version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation and downloads: https://ensmallen.org
 ### Requirements
 
 * C++ compiler with C++14 support
-* Armadillo (https://arma.sourceforge.net) >= 10.8.2
+* Armadillo (https://arma.sourceforge.net), version 10.8.2 or later
 * OpenBLAS or Intel MKL or LAPACK (see Armadillo site for details)
 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation and downloads: https://ensmallen.org
 ### Requirements
 
 * C++ compiler with C++14 support
-* Armadillo: https://arma.sourceforge.net
+* Armadillo (https://arma.sourceforge.net) >= 10.8.2
 * OpenBLAS or Intel MKL or LAPACK (see Armadillo site for details)
 
 


### PR DESCRIPTION
Just a little cleanup---I noticed this morning that this is not listed.