### PR TITLE
Deprecate the `Lambda()` and `Sigma()` functions for `AugLagrangian`

### DIFF
--- a/doc/optimizers.md
+++ b/doc/optimizers.md
@@ -808,44 +808,20 @@ corresponding vector type (e.g. `arma::vec` or `coot::fvec`).
 The attributes of the optimizer may also be modified via the member methods
 `MaxIterations()`, `PenaltyThresholdFactor()`, `SigmaUpdateFactor()` and `LBFGS()`.
 
-<details open>
-<summary>Click to collapse/expand example code.
-</summary>
+The `AugLagrangian` optimizer also allows manually specifying the initial
+Lagrange multipliers (`lambda`) and penalty parameter (`sigma`) directly in the
+call to `Optimize()`.  For this, the following version of `Optimize()` should be
+used:
 
-```c++
-/**
- * Optimize the function.  The value '1' is used for the initial value of each
- * Lagrange multiplier.  To set the Lagrange multipliers yourself, use the
- * other overload of Optimize().
- *
- * @tparam LagrangianFunctionType Function which can be optimized by this
- *     class.
- * @param function The function to optimize.
- * @param coordinates Output matrix to store the optimized coordinates in.
- */
-template<typename LagrangianFunctionType>
-bool Optimize(LagrangianFunctionType& function,
-              arma::mat& coordinates);
+ * `opt.Optimize(`_`function, coordinates, lambda, sigma, callbacks...`_`)`
 
-/**
- * Optimize the function, giving initial estimates for the Lagrange
- * multipliers.  The vector of Lagrange multipliers will be modified to
- * contain the Lagrange multipliers of the final solution (if one is found).
- *
- * @tparam LagrangianFunctionType Function which can be optimized by this
- *      class.
- * @param function The function to optimize.
- * @param coordinates Output matrix to store the optimized coordinates in.
- * @param initLambda Vector of initial Lagrange multipliers.  Should have
- *     length equal to the number of constraints.
- * @param initSigma Initial penalty parameter.
- */
-template<typename LagrangianFunctionType>
-bool Optimize(LagrangianFunctionType& function,
-              arma::mat& coordinates,
-              const arma::vec& initLambda,
-              const double initSigma);
-```
+In that call, `lambda` should be a column vector of the same type as
+`coordinates`, and `sigma` is a `double`.  `lambda` and `sigma` will be
+overwritten with the final values of the Lagrange multipliers and penalty
+parameters.
+
+If `lambda` and `sigma` are not specified, then 0 is used as the initial value
+for all Lagrange multipliers and 10 is used as the initial penalty parameter.
 
 </details>
 
@@ -2111,6 +2087,20 @@ The attributes of the LRSDP optimizer may only be accessed via member methods.
 |----------|----------|-----------------|-------------|
 | `size_t` | **`MaxIterations()`** | Maximum number of iterations before termination. | `1000` |
 | `AugLagrangian` | **`AugLag()`** | The internally-held Augmented Lagrangian optimizer. | **n/a** |
