### PR TITLE
use .index_min() instead of the deprecated form .min(index)

### DIFF
--- a/include/ensmallen_bits/fw/atoms.hpp
+++ b/include/ensmallen_bits/fw/atoms.hpp
@@ -96,8 +96,8 @@ class Atoms
       // Find possible atom to be deleted.
       arma::vec gap = sqTerm -
           currentCoeffs % trans(gradient.t() * currentAtoms);
-      arma::uword ind;
-      gap.min(ind);
+
+      arma::uword ind = gap.index_min();
 
       // Try deleting the atom.
       arma::mat newAtoms(currentAtoms.n_rows, currentAtoms.n_cols - 1);


### PR DESCRIPTION
Use `index = X.index_min()` instead of the deprecated form `X.min(index)`.

Related: https://github.com/mlpack/ensmallen/pull/432


