### PR TITLE
Release version 3.11.0: "Sunny Day"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,8 @@ $ cd ensmallen
 
 # - or -
 
-$ wget http://ensmallen.org/files/ensmallen-3.10.0.tar.gz
-$ tar -xvzpf ensmallen-3.10.0.tar.gz
+$ wget http://ensmallen.org/files/ensmallen-3.11.0.tar.gz
+$ tar -xvzpf ensmallen-3.11.0.tar.gz
 $ cd ensmallen-latest
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### ensmallen ?.??.?: "???"
+###### ????-??-??
+
 ### ensmallen 3.11.0: "Sunny Day"
 ###### 2025-12-15
  * Refactor `GradientDescent` into

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-### ensmallen ?.??.?: "???"
-###### ????-??-??
+### ensmallen 3.11.0: "Sunny Day"
+###### 2025-12-15
  * Refactor `GradientDescent` into
    `GradientDescentType<UpdatePolicyType, DecayPolicyType>` and
    add the `DeltaBarDelta` and `MomentumDeltaBarDelta` optimizers

--- a/include/ensmallen_bits/ens_version.hpp
+++ b/include/ensmallen_bits/ens_version.hpp
@@ -15,17 +15,17 @@
 #define ENS_VERSION_MAJOR 3
 // The minor version is two digits so regular numerical comparisons of versions
 // work right.  The first minor version of a release is always 10.
-#define ENS_VERSION_MINOR 10
+#define ENS_VERSION_MINOR 11
 #define ENS_VERSION_PATCH 0
 // If this is a release candidate, it will be reflected in the version name
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not
 // contain the capitalized string "RC".
-#define ENS_VERSION_NAME "Unexpected Rain"
+#define ENS_VERSION_NAME "Sunny Day"
 // Incorporate the date the version was released.
 #define ENS_VERSION_YEAR "2025"
-#define ENS_VERSION_MONTH "09"
-#define ENS_VERSION_DAY "25"
+#define ENS_VERSION_MONTH "12"
+#define ENS_VERSION_DAY "15"
 
 namespace ens {
 


### PR DESCRIPTION
This automatically-generated pull request adds the commits necessary to make the 3.11.0 release.

Once the PR is merged, mlpack-bot will tag the release as HEAD~1 (so that it doesn't include the new HISTORY block) and publish it.

Or, well, hopefully that will happen someday.

When you merge this PR, be sure to merge it using a *rebase*.

### Changelog

 * Refactor `GradientDescent` into `GradientDescentType<UpdatePolicyType, DecayPolicyType>` and add the `DeltaBarDelta` and `MomentumDeltaBarDelta` optimizers ([#440](https://github.com/mlpack/ensmallen/pull/440)).

 * Fix an off-by-one bug where the actual number of executed iterations was one fewer than the specified `maxIterations` ([#443](https://github.com/mlpack/ensmallen/pull/443)).