### PR TITLE
Add calls to `BeginEpoch` and `EndEpoch` in `GradientDescent`.

### DIFF
--- a/tests/callbacks_test.cpp
+++ b/tests/callbacks_test.cpp
@@ -375,7 +375,7 @@ TEST_CASE("FTMLCallbacksFullFunctionTest", "[CallbacksTest]")
 TEST_CASE("GradientDescentCallbacksFullFunctionTest", "[CallbacksTest]")
 {
   GradientDescent optimizer(0.001, 3, 1e-15);
-  CallbacksFullFunctionTest(optimizer, true, true, false, false, true, true,
+  CallbacksFullFunctionTest(optimizer, true, true, true, true, true, true,
       false, false, true);
 }
 


### PR DESCRIPTION
### Description

The current `GradientDescent` doesn't work with neither `ProgressBar` nor `PrintLoss`.
It doesn't work with `ProgressBar` as `ProgressBar` currently requires `OptimizerType` to have `NumFunctions` and `BatchSize`.
It doesn't work with `PrintLoss` as `PrintLoss` only prints loss when `EndEpoch` is called which `GradientDescent` doesn't call.

This PR adds calls to both `BeginEpoch` and `EndEpoch` in `GradientDescent` so that it can support `PrintLoss`.
