### PR TITLE
increase tolerance

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@
    iterations is an even number of epochs
    ([#417](https://github.com/mlpack/ensmallen/pull/417)).
 
+ * Increase tolerance in `demon_sgd_test.cpp`
+   ([#420](https://github.com/mlpack/ensmallen/pull/420)).
+
 ### ensmallen 2.22.1: "E-Bike Excitement"
 ###### 2024-12-02
  * Remove unused variables to fix compiler warnings

--- a/tests/demon_sgd_test.cpp
+++ b/tests/demon_sgd_test.cpp
@@ -22,7 +22,7 @@ using namespace ens::test;
 TEST_CASE("DemonSGDLogisticRegressionTest", "[DemonSGDTest]")
 {
   DemonSGD optimizer(0.1, 32, 0.9, 1000000, 1e-9, true, true, true);
-  LogisticRegressionFunctionTest(optimizer, 0.003, 0.006, 6);
+  LogisticRegressionFunctionTest(optimizer, 0.006, 0.006, 6);
 }
 
 /**


### PR DESCRIPTION
Increase tolerance for tests failing on 32 bit armel and armhf, aiming to address bug report #418.

PS. The form `Approx(x).epsilon(y)` as used by ensmallen tests is deprecated by Catch2, as it has several problems. The corresponding docs suggest to use `WithinAbs()` and `WithinRel`, as `Approx()` cannot be fixed without breaking backwards compatibility.  This would require rewriting all of the tests in ensmallen, which is beyond the scope of this PR.

https://github.com/catchorg/Catch2/blob/devel/docs/comparing-floating-point-numbers.md#top

@rcurtin @shrit @zoq @barak @eddelbuettel 