### PR TITLE
Allow multiple trials for Lookahead logistic regression test

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 ### ensmallen ?.??.?: "???"
 ###### ????-??-??
+ * Loosen tolerance for Lookahead tests to prevent spurious failures
+   ([#456](https://github.com/mlpack/ensmallen/pull/456)).
 
 ### ensmallen 3.11.0: "Sunny Day"
 ###### 2025-12-15

--- a/tests/lookahead_test.cpp
+++ b/tests/lookahead_test.cpp
@@ -60,5 +60,6 @@ TEMPLATE_TEST_CASE("LookaheadAdam_LogisticRegressionFunction", "[Lookahead]",
   LogisticRegressionFunctionTest<TestType>(
       optimizer,
       Tolerances<TestType>::LRTrainAcc,
-      Tolerances<TestType>::LRTestAcc);
+      Tolerances<TestType>::LRTestAcc,
+      3 /* allow a couple trials */);
 }


### PR DESCRIPTION
I saw in another PR that this test randomly failed and was a little bit disappointed because of the time I spent last summer tuning all the test suites so they had no test failures in 1000 runs.  So, I ran the test locally another 1000 times and saw one failure... an easy fix is just to allow multiple trials for the logistic regression test, so I did that, and in ~4k trials I saw no failures.