### PR TITLE
Release version 3.10.0: "Unexpected Rain"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,8 @@ $ cd ensmallen
 
 # - or -
 
-$ wget http://ensmallen.org/files/ensmallen-2.22.2.tar.gz
-$ tar -xvzpf ensmallen-2.22.2.tar.gz
+$ wget http://ensmallen.org/files/ensmallen-3.10.0.tar.gz
+$ tar -xvzpf ensmallen-3.10.0.tar.gz
 $ cd ensmallen-latest
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### ensmallen ?.??.?: "???"
+###### ????-??-??
+
 ### ensmallen 3.10.0: "Unexpected Rain"
 ###### 2025-09-25
  * SGD-like optimizers now all divide the step size by the batch size so that

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-### ensmallen ?.??.?: "???"
-###### ????-??-??
+### ensmallen 3.10.0: "Unexpected Rain"
+###### 2025-09-25
  * SGD-like optimizers now all divide the step size by the batch size so that
    step sizes don't need to be tuned in addition to batch sizes.  If you require
    behavior from ensmallen 2, define the `ENS_OLD_SEPARABLE_STEP_BEHAVIOR` macro

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -21,11 +21,11 @@
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not
 // contain the capitalized string "RC".
-#define ENS_VERSION_NAME "RC1"
+#define ENS_VERSION_NAME "Unexpected Rain"
 // Incorporate the date the version was released.
 #define ENS_VERSION_YEAR "2025"
-#define ENS_VERSION_MONTH "04"
-#define ENS_VERSION_DAY "30"
+#define ENS_VERSION_MONTH "09"
+#define ENS_VERSION_DAY "25"
 
 namespace ens {
 


### PR DESCRIPTION
This automatically-generated pull request adds the commits necessary to make the 3.10.0 release.  Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it.  Or, well, hopefully that will happen someday.  When you merge this PR, be sure to merge it using a *rebase*.

### Changelog

 * SGD-like optimizers now all divide the step size by the batch size so that step sizes don't need to be tuned in addition to batch sizes.  If you require behavior from ensmallen 2, define the `ENS_OLD_SEPARABLE_STEP_BEHAVIOR` macro before including `ensmallen.hpp` ([#431](https://github.com/mlpack/ensmallen/pull/431)).
 
 * Remove deprecated `ParetoFront()` and `ParetoSet()` from multi-objective optimizers ([#435](https://github.com/mlpack/ensmallen/pull/435)).  Instead, pass objects to the `Optimize()` function; see the documentation for each multi-objective optimizer for more details.  A typical transition will change code like:
 ```c++ optimizer.Optimize(objectives, coordinates); arma::cube paretoFront = optimizer.ParetoFront(); arma::cube paretoSet = optimizer.ParetoSet(); ```
 to instead gather the Pareto front and set in the call:
 ```c++ arma::cube paretoFront, paretoSet; optimizer.Optimize(objectives, coordinates, paretoFront, paretoSet); ```
 
 * Remove deprecated constructor for Active CMA-ES that takes `lowerBound` and `upperBound` ([#435](https://github.com/mlpack/ensmallen/pull/435)). Instead, pass an instantiated `BoundaryBoxConstraint` to the constructor.  A typical transition will change code like:
 ```c++ ActiveCMAES<FullSelection, BoundaryBoxConstraint> opt(lambda, lowerBound, upperBound, ...); ```
 into
 ```c++ ActiveCMAES<FullSelection, BoundaryBoxConstraint> opt(lambda, BoundaryBoxConstraint(lowerBound, upperBound), ...); ```
 * Add proximal gradient optimizers for L1-constrained and other related problems: `FBS`, `FISTA`, and `FASTA` ([#427](https://github.com/mlpack/ensmallen/pull/427)).  See the documentation for more details.
 
 * The `Lambda()` and `Sigma()` functions of the `AugLagrangian` optimizer, which could be used to retrieve the Lagrange multipliers and penalty parameter after optimization, are now deprecated ([#439](https://github.com/mlpack/ensmallen/pull/439)).  Instead, pass a vector and a double to the `Optimize()` function directly:
 ```c++ augLag.Optimize(function, coordinates, lambda, sigma) ```
 and these will be filled with the final Lagrange multiplier estimates and penalty parameters.