### PR TITLE
Add openmp parallelization in PSO

### DIFF
--- a/include/ensmallen_bits/config.hpp
+++ b/include/ensmallen_bits/config.hpp
@@ -44,12 +44,16 @@
 
 
 #if defined(ENS_USE_OPENMP)
-  #define ENS_PRAGMA_OMP_PARALLEL _Pragma("omp parallel")
-  #define ENS_PRAGMA_OMP_ATOMIC   _Pragma("omp atomic")
-  #define ENS_PRAGMA_OMP_CRITICAL _Pragma("omp critical")
-  #define ENS_PRAGMA_OMP_CRITICAL_NAMED _Pragma("omp critical(section)")
+  #define ENS_PRAGMA_OMP_PARALLEL                      _Pragma("omp parallel")
+  #define ENS_PRAGMA_OMP_PARALLEL_FOR_IF_NUM_THREADS   _Pragma("omp parallel for if(enableParallel) num_threads(numThreads)")
+  #define ENS_PRAGMA_OMP_ATOMIC                        _Pragma("omp atomic")
+  #define ENS_PRAGMA_OMP_CRITICAL                      _Pragma("omp critical")
+  #define ENS_PRAGMA_OMP_CRITICAL_NAMED                _Pragma("omp critical(section)")
+  #include <omp.h>
 #else
   #define ENS_PRAGMA_OMP_PARALLEL
+  #define ENS_PRAGMA_OMP_FOR
+  #define ENS_PRAGMA_OMP_PARALLEL_FOR_IF_NUM_THREADS
   #define ENS_PRAGMA_OMP_ATOMIC
   #define ENS_PRAGMA_OMP_CRITICAL
   #define ENS_PRAGMA_OMP_CRITICAL_NAMED

--- a/include/ensmallen_bits/pso/pso.hpp
+++ b/include/ensmallen_bits/pso/pso.hpp
@@ -97,7 +97,8 @@ class PSOType
           const double explorationFactor = 2.05,
           const VelocityUpdatePolicy& velocityUpdatePolicy =
               VelocityUpdatePolicy(),
-          const InitPolicy& initPolicy = InitPolicy()) :
+          const InitPolicy& initPolicy = InitPolicy(),
+          const size_t numThreads = 1) :
           numParticles(numParticles),
           lowerBound(lowerBound),
           upperBound(upperBound),
@@ -107,7 +108,8 @@ class PSOType
           exploitationFactor(exploitationFactor),
           explorationFactor(explorationFactor),
           velocityUpdatePolicy(velocityUpdatePolicy),
