### PR TITLE
fix include

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Fix include statement in `tests/de_test.cpp`
+   ([#419](https://github.com/mlpack/ensmallen/pull/419)).
+
  * Fix `exactObjective` output for SGD-like optimizers when the number of
    iterations is an even number of epochs
    ([#417](https://github.com/mlpack/ensmallen/pull/417)).

--- a/tests/de_test.cpp
+++ b/tests/de_test.cpp
@@ -8,7 +8,7 @@
  * http://www.opensource.org/licenses/BSD-3-Clause for more information.
  */
 
-#include "../include/ensmallen.hpp"
+#include <ensmallen.hpp>
 #include "catch.hpp"
 #include "test_function_tools.hpp"
 


### PR DESCRIPTION
Fix include statement to be consistent with other tests.
This is to resolve the following bug:

> include path
> The C++ test files must #include <ensmallen.hpp>
> rather than "../include/ensmallen.hpp"
> in order to allow the installed files, rather than the repo-local files, to be tested.
> 
> https://sources.debian.org/src/ensmallen/2.22.1-1/debian/patches/0001-include-path.patch/

@rcurtin @shrit @zoq @barak @eddelbuettel 