+
+Because `LRSDP` uses the [`AugLagrangian`](#auglagrangian) optimizer internally,
+an additional overload of `Optimize()` is supplied to allow specifying the
+initial Lagrange multiplier estimates and penalty parameter:
+
+ * `lrsdp.Optimize(`_`coordinates, lambda, sigma, callbacks...`_`)`
+
+In that call, `lambda` should be a column vector of the same type as
+`coordinates`, and `sigma` is a `double`.  `lambda` and `sigma` will be
+overwritten with the final values of the Lagrange multipliers and penalty
+parameters.
+
+If `lambda` and `sigma` are not specified, then 0 is used as the initial value
+for all Lagrange multipliers and 10 is used as the initial penalty parameter.
 
 #### See also:
 

--- a/include/ensmallen.hpp
+++ b/include/ensmallen.hpp
@@ -81,6 +81,7 @@
 #include "ensmallen_bits/utility/proxies.hpp"
 #include "ensmallen_bits/utility/function_traits.hpp"
 #include "ensmallen_bits/utility/using.hpp"
+#include "ensmallen_bits/utility/detect_callbacks.hpp"
 #include "ensmallen_bits/utility/indicators/epsilon.hpp"
 #include "ensmallen_bits/utility/indicators/igd.hpp"
 #include "ensmallen_bits/utility/indicators/igd_plus.hpp"

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_function.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_function.hpp
@@ -36,15 +36,6 @@ class AugLagrangianFunction
 {
  public:
   /**
-   * Initialize the AugLagrangianFunction, but don't set the Lagrange
-   * multipliers or penalty parameters yet.  Make sure you set the Lagrange
-   * multipliers before you use this...
-   *
-   * @param function Lagrangian function.
-   */
-  AugLagrangianFunction(LagrangianFunction& function);
-
-  /**
    * Initialize the AugLagrangianFunction with the given LagrangianFunction,
    * Lagrange multipliers, and initial penalty parameter.
    *
@@ -53,8 +44,8 @@ class AugLagrangianFunction
    * @param sigma Initial penalty parameter.
    */
   AugLagrangianFunction(LagrangianFunction& function,
-                        const VecType& lambda,
-                        const double sigma);
+                        VecType& lambda,
+                        double& sigma);
   /**
    * Evaluate the objective function of the Augmented Lagrangian function, which
    * is the standard Lagrangian function evaluation plus a penalty term, which
@@ -84,14 +75,9 @@ class AugLagrangianFunction
   template<typename MatType>
   const MatType& GetInitialPoint() const;
 
-  //! Get the Lagrange multipliers.
-  const VecType& Lambda() const { return lambda; }
-  //! Modify the Lagrange multipliers.
+  // Get the Lagrange multipliers.
   VecType& Lambda() { return lambda; }
-
-  //! Get sigma (the penalty parameter).
-  double Sigma() const { return sigma; }
-  //! Modify sigma (the penalty parameter).
+  // Get the penalty parameter.
   double& Sigma() { return sigma; }
 
   //! Get the Lagrangian function.
@@ -104,9 +90,9 @@ class AugLagrangianFunction
   LagrangianFunction& function;
 
   //! The Lagrange multipliers.
-  VecType lambda;
+  VecType& lambda;
   //! The penalty parameter.
-  double sigma;
+  double& sigma;
 };
 
 } // namespace ens

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_function_impl.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_function_impl.hpp
@@ -22,21 +22,9 @@ namespace ens {
 // Initialize the AugLagrangianFunction.
 template<typename LagrangianFunction, typename VecType>
 AugLagrangianFunction<LagrangianFunction, VecType>::AugLagrangianFunction(
-    LagrangianFunction& function) :
-    function(function),
-    lambda(function.NumConstraints()),
-    sigma(10)
-{
-  // Initialize lambda vector to all zeroes.
-  lambda.zeros();
-}
-
-// Initialize the AugLagrangianFunction.
-template<typename LagrangianFunction, typename VecType>
-AugLagrangianFunction<LagrangianFunction, VecType>::AugLagrangianFunction(
     LagrangianFunction& function,
-    const VecType& lambda,
-    const double sigma) :
+    VecType& lambda,
+    double& sigma) :
     function(function),
     lambda(lambda),
     sigma(sigma)

--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian_impl.hpp
@@ -30,27 +30,25 @@ inline AugLagrangianType<VecType>::AugLagrangianType(
     sigmaUpdateFactor(sigmaUpdateFactor),
     lbfgs(lbfgs),
     terminate(false),
-    sigma(0.0)
+    deprecatedSigma(0.0)
 {
 }
 
 template<typename VecType>
 template<typename LagrangianFunctionType,
          typename MatType,
+         typename InVecType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsMatrixType<GradType>::value, bool>::type
 AugLagrangianType<VecType>::Optimize(
     LagrangianFunctionType& function,
     MatType& coordinates,
-    const VecType& initLambda,
-    const double initSigma,
+    InVecType& lambda,
+    double& sigma,
     CallbackTypes&&... callbacks)
 {
-  lambda = initLambda;
-  sigma = initSigma;
-
-  AugLagrangianFunction<LagrangianFunctionType, VecType> augfunc(
+  AugLagrangianFunction<LagrangianFunctionType, InVecType> augfunc(
       function, lambda, sigma);
 
   return Optimize(augfunc, coordinates, callbacks...);
@@ -61,23 +59,37 @@ template<typename LagrangianFunctionType,
          typename MatType,
          typename GradType,
          typename... CallbackTypes>
-typename std::enable_if<IsMatrixType<GradType>::value, bool>::type
+typename std::enable_if<IsMatrixType<GradType>::value &&
+                        IsAllNonMatrix<CallbackTypes...>::value, bool>::type
 AugLagrangianType<VecType>::Optimize(LagrangianFunctionType& function,
-                        MatType& coordinates,
-                        CallbackTypes&&... callbacks)
+                                     MatType& coordinates,
+                                     CallbackTypes&&... callbacks)
 {
+  typedef typename ForwardType<MatType>::bvec InVecType;
+
   // If the user did not specify the right size for sigma and lambda, we will
   // use defaults.
-  if (!lambda.is_empty())
+  // TODO: remove this when ensmallen 4.x is released!
+  if (!deprecatedLambda.is_empty())
   {
-    AugLagrangianFunction<LagrangianFunctionType, decltype(lambda)> augfunc(
-        function, lambda, sigma);
-    return Optimize(augfunc, coordinates, callbacks...);
+    InVecType lambda(conv_to<InVecType>::from(deprecatedLambda));
+
+    AugLagrangianFunction<LagrangianFunctionType, InVecType> augfunc(function,
+        lambda, deprecatedSigma);
+    const bool result = Optimize(augfunc, coordinates, callbacks...);
+    deprecatedLambda = conv_to<VecType>::from(lambda);
+
+    return result;
   }
   else
   {
-    AugLagrangianFunction<LagrangianFunctionType, decltype(lambda)> augfunc(
-        function);
+    // Use default values.
+    InVecType lambda(function.NumConstraints());
+    lambda.zeros();
+    double sigma = 10;
+
+    AugLagrangianFunction<LagrangianFunctionType, InVecType> augfunc(
+        function, lambda, sigma);
     return Optimize(augfunc, coordinates, callbacks...);
   }
 }
@@ -85,11 +97,12 @@ AugLagrangianType<VecType>::Optimize(LagrangianFunctionType& function,
 template<typename VecType>
 template<typename LagrangianFunctionType,
          typename MatType,
+         typename InVecType,
          typename GradType,
          typename... CallbackTypes>
 typename std::enable_if<IsMatrixType<GradType>::value, bool>::type
 AugLagrangianType<VecType>::Optimize(
-    AugLagrangianFunction<LagrangianFunctionType, VecType>& augfunc,
+    AugLagrangianFunction<LagrangianFunctionType, InVecType>& augfunc,
     MatType& coordinatesIn,
     CallbackTypes&&... callbacks)
 {
@@ -157,9 +170,6 @@ AugLagrangianType<VecType>::Optimize(
     if (std::abs(lastObjective - objective) < tolerance &&
         augfunc.Sigma() > 500000)
     {
-      lambda = std::move(augfunc.Lambda());
-      sigma = augfunc.Sigma();
-
       Callback::EndOptimization(*this, function, coordinates, callbacks...);
       return true;
     }

--- a/include/ensmallen_bits/sdp/lrsdp.hpp
+++ b/include/ensmallen_bits/sdp/lrsdp.hpp
@@ -75,6 +75,22 @@ class LRSDP
   typename MatType::elem_type Optimize(MatType& coordinates,
                                        CallbackTypes&&... callbacks);
 
+  /**
+   * Optimize the LRSDP and return the final objective value, using the given
+   * starting Lagrange multipliers and penalty parameter for the augmented
+   * Lagrangian inner optimizer.  The given coordinates will be modified to
+   * contain the final solution, and the given lambda/sigma will be modified to
+   * contain the final values.
+   *
+   * @param coordinates Starting coordinates for the optimization.
+   * @param callbacks Callback functions.
+   */
+  template<typename MatType, typename VecType, typename... CallbackTypes>
+  typename MatType::elem_type Optimize(MatType& coordinates,
+                                       VecType& lambda,
+                                       double& sigma,
+                                       CallbackTypes&&... callbacks);
+
   //! Return the SDP that will be solved.
   const SDPType& SDP() const { return function.SDP(); }
   //! Modify the SDP that will be solved.

--- a/include/ensmallen_bits/sdp/lrsdp_impl.hpp
+++ b/include/ensmallen_bits/sdp/lrsdp_impl.hpp
@@ -35,9 +35,28 @@ typename MatType::elem_type LRSDP<SDPType>::Optimize(
   function.RRTAny().template Set<MatType>(
       new MatType(coordinates * coordinates.t()));
 
-  augLag.Sigma() = 10;
   augLag.MaxIterations() = maxIterations;
-  augLag.Optimize(function, coordinates, callbacks...);
+  typename ForwardType<MatType>::bvec lambda(function.NumConstraints());
+  double sigma = 10;
+  augLag.Optimize(function, coordinates, lambda, sigma, callbacks...);
+
+  return function.Evaluate(coordinates);
+}
+
+template<typename SDPType>
+template<typename MatType, typename VecType, typename... CallbackTypes>
+typename MatType::elem_type LRSDP<SDPType>::Optimize(
+    MatType& coordinates,
+    VecType& lambda,
+    double& sigma,
+    CallbackTypes&&... callbacks)
+{
+  function.RRTAny().Clean();
+  function.RRTAny().template Set<MatType>(
+      new MatType(coordinates * coordinates.t()));
+
+  augLag.MaxIterations() = maxIterations;
+  augLag.Optimize(function, coordinates, lambda, sigma, callbacks...);
 
   return function.Evaluate(coordinates);
 }


### PR DESCRIPTION
During the review process for #352, we identified that the `AugLagrangian` class, like the multi-objective optimizers, had a template parameter that it shouldn't and stored state that was really a result of the optimization and should be something returned by `Optimize()`.  So, before this PR, if you wanted to get the Lagrange multipliers and penalty parameter after optimization, you would do:

```c++
arma::vec lambda;
double sigma;
opt.Optimize(function, coordinates);

lambda = opt.Lambda();
sigma = opt.Sigma();
```

However, much like the pareto front and population for multi-objective optimizers, this is really something that should be done more like this:

```c++
arma::vec lambda;
double sigma;
opt.Optimize(function, coordinates, lambda, sigma);
```

This PR makes that change (although there was some extra work necessary to disambiguate different overloads).  Documentation is updated too.