-          initPolicy(initPolicy)
+          initPolicy(initPolicy),
+          numThreads(numThreads)
   { /* Nothing to do. */ }
 
   /**
@@ -143,7 +145,8 @@ class PSOType
           const double explorationFactor = 2.05,
           const VelocityUpdatePolicy& velocityUpdatePolicy =
               VelocityUpdatePolicy(),
-          const InitPolicy& initPolicy = InitPolicy()) :
+          const InitPolicy& initPolicy = InitPolicy(),
+          const size_t numThreads = 1) :
           numParticles(numParticles),
           lowerBound({ lowerBound }),
           upperBound({ upperBound }),
@@ -153,7 +156,8 @@ class PSOType
           exploitationFactor(exploitationFactor),
           explorationFactor(explorationFactor),
           velocityUpdatePolicy(velocityUpdatePolicy),
-          initPolicy(initPolicy)
+          initPolicy(initPolicy),
+          numThreads(numThreads)
   { /* Nothing to do. */ }
 
   /**
@@ -232,6 +236,11 @@ class PSOType
   //! with Has() before using!
   Any& InstUpdatePolicy() { return instUpdatePolicy; }
 
+  //! Get the number of threads to use for parallelization.
+  size_t NumThreads() const { return numThreads; }
+  //! Modify the number of threads to use for parallelization.
+  size_t& NumThreads() { return numThreads; }
+
  private:
   //! Number of particles in the swarm.
   size_t numParticles;
@@ -265,6 +274,9 @@ class PSOType
 
   //! The initialized update policy.
   Any instUpdatePolicy;
+
+  //! The number of threads to use for parallelization.
+  size_t numThreads;
 };
 
 using LBestPSO = PSOType<LBestUpdate, DefaultInit>;

--- a/include/ensmallen_bits/pso/pso_impl.hpp
+++ b/include/ensmallen_bits/pso/pso_impl.hpp
@@ -103,16 +103,27 @@ typename InputMatType::elem_type PSOType<
   // Initialize the update policy.
   instUpdatePolicy.As<InstUpdatePolicyType>().Initialize(exploitationFactor,
       explorationFactor, numParticles, iterate);
-
   Callback::BeginOptimization(*this, function, iterate, callbacks...);
 
+  const bool enableParallel = (numThreads != 1);
+
   // Calculate initial fitness of population.
-  for (size_t i = 0; (i < numParticles) && !terminate; i++)
+  ENS_PRAGMA_OMP_PARALLEL_FOR_IF_NUM_THREADS
+  for (size_t i = 0; i < numParticles; i++)
   {
+    if (terminate)
+    {
+        continue;
+    }
+
     // Calculate fitness value.
     particleFitnesses(i) = function.Evaluate(particlePositions.slice(i));
-    terminate |= Callback::Evaluate(*this, function,
+
+    ENS_PRAGMA_OMP_CRITICAL
+    {
+      terminate |= Callback::Evaluate(*this, function,
         particlePositions.slice(i), particleFitnesses(i), callbacks...);
+    }
     particleBestFitnesses(i) = particleFitnesses(i);
   }
 
@@ -133,13 +144,23 @@ typename InputMatType::elem_type PSOType<
   for (size_t i = 0; (i < horizonSize) && !terminate; i++, iteration++)
   {
     // Calculate fitness and evaluate personal best.
-    for (size_t j = 0; (j < numParticles) && !terminate; j++)
+    ENS_PRAGMA_OMP_PARALLEL_FOR_IF_NUM_THREADS
+    for (size_t j = 0; j < numParticles; j++)
     {
-      particleFitnesses(j) = function.Evaluate(particlePositions.slice(j));
-      terminate |= Callback::Evaluate(*this, function,
-          particlePositions.slice(j), particleFitnesses(j), callbacks...);
       if (terminate)
-        break;
+      {
+          continue;
+      }
+
+      particleFitnesses(j) = function.Evaluate(particlePositions.slice(j));
+
+      ENS_PRAGMA_OMP_CRITICAL
+      {
+        terminate |= Callback::Evaluate(*this, function,
+          particlePositions.slice(j), particleFitnesses(j), callbacks...);
+      }
+      if (terminate)
+        continue;
 
       // Compare and copy fitness and position to particle best.
       if (particleFitnesses(j) < particleBestFitnesses(j))
@@ -193,11 +214,21 @@ typename InputMatType::elem_type PSOType<
     }
 
     // Calculate fitness and evaluate personal best.
-    for (size_t j = 0; (j < numParticles) && !terminate; j++)
+    ENS_PRAGMA_OMP_PARALLEL_FOR_IF_NUM_THREADS
+    for (size_t j = 0; j < numParticles; j++)
     {
+      if (terminate)
+      {
+        continue;
+      }
+
       particleFitnesses(j) = function.Evaluate(particlePositions.slice(j));
-      terminate |= Callback::Evaluate(*this, function,
-          particlePositions.slice(j), particleFitnesses(j), callbacks...);
+
+       ENS_PRAGMA_OMP_CRITICAL
+      {
+        terminate |= Callback::Evaluate(*this, function,
+            particlePositions.slice(j), particleFitnesses(j), callbacks...);
+      }
 
       // Compare and copy fitness and position to particle best.
       if (particleFitnesses(j) < particleBestFitnesses(j))

--- a/include/ensmallen_bits/pso/pso_impl.hpp
+++ b/include/ensmallen_bits/pso/pso_impl.hpp
@@ -214,9 +214,7 @@ typename InputMatType::elem_type PSOType<
     for (size_t j = 0; j < numParticles; j++)
     {
       if (terminate)
-      {
         continue;
-      }
 
       particleFitnesses(j) = function.Evaluate(particlePositions.slice(j));
 

--- a/include/ensmallen_bits/pso/pso_impl.hpp
+++ b/include/ensmallen_bits/pso/pso_impl.hpp
@@ -218,7 +218,7 @@ typename InputMatType::elem_type PSOType<
 
       particleFitnesses(j) = function.Evaluate(particlePositions.slice(j));
 
-       ENS_PRAGMA_OMP_CRITICAL
+      ENS_PRAGMA_OMP_CRITICAL
       {
         terminate |= Callback::Evaluate(*this, function,
             particlePositions.slice(j), particleFitnesses(j), callbacks...);

--- a/include/ensmallen_bits/pso/pso_impl.hpp
+++ b/include/ensmallen_bits/pso/pso_impl.hpp
@@ -146,9 +146,7 @@ typename InputMatType::elem_type PSOType<
     for (size_t j = 0; j < numParticles; j++)
     {
       if (terminate)
-      {
-          continue;
-      }
+        continue;
 
       particleFitnesses(j) = function.Evaluate(particlePositions.slice(j));
 

--- a/include/ensmallen_bits/pso/pso_impl.hpp
+++ b/include/ensmallen_bits/pso/pso_impl.hpp
@@ -112,9 +112,7 @@ typename InputMatType::elem_type PSOType<
   for (size_t i = 0; i < numParticles; i++)
   {
     if (terminate)
-    {
-        continue;
-    }
+      continue;
 
     // Calculate fitness value.
     particleFitnesses(i) = function.Evaluate(particlePositions.slice(i));

--- a/tests/pso_test.cpp
+++ b/tests/pso_test.cpp
@@ -30,6 +30,15 @@ TEMPLATE_TEST_CASE("LBestPSO_SphereFunction", "[PSO]", ENS_ALL_CPU_TEST_TYPES)
   SphereFunction f(4);
   LBestPSO s;
 
+  SECTION("Single-threaded")
+  {
+    s.NumThreads() = 1;
+  }
+  SECTION("Multi-threaded")
+  {
+    s.NumThreads() = 0; // Use all available threads.
+  }
+
   TestType coords = f.template GetInitialPoint<TestType>();
   const ElemType finalValue = s.Optimize(f, coords);
 
@@ -57,6 +66,16 @@ TEMPLATE_TEST_CASE("LBestPSO_RosenbrockFunction", "[PSO]",
   {
     LBestPSO s(250, lowerBound, upperBound, 5000, 600,
         Tolerances<TestType>::Obj / 100, 2.05, 2.05);
+
+    SECTION("Single-threaded")
+    {
+        s.NumThreads() = 1;
+    }
+    SECTION("Multi-threaded")
+    {
+        s.NumThreads() = 0; // Use all available threads.
+    }
+
     TestType coordinates = f.GetInitialPoint<TestType>();
 
     const ElemType result = s.Optimize(f, coordinates);

--- a/tests/pso_test.cpp
+++ b/tests/pso_test.cpp
@@ -69,11 +69,11 @@ TEMPLATE_TEST_CASE("LBestPSO_RosenbrockFunction", "[PSO]",
 
     SECTION("Single-threaded")
     {
-        s.NumThreads() = 1;
+      s.NumThreads() = 1;
     }
     SECTION("Multi-threaded")
     {
-        s.NumThreads() = 0; // Use all available threads.
+      s.NumThreads() = 0; // Use all available threads.
     }
 
     TestType coordinates = f.GetInitialPoint<TestType>();


### PR DESCRIPTION
Following #452 , here's an implementation of parallel PSO using OpenMP.

- A new `numThreads` parameter is added to control parallelization
  - `numThreads=0`: parallelization is enabled with whatever default OpenMP current has
  - `numThreads=1`: parallelization is disabled
  - `numThreads>1`: parallelization is enabled and the number of threads used by OpenMP is set by the `num_threads` clause.
- `omp parallel for` is used to parallelize each generations.  