### PR TITLE
Set cmake version range to 3.5..4.0 which accommodates newer 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ensmallen CMake configuration.  This project has no configurable options---it
 # just installs the headers to the install location, and optionally builds the
 # test program.
-cmake_minimum_required(VERSION 3.3.2...3.5)
+cmake_minimum_required(VERSION 3.5..4.0)
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")  # ensure the tests are built with optimisation
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ensmallen CMake configuration.  This project has no configurable options---it
 # just installs the headers to the install location, and optionally builds the
 # test program.
-cmake_minimum_required(VERSION 3.5..4.0)
+cmake_minimum_required(VERSION 3.5...4.0)
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")  # ensure the tests are built with optimisation
 endif ()


### PR DESCRIPTION
CRAN had actually come knocking a few weeks ago for another (small) project where I had (inherited from upstream) a similar `cmake` version range that the newer (and then unreleased, now it is out) version 4.0.* barked over.

Picking 3.5..4.0 appears to be a reasonable compromise as 3.5 is both sufficient ancient yet still suitable.  Beginning the interval with something older than 3.5 is apparently recommended against by the Kitware folks if I recall correctly.