### PR TITLE
Revert "Release version 3.11.0: "Sunny Day" (#447)"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,8 @@ $ cd ensmallen
 
 # - or -
 
-$ wget http://ensmallen.org/files/ensmallen-3.11.0.tar.gz
-$ tar -xvzpf ensmallen-3.11.0.tar.gz
+$ wget http://ensmallen.org/files/ensmallen-3.10.0.tar.gz
+$ tar -xvzpf ensmallen-3.10.0.tar.gz
 $ cd ensmallen-latest
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,5 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
-
-### ensmallen 3.11.0: "Sunny Day"
-###### 2025-12-11
  * Refactor `GradientDescent` into
    `GradientDescentType<UpdatePolicyType, DecayPolicyType>` and
    add the `DeltaBarDelta` and `MomentumDeltaBarDelta` optimizers

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -15,17 +15,17 @@
 #define ENS_VERSION_MAJOR 3
 // The minor version is two digits so regular numerical comparisons of versions
 // work right.  The first minor version of a release is always 10.
-#define ENS_VERSION_MINOR 11
+#define ENS_VERSION_MINOR 10
 #define ENS_VERSION_PATCH 0
 // If this is a release candidate, it will be reflected in the version name
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not
 // contain the capitalized string "RC".
-#define ENS_VERSION_NAME "Sunny Day"
+#define ENS_VERSION_NAME "Unexpected Rain"
 // Incorporate the date the version was released.
 #define ENS_VERSION_YEAR "2025"
-#define ENS_VERSION_MONTH "12"
-#define ENS_VERSION_DAY "11"
+#define ENS_VERSION_MONTH "09"
+#define ENS_VERSION_DAY "25"
 
 namespace ens {
 


### PR DESCRIPTION
This reverts commit db5cef982396dcfea945ecab68f3b588b82be77c.  The reason is that when we merge releases (as listed in the auto-generated description) they need to be rebased to produce two commits: the first is the one that gets tagged for the release, the second is the new `HEAD` with the new empty `HISTORY.md` block.