### PR TITLE
Fix ParallelSGD test step sizes and enable OpenMP for tests when found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ endif()
 
 # Find OpenMP and link it.
 if(USE_OPENMP)
+  find_package(OpenMP)
   if(NOT TARGET OpenMP::OpenMP_CXX)
     find_package(Threads REQUIRED)
     add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
@@ -61,6 +62,8 @@ if(USE_OPENMP)
     set_property(TARGET OpenMP::OpenMP_CXX
         PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
   endif()
+
+  add_definitions(-DENS_USE_OPENMP)
   target_link_libraries(ensmallen INTERFACE OpenMP::OpenMP_CXX)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if(USE_OPENMP)
         PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
   endif()
 
-  add_definitions(-DENS_USE_OPENMP)
+  target_compile_definitions(ensmallen INTERFACE -DENS_USE_OPENMP)
   target_link_libraries(ensmallen INTERFACE OpenMP::OpenMP_CXX)
 endif()
 

--- a/include/ensmallen_bits/config.hpp
+++ b/include/ensmallen_bits/config.hpp
@@ -48,6 +48,7 @@
   #define ENS_PRAGMA_OMP_ATOMIC   _Pragma("omp atomic")
   #define ENS_PRAGMA_OMP_CRITICAL _Pragma("omp critical")
   #define ENS_PRAGMA_OMP_CRITICAL_NAMED _Pragma("omp critical(section)")
+  #include <omp.h>
 #else
   #define ENS_PRAGMA_OMP_PARALLEL
   #define ENS_PRAGMA_OMP_ATOMIC

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,9 @@ set(ENSMALLEN_TESTS_SOURCES
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 add_executable(ensmallen_tests EXCLUDE_FROM_ALL ${ENSMALLEN_TESTS_SOURCES})
 target_link_libraries(ensmallen_tests PRIVATE ensmallen)
+if (USE_OPENMP)
+  target_link_libraries(ensmallen_tests PRIVATE OpenMP::OpenMP_CXX)
+endif ()
 
 # Copy test data into place.
 add_custom_command(TARGET ensmallen_tests

--- a/tests/moead_test.cpp
+++ b/tests/moead_test.cpp
@@ -560,8 +560,6 @@ TEMPLATE_TEST_CASE("DefaultMOEAD_ZDT1Function", "[MOEAD]", ENS_TEST_TYPES)
  */
 TEMPLATE_TEST_CASE("DirichletMOEAD_ZDT3Function", "[MOEAD]", ENS_TEST_TYPES)
 {
-  typedef typename TestType::elem_type ElemType;
-
   //! Parameters taken from original ZDT Paper.
   ZDT3<TestType> zdt3(300);
   const double lowerBound = 0;

--- a/tests/parallel_sgd_test.cpp
+++ b/tests/parallel_sgd_test.cpp
@@ -45,8 +45,8 @@ TEMPLATE_TEST_CASE("ParallelSGDTest_SparseFunction", "[ParallelSGD]",
 
     size_t batchSize = std::ceil((float) f.NumFunctions() / i);
 
-    ConstantStep decayPolicy(0.4 * batchSize);
-    ParallelSGD<ConstantStep> s(10000, batchSize, 1e-5, true, decayPolicy);
+    ConstantStep decayPolicy(0.02 * batchSize);
+    ParallelSGD<ConstantStep> s(10000, batchSize, 1e-7, true, decayPolicy);
     FunctionTest<SparseTestFunction>(s,
         Tolerances<TestType>::LargeObj,
         Tolerances<TestType>::LargeCoord);
@@ -62,10 +62,10 @@ TEMPLATE_TEST_CASE("ParallelSGD_GeneralizedRosenbrockFunction",
     // Create the generalized Rosenbrock function.
     GeneralizedRosenbrockFunction f(i);
 
-    ConstantStep decayPolicy(0.001 * f.NumFunctions());
+    ConstantStep decayPolicy(0.00005 * f.NumFunctions());
 
     ParallelSGD<ConstantStep> s(
-        100000, f.NumFunctions(), Tolerances<TestType>::Obj / 100, true,
+        1000000, f.NumFunctions(), Tolerances<TestType>::Obj / 100, true,
         decayPolicy);
 
     TestType coordinates = f.GetInitialPoint<TestType>();
@@ -73,11 +73,11 @@ TEMPLATE_TEST_CASE("ParallelSGD_GeneralizedRosenbrockFunction",
     omp_set_num_threads(1);
     double result = s.Optimize(f, coordinates);
 
-    REQUIRE(result == Approx(0.0).margin(Tolerances<TestType>::Obj));
+    REQUIRE(result == Approx(0.0).margin(100 * Tolerances<TestType>::Obj));
     for (size_t j = 0; j < i; ++j)
     {
       REQUIRE(coordinates(j) ==
-          Approx(1.0).epsilon(Tolerances<TestType>::Coord));
+          Approx(1.0).epsilon(100 * Tolerances<TestType>::Coord));
     }
   }
 }


### PR DESCRIPTION
This is a follow-up for #452.  When the tests were refactored for Bandicoot over last summer, one thing that got overlooked was the ParallelSGD tests, since they require OpenMP to be enabled to run... and our CMake configuration did not actually do that even when it found OpenMP!  So, two fixes:

1. Actually enable OpenMP if we find it...

2. and update the step sizes for each of the ParallelSGD tests since they were way too large and caused divergence.

I ran the tests for 1000 iterations locally with no problems.