### PR TITLE
Fix/progress bar incomplete epoch

### DIFF
--- a/include/ensmallen_bits/callbacks/progress_bar.hpp
+++ b/include/ensmallen_bits/callbacks/progress_bar.hpp
@@ -40,7 +40,9 @@ class ProgressBar
       step(1),
       steps(0),
       newEpoch(false),
-      epoch(1)
+      epoch(1),
+      epochStarted(false),
+      epochCompleted(false)
 
   { /* Nothing to do here. */ }
 
@@ -113,6 +115,8 @@ class ProgressBar
 
     epoch = epochIn;
     newEpoch = true;
+    epochStarted = true;
+    epochCompleted = false;
 
     return false;
   }
@@ -204,6 +208,8 @@ class ProgressBar
                 const size_t /* epoch */,
                 const double objective)
   {
+    epochCompleted = true;
+
     const size_t progress = ((double) (step - 1) / epochSize) * 100;
     output << step - 1 << "/" << epochSize << " [";
     for (size_t i = 0; i < 100; i += width)
@@ -227,6 +233,25 @@ class ProgressBar
         << "s/epoch; " << stepTime << "ms/step; loss: " << objective  <<  "\n";
     output.flush();
     return false;
+  }
+
+  /**
+   * Callback function called at the end of the optimization process.
+   *
+   * @param optimizer The optimizer used to update the function.
+   * @param function Function to optimize.
+   * @param coordinates Final point.
+   */
+  template<typename OptimizerType, typename FunctionType, typename MatType>
+  void EndOptimization(OptimizerType& /* optimizer */,
+                       FunctionType& /* function */,
+                       MatType& /* coordinates */)
+  {
+    if (epochStarted && !epochCompleted && step > 1)
+    {
+      output << "\nOptimization stopped before completing the current epoch."
+          << std::endl;
+    }
   }
 
  private:
@@ -256,6 +281,12 @@ class ProgressBar
 
   //! Locally-stored epoch.
   size_t epoch;
+
+  //! Tracks whether there is an epoch whose progress is being displayed.
+  bool epochStarted;
+
+  //! Lets EndOptimization() distinguish a complete epoch from a partial one.
+  bool epochCompleted;
 
   //! Locally-stored step timer object.
   arma::wall_clock stepTimer;

--- a/tests/callbacks_test.cpp
+++ b/tests/callbacks_test.cpp
@@ -735,6 +735,8 @@ TEST_CASE("ProgressBarCallbackNoMaxIterationsEpochTest", "[CallbacksTest]")
   s.Optimize(f, coordinates, ProgressBar(10, stream));
   REQUIRE(stream.str().find("Epoch 1") != std::string::npos);
   REQUIRE(stream.str().find("Epoch 1/") == std::string::npos);
+  REQUIRE(stream.str().find("Optimization stopped before completing the "
+      "current epoch.") == std::string::npos);
 }
 
 /**

--- a/tests/callbacks_test.cpp
+++ b/tests/callbacks_test.cpp
@@ -755,6 +755,26 @@ TEST_CASE("ProgressBarCallbackEpochTest", "[CallbacksTest]")
 }
 
 /**
+ * Make sure the ProgressBar callback shows that optimization stopped before
+ * the end of an epoch.
+ */
+TEST_CASE("ProgressBarCallbackIncompleteEpochTest", "[CallbacksTest]")
+{
+  SGDTestFunction f;
+  arma::mat coordinates = f.GetInitialPoint();
+
+  StandardSGD s(0.0003, 1, 4, -1, true);
+
+  std::stringstream stream;
+  s.Optimize(f, coordinates, ProgressBar(10, stream));
+
+  REQUIRE(stream.str().find("Epoch 1/2") != std::string::npos);
+  REQUIRE(stream.str().find("Epoch 2/2") != std::string::npos);
+  REQUIRE(stream.str().find("Optimization stopped before completing the "
+      "current epoch.") != std::string::npos);
+}
+
+/**
  * Make sure the Report callback will show the report on the specified
  * output stream.
  */


### PR DESCRIPTION
ProgressBar did not print a final message when optimization stopped during an incomplete epoch after one or more epochs had already completed. Progress bar did not print a final message in other cases too, this fix is not a general one but for the specif case of not finished epochs. The callback now tracks whether the current epoch has started and completed. At EndOptimization(), it reports when the active epoch was left incomplete.

Tests dones:

Added ProgressBarCallbackIncompleteEpochTest, covering an optimizer that completes the first epoch and stops during the second. 

Extended ProgressBarCallbackNoMaxIterationsEpochTest to verify that the incomplete-epoch message is not printed when an epoch completes normally.