### PR TITLE
fix missing return in aug_lagrangian

### DIFF
--- a/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
+++ b/include/ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp
@@ -121,7 +121,7 @@ class AugLagrangianType
   {
     deprecatedLambda = initLambda;
     deprecatedSigma = initSigma;
-    const bool result = Optimize(function, coordinates, this->deprecatedLambda,
+    return Optimize(function, coordinates, this->deprecatedLambda,
         this->deprecatedSigma,
         std::forward<CallbackTypes>(callbacks)...);
   }


### PR DESCRIPTION
This fixes a missing `return` in one of the implementations of `Optimize` in `aug_lagrangian.hpp`.