### PR TITLE
Fix an off by one issue affecting number of iterations in multiple optimizers.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+* Fix an off-by-one bug where the maximum number of executed iterations was one
+  less than specified `maxIteration` and update the first iteration to start
+  from 0 instead of 1 in the following optimizers: `cd`, `active_cmaes`,
+  `cmaes`, `fasta`, `fbs`, `fista`, `frank_wolfe`, `gradient_descent`, `iqn`,
+  `parallel_sgd`, `sa`.
 
 ### ensmallen 3.10.0: "Unexpected Rain"
 ###### 2025-09-25

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,8 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
-* Fix an off-by-one bug where the maximum number of executed iterations was one
-  less than specified `maxIteration` and update the first iteration to start
-  from 0 instead of 1 in the following optimizers: `cd`, `active_cmaes`,
-  `cmaes`, `fasta`, `fbs`, `fista`, `frank_wolfe`, `gradient_descent`, `iqn`,
-  `parallel_sgd`, `sa`.
+ * Fix an off-by-one bug where the actual number of executed iterations was one
+   fewer than the specified `maxIterations`
+   ([#443](https://github.com/mlpack/ensmallen/pull/443)).
 
 ### ensmallen 3.10.0: "Unexpected Rain"
 ###### 2025-09-25

--- a/include/ensmallen_bits/cd/cd_impl.hpp
+++ b/include/ensmallen_bits/cd/cd_impl.hpp
@@ -67,7 +67,7 @@ CD<DescentPolicyType>::Optimize(
   bool terminate = false;
 
   const size_t actualMaxIterations = (maxIterations == 0) ?
-    std::numeric_limits<size_t>::max() : maxIterations;
+      std::numeric_limits<size_t>::max() : maxIterations;
 
   // Start iterating.
   Callback::BeginOptimization(*this, function, iterate, callbacks...);
@@ -126,7 +126,7 @@ CD<DescentPolicyType>::Optimize(
   if (!terminate)
   {
     Info << "CD: maximum iterations (" << maxIterations << ") reached; "
-          << "terminating optimization." << std::endl;
+        << "terminating optimization." << std::endl;
   }
   
   // Calculate and return final objective.  No need to pay attention to the

--- a/include/ensmallen_bits/cd/cd_impl.hpp
+++ b/include/ensmallen_bits/cd/cd_impl.hpp
@@ -66,9 +66,12 @@ CD<DescentPolicyType>::Optimize(
   // Controls early termination of the optimization process.
   bool terminate = false;
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+    std::numeric_limits<size_t>::max() : maxIterations;
+
   // Start iterating.
   Callback::BeginOptimization(*this, function, iterate, callbacks...);
-  for (size_t i = 1; i != maxIterations && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     // Get the coordinate to descend on.
     size_t featureIdx = descentPolicy.template DescentFeature<
@@ -120,9 +123,12 @@ CD<DescentPolicyType>::Optimize(
     }
   }
 
-  Info << "CD: maximum iterations (" << maxIterations << ") reached; "
-      << "terminating optimization." << std::endl;
-
+  if (!terminate)
+  {
+    Info << "CD: maximum iterations (" << maxIterations << ") reached; "
+          << "terminating optimization." << std::endl;
+  }
+  
   // Calculate and return final objective.  No need to pay attention to the
   // result of the callback.
   const ElemType objective = function.Evaluate(iterate);

--- a/include/ensmallen_bits/cmaes/active_cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/active_cmaes_impl.hpp
@@ -170,7 +170,7 @@ typename MatType::elem_type ActiveCMAES<SelectionPolicyType,
   {
     // To keep track of where we are.
     idx0 = i % 2;
-    idx1 = (i+1) % 2;
+    idx1 = (i + 1) % 2;
 
     // Perform Cholesky decomposition. If the matrix is not positive definite,
     // add a small value and try again.

--- a/include/ensmallen_bits/cmaes/active_cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/active_cmaes_impl.hpp
@@ -152,6 +152,9 @@ typename MatType::elem_type ActiveCMAES<SelectionPolicyType,
   // The current visitation order (sorted by population objectives).
   UVecType idx = linspace<UVecType>(0, lambda - 1, lambda);
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   // Now iterate!
   Callback::BeginOptimization(*this, function, transformedIterate,
       callbacks...);
@@ -163,11 +166,11 @@ typename MatType::elem_type ActiveCMAES<SelectionPolicyType,
   size_t patience = 10 + (30 * iterate.n_elem / lambda) + 1;
   size_t steps = 0;
 
-  for (size_t i = 1; (i != maxIterations) && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     // To keep track of where we are.
-    idx0 = (i - 1) % 2;
-    idx1 = i % 2;
+    idx0 = i % 2;
+    idx1 = (i+1) % 2;
 
     // Perform Cholesky decomposition. If the matrix is not positive definite,
     // add a small value and try again.

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -156,6 +156,9 @@ typename MatType::elem_type CMAES<SelectionPolicyType,
   // The current visitation order (sorted by population objectives).
   UVecType idx = linspace<UVecType>(0, lambda - 1, lambda);
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   // Now iterate!
   Callback::BeginOptimization(*this, function, transformedIterate,
       callbacks...);
@@ -165,11 +168,11 @@ typename MatType::elem_type CMAES<SelectionPolicyType,
   size_t patience = 10 + (30 * iterate.n_elem / lambda) + 1;
   size_t steps = 0;
 
-  for (size_t i = 1; (i != maxIterations) && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     // To keep track of where we are.
-    const size_t idx0 = (i - 1) % 2;
-    const size_t idx1 = i % 2;
+    const size_t idx0 = i % 2;
+    const size_t idx1 = (i+1) % 2;
 
     // Perform Cholesky decomposition. If the matrix is not positive definite,
     // add a small value and try again.

--- a/include/ensmallen_bits/cmaes/cmaes_impl.hpp
+++ b/include/ensmallen_bits/cmaes/cmaes_impl.hpp
@@ -172,7 +172,7 @@ typename MatType::elem_type CMAES<SelectionPolicyType,
   {
     // To keep track of where we are.
     const size_t idx0 = i % 2;
-    const size_t idx1 = (i+1) % 2;
+    const size_t idx1 = (i + 1) % 2;
 
     // Perform Cholesky decomposition. If the matrix is not positive definite,
     // add a small value and try again.

--- a/include/ensmallen_bits/fasta/fasta_impl.hpp
+++ b/include/ensmallen_bits/fasta/fasta_impl.hpp
@@ -157,8 +157,11 @@ FASTA<BackwardStepType>::Optimize(FunctionType& function,
   ElemType currentStepSize = (ElemType) maxStepSize;
   ElemType lastStepSize = (ElemType) maxStepSize;
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   Callback::BeginOptimization(*this, f, x, callbacks...);
-  for (size_t i = 1; i != maxIterations && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     // During this optimization, we want to optimize h(x) = f(x) + g(x).
     // f(x) is `f`, but g(x) is specified by `BackwardStepType`.

--- a/include/ensmallen_bits/fbs/fbs_impl.hpp
+++ b/include/ensmallen_bits/fbs/fbs_impl.hpp
@@ -77,8 +77,11 @@ FBS<BackwardStepType>::Optimize(FunctionType& function,
   // Controls early termination of the optimization process.
   bool terminate = false;
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   Callback::BeginOptimization(*this, f, iterate, callbacks...);
-  for (size_t i = 1; i != maxIterations && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     // During this optimization, we want to optimize h(x) = f(x) + g(x).
     // f(x) is `f`, but g(x) is specified by `BackwardStepType`.

--- a/include/ensmallen_bits/fista/fista_impl.hpp
+++ b/include/ensmallen_bits/fista/fista_impl.hpp
@@ -123,8 +123,11 @@ FISTA<BackwardStepType>::Optimize(FunctionType& function,
   ElemType currentStepSize = (ElemType) maxStepSize;
   ElemType lastStepSize = (ElemType) maxStepSize;
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   Callback::BeginOptimization(*this, f, x, callbacks...);
-  for (size_t i = 1; i != maxIterations && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     // During this optimization, we want to optimize h(x) = f(x) + g(x).
     // f(x) is `f`, but g(x) is specified by `BackwardStepType`.

--- a/include/ensmallen_bits/fw/frank_wolfe_impl.hpp
+++ b/include/ensmallen_bits/fw/frank_wolfe_impl.hpp
@@ -75,8 +75,11 @@ FrankWolfe<LinearConstrSolverType, UpdateRuleType>::Optimize(
   // Controls early termination of the optimization process.
   bool terminate = false;
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   Callback::BeginOptimization(*this, f, iterate, callbacks...);
-  for (size_t i = 1; i != maxIterations && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     currentObjective = f.EvaluateWithGradient(iterate, gradient);
 

--- a/include/ensmallen_bits/gradient_descent/gradient_descent_impl.hpp
+++ b/include/ensmallen_bits/gradient_descent/gradient_descent_impl.hpp
@@ -65,13 +65,12 @@ GradientDescent::Optimize(FunctionType& function,
   // Controls early termination of the optimization process.
   bool terminate = false;
 
-  // actualMaxIterations (0 means no limit)
   const size_t actualMaxIterations = (maxIterations == 0) ?
       std::numeric_limits<size_t>::max() : maxIterations;
 
   // Now iterate!
   Callback::BeginOptimization(*this, f, iterate, callbacks...);
-  for (size_t i = 1; i <= actualMaxIterations && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     overallObjective = f.EvaluateWithGradient(iterate, gradient);
 

--- a/include/ensmallen_bits/gradient_descent/gradient_descent_impl.hpp
+++ b/include/ensmallen_bits/gradient_descent/gradient_descent_impl.hpp
@@ -65,9 +65,13 @@ GradientDescent::Optimize(FunctionType& function,
   // Controls early termination of the optimization process.
   bool terminate = false;
 
+  // actualMaxIterations (0 means no limit)
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   // Now iterate!
   Callback::BeginOptimization(*this, f, iterate, callbacks...);
-  for (size_t i = 1; i != maxIterations && !terminate; ++i)
+  for (size_t i = 1; i <= actualMaxIterations && !terminate; ++i)
   {
     overallObjective = f.EvaluateWithGradient(iterate, gradient);
 

--- a/include/ensmallen_bits/iqn/iqn_impl.hpp
+++ b/include/ensmallen_bits/iqn/iqn_impl.hpp
@@ -211,8 +211,8 @@ IQN::Optimize(SeparableFunctionType& functionIn,
 
   if (!terminate)
   {
-      Info << "IQN: maximum iterations (" << maxIterations << ") reached; "
-          << "terminating optimization." << std::endl;
+    Info << "IQN: maximum iterations (" << maxIterations << ") reached; "
+        << "terminating optimization." << std::endl;
   }
 
   Callback::EndOptimization(*this, function, iterate, callbacks...);

--- a/include/ensmallen_bits/iqn/iqn_impl.hpp
+++ b/include/ensmallen_bits/iqn/iqn_impl.hpp
@@ -113,8 +113,11 @@ IQN::Optimize(SeparableFunctionType& functionIn,
   BaseGradType gradient(iterate.n_rows, iterate.n_cols);
   BaseMatType u = t[0];
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   Callback::BeginOptimization(*this, function, iterate, callbacks...);
-  for (size_t i = 1; i != maxIterations && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     for (size_t j = 0, f = 0; f < numFunctions; j++)
     {
@@ -206,8 +209,11 @@ IQN::Optimize(SeparableFunctionType& functionIn,
     }
   }
 
-  Info << "IQN: maximum iterations (" << maxIterations << ") reached; "
-      << "terminating optimization." << std::endl;
+  if (!terminate)
+  {
+      Info << "IQN: maximum iterations (" << maxIterations << ") reached; "
+          << "terminating optimization." << std::endl;
+  }
 
   Callback::EndOptimization(*this, function, iterate, callbacks...);
   return overallObjective;

--- a/include/ensmallen_bits/parallel_sgd/parallel_sgd_impl.hpp
+++ b/include/ensmallen_bits/parallel_sgd/parallel_sgd_impl.hpp
@@ -95,11 +95,14 @@ typename MatType::elem_type>::type ParallelSGD<DecayPolicyType>::Optimize(
   arma::Col<size_t> visitationOrder = arma::linspace<arma::Col<size_t>>(0,
       (function.NumFunctions() - 1), function.NumFunctions());
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   // Iterate till the objective is within tolerance or the maximum number of
   // allowed iterations is reached. If maxIterations is 0, this will iterate
   // till convergence.
   Callback::BeginOptimization(*this, function, iterate, callbacks...);
-  for (size_t i = 1; i != maxIterations && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     // Calculate the overall objective.
     lastObjective = overallObjective;

--- a/include/ensmallen_bits/sa/sa_impl.hpp
+++ b/include/ensmallen_bits/sa/sa_impl.hpp
@@ -80,6 +80,9 @@ typename MatType::elem_type SA<CoolingScheduleType>::Optimize(
   BaseMatType moveSize(rows, cols, GetFillType<BaseMatType>::none);
   moveSize.fill(ElemType(initMoveCoef));
 
+  const size_t actualMaxIterations = (maxIterations == 0) ?
+      std::numeric_limits<size_t>::max() : maxIterations;
+
   Callback::BeginOptimization(*this, function, iterate, callbacks...);
 
   // Initial moves to get rid of dependency of initial states.
@@ -92,7 +95,7 @@ typename MatType::elem_type SA<CoolingScheduleType>::Optimize(
   }
 
   // Iterating and cooling.
-  for (size_t i = 0; i != maxIterations && !terminate; ++i)
+  for (size_t i = 0; i < actualMaxIterations && !terminate; ++i)
   {
     oldEnergy = energy;
     terminate |= GenerateMove(function, iterate, accept, moveSize, energy, idx,
@@ -121,8 +124,11 @@ typename MatType::elem_type SA<CoolingScheduleType>::Optimize(
     }
   }
 
-  Warn << "SA: maximum iterations (" << maxIterations << ") reached; "
-      << "terminating optimization." << std::endl;
+  if (!terminate)
+  {
+    Warn << "SA: maximum iterations (" << maxIterations << ") reached; "
+        << "terminating optimization." << std::endl;
+  }
 
   Callback::EndOptimization(*this, function, iterate, callbacks...);
   return energy;


### PR DESCRIPTION
### Description

This PR fixes the following issue in multiple optimizers:

##### Example

If `maxIterations` is non-zero it will perform one less iteration.

https://github.com/mlpack/ensmallen/blob/9aebc1d2e43122213f25bdb4a560a938108c2ccd/include/ensmallen_bits/gradient_descent/gradient_descent_impl.hpp#L70
